### PR TITLE
Cleanup / simplify.

### DIFF
--- a/testkit/gradle-testkit-plugin/src/main/kotlin/com/autonomousapps/GradleTestKitPlugin.kt
+++ b/testkit/gradle-testkit-plugin/src/main/kotlin/com/autonomousapps/GradleTestKitPlugin.kt
@@ -23,14 +23,14 @@ public class GradleTestKitPlugin : Plugin<Project> {
     // All projects get the extension and publishing setup
     GradleTestKitSupportExtension.create(this)
     val configurator = PublishingConfigurator(this)
-
+    
     // Only plugin projects get this
     pluginManager.withPlugin("java-gradle-plugin") {
       val sourceSets = extensions.getByType(SourceSetContainer::class.java)
       val functionalTestSourceSet = sourceSets.create("functionalTest")
 
-      val gradlePlugin = extensions.getByType(GradlePluginDevelopmentExtension::class.java)
-      gradlePlugin.testSourceSet(functionalTestSourceSet)
+      extensions.getByType(GradlePluginDevelopmentExtension::class.java)
+        .testSourceSet(functionalTestSourceSet)
 
       // Ensure build/functionalTest doesn't grow without bound when tests sometimes fail to clean up after themselves.
       val deleteOldFuncTests = tasks.register("deleteOldFuncTests", Delete::class.java) { t ->

--- a/testkit/gradle-testkit-plugin/src/main/kotlin/com/autonomousapps/PublishingConfigurator.kt
+++ b/testkit/gradle-testkit-plugin/src/main/kotlin/com/autonomousapps/PublishingConfigurator.kt
@@ -10,11 +10,12 @@ import java.io.File
 internal class PublishingConfigurator(private val project: Project) {
 
   private val repoName = "FunctionalTests"
+  private val taskName = "installForFunctionalTest"
 
   val funcTestRepoName = "functionalTestRepo"
   val funcTestRepo: File = File(project.rootDir, "build/$funcTestRepoName").absoluteFile
 
-  val installForFunctionalTest: TaskProvider<Task> = project.tasks.register("installForFunctionalTest") {
+  val installForFunctionalTest: TaskProvider<Task> = project.tasks.register(taskName) {
     // install this project's publications
     it.dependsOn("publishAllPublicationsTo${repoName}Repository")
   }
@@ -37,7 +38,7 @@ internal class PublishingConfigurator(private val project: Project) {
       // Install dependency projects
       val installationTasks = configurations.getAt("runtimeClasspath").allDependencies
         .filterIsInstance<ProjectDependency>()
-        .map { "${it.dependencyProject.path}:installForFunctionalTest" }
+        .map { "${it.dependencyProject.path}:$taskName" }
 
       installForFunctionalTest.configure {
         // all dependency projects


### PR DESCRIPTION
I still want to make the test name configurable, although it seems (annoyingly) like it might require `afterEvaluate`, and I would like some kind of improved support for included builds.