### PR TITLE
Filter out weird flat dependencies.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/utils/gradleStrings.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/gradleStrings.kt
@@ -19,6 +19,7 @@ import org.gradle.api.capabilities.Capability
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
+import org.gradle.api.provider.Property
 import org.gradle.internal.component.local.model.OpaqueComponentArtifactIdentifier
 import org.gradle.internal.component.local.model.OpaqueComponentIdentifier
 
@@ -202,7 +203,13 @@ internal fun Dependency.toIdentifier(): Pair<String, GradleVariantIdentification
               first
             }
 
-            firstFile?.toString()?.substringAfterLast("/")
+            // Handle weirdness that seems to come from KGP? Unclear. See comments from
+            // https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/997#issuecomment-1826627186
+            when (firstFile) {
+              is Function0<*> -> null // "() -> Any?"
+              is Property<*> -> null  // "property 'destinationDirectory'"
+              else -> firstFile?.toString()?.substringAfterLast('/')
+            }
           }?.let {
             Pair(it.intern(), GradleVariantIdentification.EMPTY)
           }


### PR DESCRIPTION
Sometimes (from KGP? Not sure) FindDeclarationsTask discovers flat dependencies that are:
1. () -> Any?
2. property 'destinationDirectory'

Basically they're properties that point to directories on the filesystem. They're not interesting for dependency analysis. So, skip them.