### PR TITLE
Fix plugin, repository, and settings script rendering for Kotlin Dsl

### DIFF
--- a/CONTRIBUTING.asciidoc
+++ b/CONTRIBUTING.asciidoc
@@ -1,41 +1,87 @@
-This file is meant to help contributors working on the project. Please see the https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/wiki/Contributing-&-Debugging[wiki] for more detailed information.
+This document is meant to help contributors working on the project.
+For more detailed information, please refer to the https://github.com/autonomousapps/dependency-analysis-gradle-plugin/wiki/Contributing-&-Debugging[project wiki].
 
-== Install to maven local
+== Required Tools
+
+- Android SDK
+- JDK 8, 11, 17
+
+=== Android SDK Setup
+
+If you haven't installed the Android SDK locally, you can do so for macOS using Homebrew:
+
+----
+brew install android-commandlinetools
+----
+
+Then, set the `ANDROID_HOME` environment variable in your shell by adding the following line to your profile file
+(e.g., `.zshrc`, `.bash_profile`, `.bashrc`):
+
+> The `ANDROID_HOME` path is where `android-commandlinetools` gets installed to by Homebrew
+
+----
+export ANDROID_HOME="/<path>/<to>/<your>/android-commandlinetools"
+----
+
+> IMPORTANT - Make sure to restart IntelliJ after `ANDROID_HOME` is set,
+otherwise, tests will continue to fail when invoked via IntelliJ.
+
+== Install to Maven Local
+
+To install the project to Maven Local, run the following command:
+
 ----
 ./gradlew installForFuncTest
 ----
-== Run the tests
-To run all the checks:
+
+== Running Tests
+
+To execute all checks, run:
+
 ----
 ./gradlew check
 ----
-=== Unit tests
+
+=== Unit Tests
+
+Run unit tests with the following command:
+
 ----
 ./gradlew test
 ----
-=== Functional tests
-This runs all the functional tests against the full test matrix (all supported versions of AGP and
-Gradle). Please be aware this can take a long time.
+
+=== Functional Tests
+
+To run all functional tests against the full test matrix (all supported versions of AGP and Gradle), use the following (please be aware, this can take a long time):
+
 ----
 ./gradlew functionalTest
 ----
-This runs all the functional tests against only the latest-support combination of AGP and Gradle.
+
+For a quicker run against the latest-supported combination of AGP and Gradle, use:
+
 ----
 ./gradlew functionalTest -DfuncTest.quick
 ----
-or
+
+Alternatively:
+
 ----
 ./gradlew quickFunctionalTest
 ----
-> Protip. You can also use `./gradlew qFT` and save yourself some typing.
 
-If you want to run tests against only a subset of the suite, use Gradle's `--tests` option
-https://docs.gradle.org/current/userguide/java_testing.html#simple_name_pattern[support]:
+> Pro tip: You can also use `./gradlew qFT` for brevity.
+
+To run tests against a specific subset of the suite, use Gradle's `--tests`
+https://docs.gradle.org/current/userguide/java_testing.html#simple_name_pattern[option].
+For example:
+
 ----
 ./gradlew functionalTest --tests AnnotationProcessorSpec
 ----
-You can combine quick tests with test filtering, but you must use the more verbose quick-test
-syntax:
+
+For a combination of quick tests and test filtering, use the more verbose quick-test syntax:
+
 ----
 ./gradlew functionalTest --tests AnnotationProcessorSpec -DfuncTest.quick
 ----

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/RewriteDependenciesProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/RewriteDependenciesProject.groovy
@@ -134,7 +134,7 @@ final class RewriteDependenciesProject extends AbstractProject {
 
   final String expectedBuildFile = '''\
     plugins {
-      id 'java-library'
+      id('java-library')
     }
     
     dependencies {
@@ -147,7 +147,7 @@ final class RewriteDependenciesProject extends AbstractProject {
   /** This build script has only been upgrade. Downgrades have been ignored. */
   final String expectedBuildFileUpgraded = '''\
     plugins {
-      id 'java-library'
+      id('java-library')
     }
     
     dependencies {

--- a/testkit/gradle-testkit-plugin/src/main/kotlin/com/autonomousapps/GradleTestKitPlugin.kt
+++ b/testkit/gradle-testkit-plugin/src/main/kotlin/com/autonomousapps/GradleTestKitPlugin.kt
@@ -53,8 +53,14 @@ public class GradleTestKitPlugin : Plugin<Project> {
           // Gradle tests generally require more metaspace
           jvmArgs("-XX:+HeapDumpOnOutOfMemoryError", "-XX:MaxMetaspaceSize=1g")
 
-          systemProperty("com.autonomousapps.plugin-under-test.repo", extension.funcTestRepo.absolutePath)
-          systemProperty("com.autonomousapps.plugin-under-test.version", version.toString())
+          systemProperty(
+            "com.autonomousapps.plugin-under-test.repo",
+            target.provider { extension.funcTestRepo.absolutePath }.get()
+          )
+          systemProperty(
+            "com.autonomousapps.plugin-under-test.version",
+            target.provider { version.toString() }.get()
+          )
         }
       }
       extension.setTestTask(gradleTest)

--- a/testkit/gradle-testkit-plugin/src/main/kotlin/com/autonomousapps/GradleTestKitPlugin.kt
+++ b/testkit/gradle-testkit-plugin/src/main/kotlin/com/autonomousapps/GradleTestKitPlugin.kt
@@ -53,14 +53,8 @@ public class GradleTestKitPlugin : Plugin<Project> {
           // Gradle tests generally require more metaspace
           jvmArgs("-XX:+HeapDumpOnOutOfMemoryError", "-XX:MaxMetaspaceSize=1g")
 
-          systemProperty(
-            "com.autonomousapps.plugin-under-test.repo",
-            target.provider { extension.funcTestRepo.absolutePath }.get()
-          )
-          systemProperty(
-            "com.autonomousapps.plugin-under-test.version",
-            target.provider { version.toString() }.get()
-          )
+          systemProperty("com.autonomousapps.plugin-under-test.repo", extension.funcTestRepo.absolutePath)
+          systemProperty("com.autonomousapps.plugin-under-test.version", version.toString())
         }
       }
       extension.setTestTask(gradleTest)

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/Plugin.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/Plugin.kt
@@ -10,8 +10,9 @@ public class Plugin @JvmOverloads constructor(
 ) : Element.Line {
 
   override fun render(scribe: Scribe): String = scribe.line { s ->
-    s.append("id ")
+    s.append("id(")
     s.appendQuoted(id)
+    s.append(")")
     version?.let { v ->
       s.append(" version ")
       s.appendQuoted(v)

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/Repository.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/Repository.kt
@@ -61,7 +61,7 @@ public sealed class Repository : Element.Line {
 
     @JvmStatic
     public fun ofMaven(repoUrl: String): Repository {
-      return Url("maven { url = \"${repoUrl.escape()}\" }")
+      return Url("maven { url = uri(\"${repoUrl.escape()}\") }")
     }
   }
 }

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/SettingsScript.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/SettingsScript.kt
@@ -24,9 +24,25 @@ public class SettingsScript @JvmOverloads constructor(
       appendLine(scribe.use { s -> d.render(s) })
     }
 
-    appendLine("rootProject.name = '$rootProjectName'")
+    val rootProjectNameLine = scribe.use { s ->
+      s.append("rootProject.name = ")
+      s.appendQuoted(rootProjectName)
+      s.build()
+    }
+
+    appendLine(rootProjectNameLine)
     appendLine()
-    appendLine(subprojects.joinToString("\n") { "include ':$it'" })
+
+    val subprojectLines = subprojects.joinToString("\n") {
+      scribe.use { s ->
+        s.append("include(")
+        s.appendQuoted(":$it")
+        s.append(")")
+        s.build()
+      }
+    }
+
+    appendLine(subprojectLines)
 
     if (additions.isNotBlank()) {
       appendLine()

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/render/Scribe.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/render/Scribe.kt
@@ -85,4 +85,8 @@ public class Scribe @JvmOverloads constructor(
   }
 
   private fun quote(): String = if (dslKind == GradleProject.DslKind.GROOVY) "'" else "\""
+
+  internal fun build(): String {
+    return buffer.toString()
+  }
 }

--- a/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTest.kt
+++ b/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTest.kt
@@ -121,8 +121,8 @@ internal class ScribeTest {
         
         rootProject.name = '$rootProjectName'
         
-        include ':a'
-        include ':b'
+        include(':a')
+        include(':b')
         
         ext.magic = 'octarine'
         ext.meaningOfLife = 42

--- a/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTest.kt
+++ b/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTest.kt
@@ -100,7 +100,7 @@ internal class ScribeTest {
         """
         pluginManagement {
           repositories {
-            maven { url = "" }
+            maven { url = uri("") }
             gradlePluginPortal()
             mavenCentral()
             google()
@@ -108,8 +108,8 @@ internal class ScribeTest {
         }
         
         plugins {
-          id 'com.autonomousapps.dependency-analysis' version '1.25.0'
-          id 'com.gradle.enterprise' version '3.11.4'
+          id('com.autonomousapps.dependency-analysis') version '1.25.0'
+          id('com.gradle.enterprise') version '3.11.4'
         }
         
         dependencyResolutionManagement {
@@ -325,7 +325,7 @@ internal class ScribeTest {
         """
           buildscript {
             repositories {
-              maven { url = "" }
+              maven { url = uri("") }
               gradlePluginPortal()
               mavenCentral()
               google()
@@ -407,7 +407,7 @@ internal class ScribeTest {
         """
           buildscript {
             repositories {
-              maven { url = "" }
+              maven { url = uri("") }
               gradlePluginPortal()
               mavenCentral()
               google()
@@ -419,8 +419,8 @@ internal class ScribeTest {
           }
           
           plugins {
-            id 'application'
-            id 'groovy'
+            id('application')
+            id('groovy')
           }
           
           group = '$group'
@@ -476,7 +476,7 @@ internal class ScribeTest {
       val plugin = Plugin("magic", "1.0")
 
       // Expect
-      assertThat(plugin.render(scribe)).isEqualTo("id 'magic' version '1.0'\n")
+      assertThat(plugin.render(scribe)).isEqualTo("id('magic') version '1.0'\n")
     }
 
     @Test fun `can render a plugin without a version`() {
@@ -484,7 +484,7 @@ internal class ScribeTest {
       val plugin = Plugin("magic")
 
       // Expect
-      assertThat(plugin.render(scribe)).isEqualTo("id 'magic'\n")
+      assertThat(plugin.render(scribe)).isEqualTo("id('magic')\n")
     }
 
     @Test fun `can render a plugin with a version and apply false`() {
@@ -492,7 +492,7 @@ internal class ScribeTest {
       val plugin = Plugin("magic", "1.0", false)
 
       // Expect
-      assertThat(plugin.render(scribe)).isEqualTo("id 'magic' version '1.0' apply false\n")
+      assertThat(plugin.render(scribe)).isEqualTo("id('magic') version '1.0' apply false\n")
     }
 
     @Test fun `can render a plugin without a version and apply false`() {
@@ -500,7 +500,7 @@ internal class ScribeTest {
       val plugin = Plugin(id = "magic", apply = false)
 
       // Expect
-      assertThat(plugin.render(scribe)).isEqualTo("id 'magic' apply false\n")
+      assertThat(plugin.render(scribe)).isEqualTo("id('magic') apply false\n")
     }
 
     @Test fun `can render plugins block`() {
@@ -514,8 +514,8 @@ internal class ScribeTest {
       assertThat(plugins.render(scribe)).isEqualTo(
         """
           plugins {
-            id 'magic' version '1.0'
-            id 'meaning-of-life' version '2.0'
+            id('magic') version '1.0'
+            id('meaning-of-life') version '2.0'
           }
           
         """.trimIndent()


### PR DESCRIPTION
I did take note that the `Dependency` rendering for Kotlin Dsl also requires some work and will likely not generate a valid Kotlin Dsl, but chose to forego adjusting any of that since it seems to require a larger change.