### PR TITLE
Use the 'shadowed' subprojects from source

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -41,6 +41,9 @@ plugins {
 
 // Yes, this is also in pluginManagement above. This is required for normal dependencies.
 includeBuild("testkit")
+// Address subprojects of this build (e.g. 'relocated.asm') by their coordinates.
+// https://docs.gradle.org/current/userguide/composite_builds.html#included_build_declaring_substitutions
+includeBuild(".")
 
 dependencyResolutionManagement {
   repositories {

--- a/shadowed/README.asciidoc
+++ b/shadowed/README.asciidoc
@@ -1,4 +1,0 @@
-The projects in this directory are not used as project dependencies,
-primarily due to limitations with IDEA consuming the shadowed variants of
-projects. Also they're very stable. Therefore, we publish the shadowed jars
-and consume those as binary dependencies for simplicity.

--- a/shadowed/antlr/build.gradle.kts
+++ b/shadowed/antlr/build.gradle.kts
@@ -58,6 +58,11 @@ dependencies {
   testRuntimeOnly(libs.junit.engine)
 }
 
+tasks.jar {
+  // Change the classifier of the original 'jar' task so that it does not overlap with the 'shadowJar' task
+  archiveClassifier.set("plain")
+}
+
 tasks.shadowJar {
   archiveClassifier.set("")
 
@@ -83,7 +88,8 @@ tasks.named<Jar>("sourcesJar") {
 
 val javaComponent = components["java"] as AdhocComponentWithVariants
 listOf("apiElements", "runtimeElements").forEach { unpublishable ->
-  javaComponent.withVariantsFromConfiguration(configurations[unpublishable]) {
-    skip()
-  }
+  // Hide the un-shadowed variants in local consumption
+  configurations[unpublishable].isCanBeConsumed = false
+  // Hide the un-shadowed variants in publishing
+  javaComponent.withVariantsFromConfiguration(configurations[unpublishable]) { skip() }
 }

--- a/shadowed/asm-relocated/build.gradle.kts
+++ b/shadowed/asm-relocated/build.gradle.kts
@@ -35,6 +35,11 @@ dagp {
   publishTaskDescription("Publishes to Maven Central and promotes.")
 }
 
+tasks.jar {
+  // Change the classifier of the original 'jar' task so that it does not overlap with the 'shadowJar' task
+  archiveClassifier.set("plain")
+}
+
 tasks.shadowJar {
   archiveClassifier.set("")
   relocate("org.objectweb.asm", "com.autonomousapps.internal.asm")
@@ -42,7 +47,8 @@ tasks.shadowJar {
 
 val javaComponent = components["java"] as AdhocComponentWithVariants
 listOf("apiElements", "runtimeElements").forEach { unpublishable ->
-  javaComponent.withVariantsFromConfiguration(configurations[unpublishable]) {
-    skip()
-  }
+  // Hide the un-shadowed variants in local consumption
+  configurations[unpublishable].isCanBeConsumed = false
+  // Hide the un-shadowed variants in publishing
+  javaComponent.withVariantsFromConfiguration(configurations[unpublishable]) { skip() }
 }


### PR DESCRIPTION
The reason why I would like to have this working is that currently you can't use the plugin via:

```
pluginManagement {
    includedBuild("/path/to/dependency-analysis-android-gradle-plugin")
}
```

Because the moment it becomes an included build, the composite build dependency substitution starts working and then the 'shadowed' components are used from source - which does not work without this change.