### PR TITLE
Catch exception when analyzing Kotlin files for inline members.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
@@ -21,6 +21,7 @@ internal class OutputPaths(
   val externalDependenciesPath = file("${intermediatesDir}/external-dependencies.txt")
   val allDeclaredDepsPath = file("${intermediatesDir}/exploded-jars.json")
   val inlineUsagePath = file("${intermediatesDir}/inline-usage.json")
+  val inlineUsageErrorsPath = file("${intermediatesDir}/inline-usage-errors.txt")
   val androidResPath = file("${intermediatesDir}/android-res.json")
   val androidResToResUsagePath = file("${intermediatesDir}/android-res-by-res-usage.json")
   val androidAssetSourcePath = file("${intermediatesDir}/exploded-assets.json")

--- a/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
@@ -588,6 +588,7 @@ internal class ProjectPlugin(private val project: Project) {
       )
       artifacts.set(artifactsReportTask.flatMap { it.output })
       output.set(outputPaths.inlineUsagePath)
+      outputErrors.set(outputPaths.inlineUsageErrorsPath)
     }
 
     // Produces a report of packages from included manifests. Null for java-library projects.

--- a/src/main/kotlin/com/autonomousapps/tasks/GenerateBuildHealthTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/GenerateBuildHealthTask.kt
@@ -132,8 +132,9 @@ abstract class GenerateBuildHealthTask : DefaultTask() {
 
     output.bufferWriteJson(buildHealth)
     outputFail.writeText(shouldFail.toString())
+
+    // This file must always exist, even if empty
     if (!didWrite) {
-      // This file must always exist, even if empty
       consoleOutput.writeText("")
     }
   }


### PR DESCRIPTION
#1035

This happened when updating to kotlinx-metadata-jvm v0.7.0, which appears to have fixed a bug and become more strict. Not entirely clear on the root cause, so for now we just catch and log.