### PR TITLE
Declared CompileOnly file dependencies should not be marked  as transitive

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/CompileOnlyJarSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/CompileOnlyJarSpec.groovy
@@ -1,0 +1,26 @@
+package com.autonomousapps.jvm
+
+import com.autonomousapps.jvm.projects.CompileOnlyJarProject
+
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertThat
+
+class CompileOnlyJarSpec extends AbstractJvmSpec {
+
+    def "compileOnly file dependency should not be marked as transitive (#gradleVersion)"() {
+        given:
+        def project = new CompileOnlyJarProject()
+        gradleProject = project.gradleProject
+
+        when:
+        build(gradleVersion, gradleProject.rootDir, ':external:jar')
+        build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+        then:
+        assertThat(actualAdvice('proj')).containsExactlyElementsIn(project.expectedAdvice)
+
+        where:
+        gradleVersion << gradleVersions()
+    }
+
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/CompileOnlyJarProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/CompileOnlyJarProject.groovy
@@ -1,0 +1,78 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.advice.Advice
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Plugin
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+
+import static com.autonomousapps.kit.Dependency.project
+
+final class CompileOnlyJarProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  CompileOnlyJarProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    def builder = newGradleProjectBuilder()
+    builder.rootProjectBuilder.with {s ->
+      s.withBuildScript { bs ->
+        bs.additions = """
+          ext {
+            libshared = [
+              servlet: fileTree("\${project(':external').buildDir}/libs/external.jar"),
+            ]
+          }
+        """
+      }
+    }
+    // consumer
+    builder.withSubproject('proj') { s ->
+      s.sources = [SOURCE_CONSUMER]
+      s.withBuildScript { bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin]
+        bs.dependencies = [
+          'compileOnly libshared.servlet'
+        ]
+      }
+    }
+    // producer
+    builder.withSubproject('external') { s ->
+      s.sources = [EXTERNAL_PRODUCER]
+      s.withBuildScript { bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin]
+      }
+    }
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  private static final Source SOURCE_CONSUMER = new Source(SourceType.JAVA, "AppContextListener", "com/example/servlet",
+    """\
+      package com.example.servlet;
+
+      import javax.servlet.*;
+
+      public class AppContextListener implements ServletContextListener {}
+    """.stripIndent()
+  )
+
+  private static final Source EXTERNAL_PRODUCER = new Source(SourceType.JAVA, "ServletContextListener", "javax/servlet",
+    """\
+      package javax.servlet;
+
+      public interface ServletContextListener {
+        default void contextDestroyed() {};
+        default void contextInitialized() {};
+      }
+    """.stripIndent()
+  )
+
+  final List<Advice> expectedAdvice = []
+}

--- a/src/main/kotlin/com/autonomousapps/internal/utils/gradleStrings.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/gradleStrings.kt
@@ -7,6 +7,7 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.attributes.Category
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.internal.component.local.model.OpaqueComponentArtifactIdentifier
 import org.gradle.internal.component.local.model.OpaqueComponentIdentifier
 
@@ -77,8 +78,12 @@ internal fun Dependency.toIdentifier(
   }
   is FileCollectionDependency -> {
     // Note that this only gets the first file in the collection, ignoring the rest.
-    (files as? ConfigurableFileCollection)?.from?.let { from ->
-      (from.firstOrNull() as? String)?.substringAfterLast("/")
+    when (files) {
+      is ConfigurableFileCollection -> (files as? ConfigurableFileCollection)?.from?.let { from ->
+        (from.firstOrNull() as? String)?.substringAfterLast("/")
+      }
+      is ConfigurableFileTree -> files.firstOrNull()?.name
+      else -> null
     }
   }
   // Don't have enough information, so ignore it. Please note that a `FileCollectionDependency` is


### PR DESCRIPTION
This also solved a bug where file (.jar) dependency returned null, will see if I can reproduce it in the test framework.