### PR TITLE
Rename all-declared-dependencies to exploded-jars.json.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
@@ -19,7 +19,7 @@ internal class OutputPaths(
 
   val artifactsPath = file("${intermediatesDir}/artifacts.json")
   val externalDependenciesPath = file("${intermediatesDir}/external-dependencies.txt")
-  val allDeclaredDepsPath = file("${intermediatesDir}/all-declared-dependencies.json")
+  val allDeclaredDepsPath = file("${intermediatesDir}/exploded-jars.json")
   val inlineUsagePath = file("${intermediatesDir}/inline-usage.json")
   val androidResPath = file("${intermediatesDir}/android-res.json")
   val androidResToResUsagePath = file("${intermediatesDir}/android-res-by-res-usage.json")


### PR DESCRIPTION
Been meaning to do this for ages. These are not declared dependencies, they're the exploded jars from the full compile classpath, direct and transitive.