### PR TITLE
Opt-out of configuration cache in `FindDeclaredProcsTask.kt`

### DIFF
--- a/src/main/kotlin/com/autonomousapps/tasks/FindDeclaredProcsTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindDeclaredProcsTask.kt
@@ -2,6 +2,7 @@ package com.autonomousapps.tasks
 
 import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.internal.ANNOTATION_PROCESSOR_PATH
+import com.autonomousapps.internal.GradleVersions
 import com.autonomousapps.internal.unsafeLazy
 import com.autonomousapps.internal.utils.*
 import com.autonomousapps.internal.utils.getAndDelete
@@ -55,6 +56,11 @@ abstract class FindDeclaredProcsTask : DefaultTask() {
   init {
     group = TASK_GROUP_DEP_INTERNAL
     description = "Produces a report of all supported annotation types and their annotation processors"
+
+    if (GradleVersions.isAtLeastGradle74) {
+      @Suppress("LeakingThis")
+      notCompatibleWithConfigurationCache("Cannot serialize unsafeLazy")
+    }
   }
 
   private var kaptArtifacts: ArtifactCollection? = null


### PR DESCRIPTION
This should fix the corresponding issue:

```
> Task :Foo:findDeclaredProcsMain FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':Foo:findDeclaredProcsMain'.
> Cannot invoke "kotlin.Lazy.getValue()" because "<local1>" is null
```