### PR TITLE
Exclude test based configurations from locations.json if we should not analyze test

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/ConfigurationsToDependenciesTransformer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/ConfigurationsToDependenciesTransformer.kt
@@ -8,22 +8,23 @@ internal class ConfigurationsToDependenciesTransformer(
   private val flavorName: String?,
   private val buildType: String?,
   private val variantName: String,
-  private val configurations: ConfigurationContainer
+  private val configurations: ConfigurationContainer,
+  private val includeTest: Boolean
 ) {
 
   private val logger = getLogger<LocateDependenciesTask>()
 
   companion object {
-    private val DEFAULT_CONFS = listOf(
+    private val DEFAULT_MAIN_CONFS = listOf(
       "api",
       "implementation",
       // Deprecated, removed in Gradle 7
       "compile",
       "compileOnly",
       //"compileOnlyApi", // TODO
-      "runtimeOnly",
-
-      // Test configurations
+      "runtimeOnly"
+    )
+    private val DEFAULT_TEST_CONFS = listOf(
       "testRuntimeOnly",
       "testImplementation",
       "testCompileOnly"
@@ -96,20 +97,25 @@ internal class ConfigurationsToDependenciesTransformer(
   }
 
   private fun buildConfNames(): Set<String> {
-    val confNames = (DEFAULT_CONFS + DEFAULT_CONFS.map {
+    var defaultConfigurations = DEFAULT_MAIN_CONFS
+    if (includeTest) {
+      defaultConfigurations = defaultConfigurations + DEFAULT_TEST_CONFS
+    }
+
+    val confNames = (defaultConfigurations + defaultConfigurations.map {
       // so, flavorDebugApi, etc.
       "${variantName}${it.capitalizeSafely()}"
     }).toMutableSet()
 
     if (flavorName != null) {
-      confNames.addAll(DEFAULT_CONFS.map {
+      confNames.addAll(defaultConfigurations.map {
         // so, flavorApi, etc.
         "${flavorName}${it.capitalizeSafely()}"
       })
     }
 
     if (buildType != null) {
-      confNames.addAll(DEFAULT_CONFS.map {
+      confNames.addAll(defaultConfigurations.map {
         // so, buildTypeApi, etc.
         "${buildType}${it.capitalizeSafely()}"
       })

--- a/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
@@ -386,6 +386,7 @@ internal class ProjectPlugin(private val project: Project) {
         this@register.flavorName.set(flavorName)
         this@register.variantName.set(variantName)
         this@register.buildType.set(buildType)
+        this@register.includeTest.set(shouldAnalyzeTests())
 
         output.set(outputPaths.locationsPath)
       }

--- a/src/main/kotlin/com/autonomousapps/tasks/LocateDependenciesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/LocateDependenciesTask.kt
@@ -36,6 +36,9 @@ abstract class LocateDependenciesTask : DefaultTask() {
   @get:Input
   abstract val variantName: Property<String>
 
+  @get:Input
+  abstract val includeTest: Property<Boolean>
+
   //  For up to date correctness
 //  @get:Classpath
 //  abstract val compileClasspathArtifacts: ConfigurableFileCollection
@@ -54,7 +57,8 @@ abstract class LocateDependenciesTask : DefaultTask() {
       flavorName = flavorName.orNull,
       buildType = buildType.orNull,
       variantName = variantName.get(),
-      configurations = project.configurations
+      configurations = project.configurations,
+      includeTest = includeTest.get()
     ).locations()
 
     outputFile.writeText(locations.toJson())


### PR DESCRIPTION
It is a bit of a work around as the `test` configuration should be treated as a different variant but that would require the whole plugin setup to move from main (with test) to main + test.