### PR TITLE
Use BuildIdentifier.getBuildPath() starting with Gradle 8.2 (second PR)

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/IncludedBuildSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/IncludedBuildSpec.groovy
@@ -3,12 +3,21 @@ package com.autonomousapps.jvm
 import com.autonomousapps.jvm.projects.IncludedBuildProject
 import com.autonomousapps.jvm.projects.IncludedBuildWithAnnotationProcessorProject
 import com.autonomousapps.jvm.projects.IncludedBuildWithSubprojectsProject
+import org.gradle.util.GradleVersion
 
 import static com.autonomousapps.utils.Runner.build
 import static com.google.common.truth.Truth.assertThat
 
 // https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/565
 final class IncludedBuildSpec extends AbstractJvmSpec {
+
+  /**
+   * Only since Gradle 8.2 we can use the more precise BuildIdentifier.buildPath (instead of BuildIdentifier.name).
+   * That's why the expectations in this test differ depending on Gradle version.
+   */
+  private final static isAtLeastGradle82(GradleVersion version)  {
+    version >= GradleVersion.version("8.2")
+  }
 
   def "doesn't crash in presence of an included build (#gradleVersion)"() {
     given:
@@ -20,7 +29,7 @@ final class IncludedBuildSpec extends AbstractJvmSpec {
     build(gradleVersion, gradleProject.rootDir, ':second-build:buildHealth')
 
     then: 'the build health of the first build is as expected'
-    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth('second-build'))
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth(isAtLeastGradle82(gradleVersion) ? ':second-build' : 'second-build'))
 
     and: 'the build health of the second build is as expected'
     assertThat(project.actualBuildHealthOfSecondBuild())
@@ -44,7 +53,7 @@ final class IncludedBuildSpec extends AbstractJvmSpec {
 
     then: 'the build health of the second build is the same as when running that build as included build'
     assertThat(project.actualBuildHealthOfSecondBuild())
-      .containsExactlyElementsIn(project.expectedBuildHealthOfIncludedBuild('the-project'))
+      .containsExactlyElementsIn(project.expectedBuildHealthOfIncludedBuild(isAtLeastGradle82(gradleVersion) ? ':the-project' : 'the-project'))
 
     where:
     gradleVersion << gradleVersions()
@@ -75,7 +84,7 @@ final class IncludedBuildSpec extends AbstractJvmSpec {
 
     then: 'and there is no advice'
     assertThat(project.actualIncludedBuildHealth())
-      .containsExactlyElementsIn(project.expectedIncludedBuildHealth('second-build'))
+      .containsExactlyElementsIn(project.expectedIncludedBuildHealth(isAtLeastGradle82(gradleVersion) ? ':second-build' : 'second-build'))
 
     where:
     gradleVersion << gradleVersions()
@@ -91,7 +100,7 @@ final class IncludedBuildSpec extends AbstractJvmSpec {
 
     then:
     assertThat(project.actualIncludedBuildHealth())
-      .containsExactlyElementsIn(project.expectedIncludedBuildHealth('second-build'))
+      .containsExactlyElementsIn(project.expectedIncludedBuildHealth(isAtLeastGradle82(gradleVersion) ? ':second-build' : 'second-build'))
 
     where:
     gradleVersion << gradleVersions()
@@ -122,7 +131,7 @@ final class IncludedBuildSpec extends AbstractJvmSpec {
 
     then:
     assertThat(project.actualIncludedBuildHealth())
-      .containsExactlyElementsIn(project.expectedIncludedBuildHealth('second-build'))
+      .containsExactlyElementsIn(project.expectedIncludedBuildHealth(isAtLeastGradle82(gradleVersion) ? ':second-build' : 'second-build'))
 
     when: 'The second build is the root - the "buildPath" attribute of ProjectCoordinates changes'
     build(gradleVersion, new File(gradleProject.rootDir, 'second-build'), ':buildHealth')

--- a/src/main/kotlin/com/autonomousapps/internal/utils/gradleStrings.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/gradleStrings.kt
@@ -46,8 +46,9 @@ private fun ResolvedDependencyResult.compositeRequest(): IncludedBuildCoordinate
   val resolved = ProjectCoordinates(
     identifier = (selected.id as ProjectComponentIdentifier).identityPath(),
     gradleVariantIdentification = gradleVariantIdentification,
-    // FIXME use 'buildState.buildIdentifier.buildPath' with Gradle 8.2+
-    buildPath = (selected.id as ProjectComponentIdentifier).build.name
+    buildPath = (selected.id as ProjectComponentIdentifier).build.let {
+      if (GradleVersions.isAtLeastGradle82) it.buildPath else @Suppress("DEPRECATION") it.name
+    }
   )
 
   return IncludedBuildCoordinates.of(requested, resolved)
@@ -106,11 +107,8 @@ private fun ComponentIdentifier.toCoordinates(gradleVariantIdentification: Gradl
   val identifier = toIdentifier()
   return when (this) {
     is ProjectComponentIdentifier -> {
-      ProjectCoordinates(identifier, gradleVariantIdentification, build.name)
-      // FIXME use 'buildState.buildIdentifier.buildPath' with Gradle 8.2+?
-      //  this breaks IncludedBuildSpec for later versions of Gradle:
-      // val buildPath = if (GradleVersions.isAtLeastGradle82) build.buildPath else build.name
-      // ProjectCoordinates(identifier, gradleVariantIdentification, buildPath)
+      val buildPath = if (GradleVersions.isAtLeastGradle82) build.buildPath else @Suppress("DEPRECATION") build.name
+      ProjectCoordinates(identifier, gradleVariantIdentification, buildPath)
     }
 
     is ModuleComponentIdentifier -> {


### PR DESCRIPTION
Follow up to #949

I totally missed these other usages. They did not show up in the builds I tested with and I forgot about them. Sorry for updating this inconsistently in #949. 