### PR TITLE
Improve actual output on testkit-truth

### DIFF
--- a/testkit/gradle-testkit-truth/src/main/kotlin/com/autonomousapps/kit/truth/BuildResultSubject.kt
+++ b/testkit/gradle-testkit-truth/src/main/kotlin/com/autonomousapps/kit/truth/BuildResultSubject.kt
@@ -64,4 +64,8 @@ public class BuildResultSubject private constructor(
     }
     return check("taskPaths(%s)", outcome).that(actual!!.taskPaths(outcome))
   }
+
+  override fun actualCustomStringRepresentation(): String {
+    return actual?.output ?: "null"
+  }
 }


### PR DESCRIPTION
Right now when a test doesn't pass you get an output like this one:

```
Caused by: value of                : buildResult.task(:proj:compileJava2)
expected to have a value: FAILED
but was                 : null
buildResult was         : org.gradle.testkit.runner.internal.FeatureCheckBuildResult@1d75e7af
	at [[Reflective call: 4 frames collapsed (https://goo.gl/aH3UyP)]].(:0)
	... 1 more
```

With this change we get outputs like this one that give more information:

```
Caused by: value of:
    buildResult.task(:proj:compileJava2)
expected to have a value:
    FAILED
but was:
    null
buildResult was:
    Calculating task graph as no cached configuration is available for tasks: proj:assemble
    > Task :proj:processResources NO-SOURCE
    > Task :proj:compileJava
    > Task :proj:classes
    > Task :proj:jar
    > Task :proj:assemble
    
    BUILD SUCCESSFUL in 2s
    2 actionable tasks: 2 executed
    Configuration cache entry stored.
    
	at [[Reflective call: 4 frames collapsed (https://goo.gl/aH3UyP)]].(:0)
	... 1 more
```

This way you can see directly that the task `:proj:compileJava2` was not executed but `:proj:compileJava` was.

Related with #1068 (doesn't close it yet, I will create some more PRs) 