### PR TITLE
Users can exclude source sets from ABI analysis.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/AbiExclusionsSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/AbiExclusionsSpec.groovy
@@ -1,5 +1,6 @@
 package com.autonomousapps.jvm
 
+import com.autonomousapps.jvm.projects.AbiExcludedSourceSetProject
 import com.autonomousapps.jvm.projects.AbiExclusionsProject
 
 import static com.autonomousapps.utils.Runner.build
@@ -10,6 +11,21 @@ final class AbiExclusionsSpec extends AbstractJvmSpec {
   def "abi exclusion smoke test (#gradleVersion)"() {
     given:
     def project = new AbiExclusionsProject()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+
+  def "can exclude custom source set from ABI analysis (#gradleVersion)"() {
+    given:
+    def project = new AbiExcludedSourceSetProject()
     gradleProject = project.gradleProject
 
     when:

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiExcludedSourceSetProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiExcludedSourceSetProject.groovy
@@ -1,0 +1,90 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.gradle.dependencies.Plugins
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.actualProjectAdvice
+import static com.autonomousapps.AdviceHelper.emptyProjectAdviceFor
+import static com.autonomousapps.kit.gradle.Dependency.project
+
+final class AbiExcludedSourceSetProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  AbiExcludedSourceSetProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newGradleProjectBuilder()
+      .withRootProject { r ->
+        r.withBuildScript { bs ->
+          bs.withGroovy("""\
+            dependencyAnalysis {
+              abi {
+                exclusions {
+                  excludeSourceSets('functionalTest')
+                }
+              }
+            }"""
+          )
+        }
+      }
+      .withSubproject('consumer') { s ->
+        s.sources = sourcesConsumer
+        s.withBuildScript { bs ->
+          bs.plugins(Plugins.kotlinNoVersion)
+          bs.sourceSets('functionalTest')
+          bs.dependencies(project('functionalTestImplementation', ':producer'))
+        }
+      }
+      .withSubproject('producer') { s ->
+        s.sources = sourcesProducer
+        s.withBuildScript { bs ->
+          bs.plugins(Plugins.kotlinNoVersion)
+        }
+      }
+      .write()
+  }
+
+  private sourcesConsumer = [
+    Source.kotlin(
+      """\
+        package com.example.consumer
+        
+        import com.example.producer.Producer
+        
+        class Consumer {
+          val producer: Producer = Producer()
+        }
+      """.stripIndent()
+    )
+      .withSourceSet('functionalTest')
+      .withPath('com.example.consumer', 'Consumer')
+      .build()
+  ]
+
+  private sourcesProducer = [
+    Source.kotlin(
+      """\
+        package com.example.producer
+        
+        class Producer
+      """.stripIndent()
+    )
+      .withPath('com.example.producer', 'Producer')
+      .build()
+  ]
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  final Set<ProjectAdvice> expectedBuildHealth = [
+    emptyProjectAdviceFor(':consumer'),
+    emptyProjectAdviceFor(':producer')
+  ]
+}

--- a/src/main/kotlin/com/autonomousapps/extension/AbiHandler.kt
+++ b/src/main/kotlin/com/autonomousapps/extension/AbiHandler.kt
@@ -14,6 +14,8 @@ import javax.inject.Inject
  * dependencyAnalysis {
  *   abi {
  *     exclusions {
+ *       excludeSourceSets(/* source sets to exclude from ABI analysis */)
+ *
  *       ignoreSubPackage("internal")
  *       ignoreInternalPackages()
  *       ignoreGeneratedCode()
@@ -38,6 +40,11 @@ abstract class ExclusionsHandler @Inject constructor(objects: ObjectFactory) {
   internal val classExclusions = objects.setProperty<String>().convention(emptySet())
   internal val annotationExclusions = objects.setProperty<String>().convention(emptySet())
   internal val pathExclusions = objects.setProperty<String>().convention(emptySet())
+  internal val excludedSourceSets = objects.setProperty<String>().convention(emptySet())
+
+  fun excludeSourceSets(vararg sourceSets: String) {
+    excludedSourceSets.addAll(*sourceSets)
+  }
 
   fun ignoreInternalPackages() {
     ignoreSubPackage("internal")

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/BuildScript.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/BuildScript.kt
@@ -98,6 +98,14 @@ public class BuildScript(
       this.plugins = plugins.toMutableList()
     }
 
+    public fun sourceSets(vararg sourceSets: String) {
+      this.sourceSets = sourceSets.toMutableList()
+    }
+
+    public fun sourceSets(sourceSets: Iterable<String>) {
+      this.sourceSets = sourceSets.toMutableList()
+    }
+
     public fun build(): BuildScript {
       return BuildScript(
         buildscript = buildscript,


### PR DESCRIPTION
e.g.,
```
dependencyAnalysis {
  abi {
    exclusions {
      excludeSourceSets('customSourceSet', 'another')
    }
  }
}
```

Resolves https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1026