### PR TITLE
Deprecate dependencyAnalysis.dependencies for structure

### DIFF
--- a/sandbox-sample/build.gradle
+++ b/sandbox-sample/build.gradle
@@ -28,7 +28,7 @@ dependencyAnalysis {
       }
     }
   }
-  dependencies {
+  structure {
     bundle('hilt') {
       include('com.google.dagger:hilt-android')
       include('com.google.dagger:hilt-core')

--- a/src/functionalTest/groovy/com/autonomousapps/android/DependenciesSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/DependenciesSpec.groovy
@@ -32,7 +32,7 @@ final class DependenciesSpec extends AbstractAndroidSpec {
     given:
     def additions = """\
       dependencyAnalysis {
-        dependencies {
+        structure {
           bundle('three-ten') {
             includeDependency('org.threeten:threetenbp')
             includeDependency('com.jakewharton.threetenabp:threetenabp')

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/BundleProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/BundleProject.groovy
@@ -25,7 +25,7 @@ final class BundleProject extends AbstractProject {
       it.withBuildScript { bs ->
         bs.additions = """
           dependencyAnalysis {
-            dependencies {
+            structure {
               bundle('facade') {
                 primary(':entry-point')
                 includeDependency(':entry-point')

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/RewriteDependenciesProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/RewriteDependenciesProject.groovy
@@ -44,7 +44,7 @@ final class RewriteDependenciesProject extends AbstractProject {
           ]
           
           dependencyAnalysis {
-            dependencies {
+            structure {
               map.set([
                 'com.squareup.okio:okio:2.6.0': 'deps.okio',
                 'org.apache.commons:commons-collections4:4.4': 'deps.commonsCollections'

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TestBundleProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TestBundleProject.groovy
@@ -36,7 +36,7 @@ final class TestBundleProject extends AbstractProject {
       it.withBuildScript { bs ->
         bs.additions = """
           dependencyAnalysis {
-            dependencies {
+            structure {
               bundle('kotest-assertions') {
                 includeDependency('io.kotest:kotest-assertions-core-jvm')
                 includeDependency('io.kotest:kotest-assertions-shared-jvm')

--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisExtension.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisExtension.kt
@@ -22,8 +22,8 @@ import javax.inject.Inject
  *   // Configure the severity of issues, and exclusion rules, for potentially the entire project.
  *   issues { ... }
  *
- *   // Configure dependency bundles.
- *   dependencies { ... }
+ *   // Configure dependency structure rules (bundles, mapping, etc).
+ *   structure { ... }
  *
  *   // Configure ABI exclusion rules.
  *   abi { ... }
@@ -48,8 +48,13 @@ open class DependencyAnalysisExtension @Inject constructor(
   /**
    * Customize how dependencies are treated. See [DependenciesHandler] for more information.
    */
-  fun dependencies(action: Action<DependenciesHandler>) {
+  fun structure(action: Action<DependenciesHandler>) {
     action.execute(dependenciesHandler)
+  }
+
+  @Deprecated("Use structure", ReplaceWith("structure(action)"))
+  fun dependencies(action: Action<DependenciesHandler>) {
+    structure(action)
   }
 
   /**

--- a/src/main/kotlin/com/autonomousapps/extension/DependenciesHandler.kt
+++ b/src/main/kotlin/com/autonomousapps/extension/DependenciesHandler.kt
@@ -16,7 +16,7 @@ import javax.inject.Inject
 /**
  * ```
  * dependencyAnalysis {
- *   dependencies {
+ *   structure {
  *     // Set the given map. Used when printing advice and rewriting build scripts.
  *     map.set(/* map */)
  *


### PR DESCRIPTION
Resolves #891. Open to suggestions on the name, this felt the most semantically similar