### PR TITLE
feat(testkit-support): support DslKind.KOTLIN.

### DIFF
--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/Feature.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/Feature.kt
@@ -1,5 +1,6 @@
 package com.autonomousapps.kit.gradle
 
+import com.autonomousapps.kit.GradleProject.DslKind
 import com.autonomousapps.kit.render.Element
 import com.autonomousapps.kit.render.Scribe
 
@@ -10,11 +11,26 @@ public class Feature @JvmOverloads constructor(
 
   override val name: String = "registerFeature(\"$featureName\")"
 
-  override fun render(scribe: Scribe): String = scribe.block(this) { s ->
+  override fun render(scribe: Scribe): String = when (scribe.dslKind) {
+    DslKind.GROOVY -> renderGroovy(scribe)
+    DslKind.KOTLIN -> renderKotlin(scribe)
+  }
+
+  private fun renderGroovy(scribe: Scribe): String = scribe.block(this) { s ->
     s.line {
       s.append("usingSourceSet(")
       s.append("sourceSets.")
       s.append(sourceSetName)
+      s.append(")")
+    }
+  }
+
+  private fun renderKotlin(scribe: Scribe): String = scribe.block(this) { s ->
+    s.line {
+      s.append("usingSourceSet(")
+      s.append("sourceSets[")
+      s.appendQuoted(sourceSetName)
+      s.append("]")
       s.append(")")
     }
   }

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/Plugin.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/Plugin.kt
@@ -1,5 +1,6 @@
 package com.autonomousapps.kit.gradle
 
+import com.autonomousapps.kit.GradleProject.DslKind
 import com.autonomousapps.kit.render.Element
 import com.autonomousapps.kit.render.Scribe
 
@@ -9,9 +10,27 @@ public class Plugin @JvmOverloads constructor(
   public val apply: Boolean = true,
 ) : Element.Line {
 
-  override fun render(scribe: Scribe): String = scribe.line { s ->
+  override fun render(scribe: Scribe): String = when (scribe.dslKind) {
+    DslKind.GROOVY -> renderGroovy(scribe)
+    DslKind.KOTLIN -> renderKotlin(scribe)
+  }
+
+  private fun renderGroovy(scribe: Scribe): String = scribe.line { s ->
     s.append("id ")
     s.appendQuoted(id)
+    version?.let { v ->
+      s.append(" version ")
+      s.appendQuoted(v)
+    }
+    if (!apply) {
+      s.append(" apply false")
+    }
+  }
+
+  private fun renderKotlin(scribe: Scribe): String = scribe.line { s ->
+    s.append("id(")
+    s.appendQuoted(id)
+    s.append(")")
     version?.let { v ->
       s.append(" version ")
       s.appendQuoted(v)

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/Repositories.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/Repositories.kt
@@ -3,6 +3,23 @@ package com.autonomousapps.kit.gradle
 import com.autonomousapps.kit.render.Element
 import com.autonomousapps.kit.render.Scribe
 
+/**
+ * ```
+ * // Groovy DSL
+ * repositories {
+ *   maven { url 'https://repo.spring.io/release' }
+ * }
+ *
+ * // Kotlin DSL
+ * repositories {
+ *   // 1
+ *   maven { url = uri("https://repo.spring.io/release") }
+ *
+ *   // 2
+ *   maven(url = "https://repo.spring.io/release")
+ * }
+ * ```
+ */
 public class Repositories @JvmOverloads constructor(
   private val repositories: MutableList<Repository> = mutableListOf(),
 ) : Element.Block {

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/Repository.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/Repository.kt
@@ -2,33 +2,67 @@ package com.autonomousapps.kit.gradle
 
 import com.autonomousapps.kit.AbstractGradleProject.Companion.FUNC_TEST_INCLUDED_BUILD_REPOS
 import com.autonomousapps.kit.AbstractGradleProject.Companion.FUNC_TEST_REPO
+import com.autonomousapps.kit.GradleProject.DslKind
 import com.autonomousapps.kit.render.Element
 import com.autonomousapps.kit.render.Scribe
-import com.autonomousapps.kit.utils.escape
+import com.autonomousapps.kit.render.escape
 
+/**
+ * ```
+ * // Groovy DSL
+ * maven { url 'https://repo.spring.io/release' }
+ * mavenCentral()
+ *
+ * // Kotlin DSL
+ * // 1
+ * maven { url = uri("https://repo.spring.io/release") }
+ * mavenCentral()
+ *
+ * // 2
+ * maven(url = "https://repo.spring.io/release")
+ * mavenCentral()
+ * ```
+ */
 public sealed class Repository : Element.Line {
 
-  public data class Method(private val repo: String) : Repository() {
-
+  private data class Method(private val repoCall: String) : Repository() {
     override fun render(scribe: Scribe): String = scribe.line { s ->
-      s.append(repo)
+      s.append(repoCall)
     }
   }
 
-  public data class Url(private val repo: String) : Repository() {
-
+  private data class Url(private val repoUrl: String) : Repository() {
     override fun render(scribe: Scribe): String = scribe.line { s ->
-      s.append(repo)
+      s.append("maven { url = ")
+
+      // TODO(tsr): model
+      if (scribe.dslKind == DslKind.KOTLIN) {
+        s.append("uri(")
+      }
+      s.appendQuoted(repoUrl)
+      if (scribe.dslKind == DslKind.KOTLIN) {
+        s.append(")")
+      }
+
+      s.append(" }")
+    }
+  }
+
+  private data class FlatDir(private val repoUrl: String) : Repository() {
+    override fun render(scribe: Scribe): String = scribe.line { s ->
+      s.append("flatDir { ")
+      s.appendQuoted(repoUrl)
+      s.append(" }")
     }
   }
 
   public companion object {
     @JvmField public val GOOGLE: Repository = Method("google()")
     @JvmField public val GRADLE_PLUGIN_PORTAL: Repository = Method("gradlePluginPortal()")
-    @JvmField public val LIBS: Repository = Url("flatDir { 'libs' }")
     @JvmField public val MAVEN_CENTRAL: Repository = Method("mavenCentral()")
     @JvmField public val MAVEN_LOCAL: Repository = Method("mavenLocal()")
     @JvmField public val SNAPSHOTS: Repository = ofMaven("https://oss.sonatype.org/content/repositories/snapshots/")
+    @JvmField public val LIBS: Repository = FlatDir("libs")
 
     /**
      * The repository for local projects if you're using the plugin `com.autonomousapps.testkit`. If not, a broken,
@@ -60,8 +94,6 @@ public sealed class Repository : Element.Line {
     )
 
     @JvmStatic
-    public fun ofMaven(repoUrl: String): Repository {
-      return Url("maven { url = \"${repoUrl.escape()}\" }")
-    }
+    public fun ofMaven(repoUrl: String): Repository = Url(repoUrl.escape())
   }
 }

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/SettingsScript.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/SettingsScript.kt
@@ -1,5 +1,6 @@
 package com.autonomousapps.kit.gradle
 
+import com.autonomousapps.kit.GradleProject.DslKind
 import com.autonomousapps.kit.render.Scribe
 
 public class SettingsScript @JvmOverloads constructor(
@@ -24,13 +25,23 @@ public class SettingsScript @JvmOverloads constructor(
       appendLine(scribe.use { s -> d.render(s) })
     }
 
-    appendLine("rootProject.name = '$rootProjectName'")
+    appendLine(renderRootProjectName(scribe.dslKind))
     appendLine()
-    appendLine(subprojects.joinToString("\n") { "include ':$it'" })
+    appendLine(subprojects.joinToString("\n") { renderInclude(scribe.dslKind, it) })
 
     if (additions.isNotBlank()) {
       appendLine()
       appendLine(additions)
     }
+  }
+
+  private fun renderRootProjectName(dslKind: DslKind) = when (dslKind) {
+    DslKind.GROOVY -> "rootProject.name = '$rootProjectName'"
+    DslKind.KOTLIN -> "rootProject.name = \"$rootProjectName\""
+  }
+
+  private fun renderInclude(dslKind: DslKind, subproject: String) = when (dslKind) {
+    DslKind.GROOVY -> "include ':$subproject'"
+    DslKind.KOTLIN -> "include(\":$subproject\")"
   }
 }

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/SourceSet.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/SourceSet.kt
@@ -1,14 +1,26 @@
 package com.autonomousapps.kit.gradle
 
+import com.autonomousapps.kit.GradleProject.DslKind
 import com.autonomousapps.kit.render.Element
 import com.autonomousapps.kit.render.Scribe
 
 public class SourceSet(
-  public val name: String
+  public val name: String,
 ) : Element.Line {
 
-  override fun render(scribe: Scribe): String = scribe.line { s ->
+  override fun render(scribe: Scribe): String = when (scribe.dslKind) {
+    DslKind.GROOVY -> renderGroovy(scribe)
+    DslKind.KOTLIN -> renderKotlin(scribe)
+  }
+
+  private fun renderGroovy(scribe: Scribe): String = scribe.line { s ->
     s.append(name)
+  }
+
+  private fun renderKotlin(scribe: Scribe): String = scribe.line { s ->
+    s.append("create(")
+    s.appendQuoted(name)
+    s.append(")")
   }
 
   public companion object {

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/android/AndroidBlock.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/android/AndroidBlock.kt
@@ -1,5 +1,6 @@
 package com.autonomousapps.kit.gradle.android
 
+import com.autonomousapps.kit.GradleProject.DslKind
 import com.autonomousapps.kit.render.Element
 import com.autonomousapps.kit.render.Scribe
 
@@ -22,7 +23,12 @@ public class AndroidBlock @JvmOverloads constructor(
 
   override val name: String = "android"
 
-  override fun render(scribe: Scribe): String = scribe.block(this) { s ->
+  override fun render(scribe: Scribe): String = when (scribe.dslKind) {
+    DslKind.GROOVY -> renderGroovy(scribe)
+    DslKind.KOTLIN -> renderKotlin(scribe)
+  }
+
+  private fun renderGroovy(scribe: Scribe): String = scribe.block(this) { s ->
     if (namespace != null) {
       s.line {
         it.append("namespace '")
@@ -32,6 +38,23 @@ public class AndroidBlock @JvmOverloads constructor(
     }
     s.line {
       it.append("compileSdkVersion ")
+      it.append(compileSdkVersion)
+    }
+    defaultConfig.render(s)
+    compileOptions.render(s)
+    kotlinOptions?.render(s)
+  }
+
+  private fun renderKotlin(scribe: Scribe): String = scribe.block(this) { s ->
+    if (namespace != null) {
+      s.line {
+        it.append("namespace \"")
+        it.append(namespace)
+        it.append("\"")
+      }
+    }
+    s.line {
+      it.append("compileSdkVersion = ")
       it.append(compileSdkVersion)
     }
     defaultConfig.render(s)

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/android/CompileOptions.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/android/CompileOptions.kt
@@ -1,5 +1,6 @@
 package com.autonomousapps.kit.gradle.android
 
+import com.autonomousapps.kit.GradleProject.DslKind
 import com.autonomousapps.kit.render.Element
 import com.autonomousapps.kit.render.Scribe
 import org.gradle.api.JavaVersion
@@ -19,7 +20,12 @@ public class CompileOptions @JvmOverloads constructor(
 
   override val name: String = "compileOptions"
 
-  override fun render(scribe: Scribe): String = scribe.block(this) { s ->
+  override fun render(scribe: Scribe): String = when (scribe.dslKind) {
+    DslKind.GROOVY -> renderGroovy(scribe)
+    DslKind.KOTLIN -> renderKotlin(scribe)
+  }
+
+  private fun renderGroovy(scribe: Scribe): String = scribe.block(this) { s ->
     s.line {
       it.append("sourceCompatibility ")
       it.append("JavaVersion.")
@@ -32,8 +38,20 @@ public class CompileOptions @JvmOverloads constructor(
     }
   }
 
+  private fun renderKotlin(scribe: Scribe): String = scribe.block(this) { s ->
+    s.line {
+      it.append("sourceCompatibility = ")
+      it.append("JavaVersion.")
+      it.append(sourceCompatibility.name)
+    }
+    s.line {
+      it.append("targetCompatibility = ")
+      it.append("JavaVersion.")
+      it.append(targetCompatibility.name)
+    }
+  }
+
   public companion object {
-    @JvmField
-    public val DEFAULT: CompileOptions = CompileOptions()
+    @JvmField public val DEFAULT: CompileOptions = CompileOptions()
   }
 }

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/android/DefaultConfig.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/android/DefaultConfig.kt
@@ -1,5 +1,6 @@
 package com.autonomousapps.kit.gradle.android
 
+import com.autonomousapps.kit.GradleProject.DslKind
 import com.autonomousapps.kit.render.Element
 import com.autonomousapps.kit.render.Scribe
 
@@ -26,7 +27,12 @@ public class DefaultConfig @JvmOverloads constructor(
 
   override val name: String = "defaultConfig"
 
-  override fun render(scribe: Scribe): String = scribe.block(this) { s ->
+  override fun render(scribe: Scribe): String = when (scribe.dslKind) {
+    DslKind.GROOVY -> renderGroovy(scribe)
+    DslKind.KOTLIN -> renderKotlin(scribe)
+  }
+
+  private fun renderGroovy(scribe: Scribe): String = scribe.block(this) { s ->
     if (applicationId != null) {
       s.line {
         it.append("applicationId ")
@@ -47,6 +53,37 @@ public class DefaultConfig @JvmOverloads constructor(
     }
     s.line {
       it.append("versionName ")
+      it.appendQuoted(versionName)
+    }
+    if (testInstrumentationRunner != null) {
+      s.line {
+        it.append("testInstrumentationRunner = ")
+        it.appendQuoted(testInstrumentationRunner)
+      }
+    }
+  }
+
+  private fun renderKotlin(scribe: Scribe): String = scribe.block(this) { s ->
+    if (applicationId != null) {
+      s.line {
+        it.append("applicationId ")
+        it.appendQuoted(applicationId)
+      }
+    }
+    s.line {
+      it.append("minSdkVersion = ")
+      it.append(minSdkVersion)
+    }
+    s.line {
+      it.append("targetSdkVersion = ")
+      it.append(targetSdkVersion)
+    }
+    s.line {
+      it.append("versionCode = ")
+      it.append(versionCode)
+    }
+    s.line {
+      it.append("versionName = ")
       it.appendQuoted(versionName)
     }
     if (testInstrumentationRunner != null) {

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/render/MethodOrAssignment.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/render/MethodOrAssignment.kt
@@ -1,0 +1,21 @@
+package com.autonomousapps.kit.render
+
+/**
+ * Sometimes the differences between Groovy and Kotlin DSL are not just whether parentheses are optional or single- vs
+ * double-quotes, but whether a property is configured via a method call or an assignment. For example, a repository
+ * may be declared like so:
+ *
+ * ```
+ * // valid Groovy syntax
+ * maven { url '...' }
+ * maven { url = '...' }
+ * ```
+ * ```
+ * // valid Kotlin syntax
+ * maven { url = uri("...") }
+ * maven(url = "...")
+ * ```
+ */
+internal class MethodOrAssignment {
+  // TODO(tsr): use?
+}

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/render/Scribe.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/render/Scribe.kt
@@ -70,6 +70,10 @@ public class Scribe @JvmOverloads constructor(
     buffer.append(obj.toString())
   }
 
+  internal fun appendMethodOrAssignment(obj: Any?) {
+
+  }
+
   internal fun appendLine() {
     buffer.appendLine()
   }

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/render/text.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/render/text.kt
@@ -1,5 +1,5 @@
 @file:JvmName("Text")
 
-package com.autonomousapps.kit.utils
+package com.autonomousapps.kit.render
 
 internal fun String.escape(): String = replace("\\", "\\\\")

--- a/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestGroovy.kt
+++ b/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestGroovy.kt
@@ -8,7 +8,7 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class ScribeTest {
+internal class ScribeTestGroovy {
 
   private val scribe = Scribe(
     dslKind = DslKind.GROOVY,
@@ -29,7 +29,11 @@ internal class ScribeTest {
 
     @Test fun `can render repositories block`() {
       // Given
-      val repositories = Repositories(Repository.GOOGLE, Repository.MAVEN_CENTRAL)
+      val repositories = Repositories(
+        Repository.GOOGLE,
+        Repository.MAVEN_CENTRAL,
+        Repository.SNAPSHOTS,
+      )
 
       // When
       val text = repositories.render(scribe)
@@ -40,6 +44,7 @@ internal class ScribeTest {
         repositories {
           google()
           mavenCentral()
+          maven { url = 'https://oss.sonatype.org/content/repositories/snapshots/' }
         }
         
       """.trimIndent()
@@ -100,7 +105,7 @@ internal class ScribeTest {
         """
         pluginManagement {
           repositories {
-            maven { url = "" }
+            maven { url = '' }
             gradlePluginPortal()
             mavenCentral()
             google()
@@ -387,7 +392,7 @@ internal class ScribeTest {
         """
           buildscript {
             repositories {
-              maven { url = "" }
+              maven { url = '' }
               gradlePluginPortal()
               mavenCentral()
               google()
@@ -469,7 +474,7 @@ internal class ScribeTest {
         """
           buildscript {
             repositories {
-              maven { url = "" }
+              maven { url = '' }
               gradlePluginPortal()
               mavenCentral()
               google()

--- a/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestKotlin.kt
+++ b/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestKotlin.kt
@@ -1,0 +1,592 @@
+package com.autonomousapps.kit.render
+
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.gradle.*
+import com.autonomousapps.kit.gradle.Dependency.Companion.implementation
+import com.autonomousapps.kit.gradle.android.AndroidBlock
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+internal class ScribeTestKotlin {
+
+  private val scribe = Scribe(
+    dslKind = GradleProject.DslKind.KOTLIN,
+    indent = 2,
+  )
+
+  @Nested inner class RepositoriesTest {
+    @Test fun `can render single repository`() {
+      // Given
+      val repo = Repository.GOOGLE
+
+      // When
+      val text = repo.render(scribe)
+
+      // Then
+      assertThat(text).isEqualTo("google()\n")
+    }
+
+    @Test fun `can render repositories block`() {
+      // Given
+      val repositories = Repositories(
+        Repository.GOOGLE,
+        Repository.MAVEN_CENTRAL,
+        Repository.SNAPSHOTS,
+      )
+
+      // When
+      val text = repositories.render(scribe)
+
+      // Then
+      assertThat(text).isEqualTo(
+        """
+        repositories {
+          google()
+          mavenCentral()
+          maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots/") }
+        }
+        
+      """.trimIndent()
+      )
+    }
+  }
+
+  @Nested inner class SettingsTest {
+    @Test fun `can render dependencyResolutionManagement block`() {
+      // Given
+      val repositories = Repositories(Repository.GOOGLE, Repository.MAVEN_CENTRAL)
+      val dependencyResolutionManagement = DependencyResolutionManagement(repositories)
+
+      // When
+      val text = dependencyResolutionManagement.render(scribe)
+
+      // Then
+      assertThat(text).isEqualTo(
+        """
+        dependencyResolutionManagement {
+          repositories {
+            google()
+            mavenCentral()
+          }
+        }
+        
+      """.trimIndent()
+      )
+    }
+
+    @Test fun `can render settings script in one pass`() {
+      // Given
+      val pluginManagement = PluginManagement(Repositories.DEFAULT_PLUGINS)
+      val dependencyResolutionManagement = DependencyResolutionManagement(
+        Repositories(Repository.GOOGLE, Repository.MAVEN_CENTRAL)
+      )
+      val rootProjectName = "test-project"
+      val settings = SettingsScript(
+        pluginManagement = pluginManagement,
+        dependencyResolutionManagement = dependencyResolutionManagement,
+        rootProjectName = rootProjectName,
+        plugins = Plugins(
+          Plugin("com.autonomousapps.dependency-analysis", "1.25.0"),
+          Plugin("com.gradle.enterprise", "3.11.4")
+        ),
+        subprojects = setOf("a", "b"),
+        // TODO(tsr): need withGroovy() and withKotlin() methods.
+        //   additions = """
+        //   ext.magic = 'octarine'
+        //   ext.meaningOfLife = 42
+        // """.trimIndent()
+      )
+
+      // When
+      val text = settings.render(scribe)
+
+      // Then
+      assertThat(text).isEqualTo(
+        """
+        pluginManagement {
+          repositories {
+            maven { url = uri("") }
+            gradlePluginPortal()
+            mavenCentral()
+            google()
+          }
+        }
+        
+        plugins {
+          id("com.autonomousapps.dependency-analysis") version "1.25.0"
+          id("com.gradle.enterprise") version "3.11.4"
+        }
+        
+        dependencyResolutionManagement {
+          repositories {
+            google()
+            mavenCentral()
+          }
+        }
+        
+        rootProject.name = "$rootProjectName"
+        
+        include(":a")
+        include(":b")
+        
+      """.trimIndent()
+      )
+    }
+  }
+
+  @Nested inner class DependenciesTest {
+    @Test fun `can render an external dependency`() {
+      // Given
+      val dependency = Dependency(
+        configuration = "implementation",
+        dependency = "com:foo:1.0",
+      )
+
+      // When
+      val text = dependency.render(scribe)
+
+      // Then
+      assertThat(text).isEqualTo("implementation(\"com:foo:1.0\")\n")
+    }
+
+    @Test fun `can render a local dependency`() {
+      // Given
+      val dependency = Dependency(
+        configuration = "implementation",
+        dependency = ":foo",
+      )
+
+      // When
+      val text = dependency.render(scribe)
+
+      // Then
+      assertThat(text).isEqualTo("implementation(project(\":foo\"))\n")
+    }
+
+    @Test fun `can render function call`() {
+      // Given
+      val dependency = Dependency(
+        configuration = "implementation",
+        dependency = "dagger()",
+      )
+
+      // When
+      val text = dependency.render(scribe)
+
+      // Then
+      assertThat(text).isEqualTo("implementation(dagger())\n")
+    }
+
+    @Test fun `can render custom notation`() {
+      // Given
+      val dependency = Dependency(
+        configuration = "implementation",
+        dependency = "deps.foo.bar",
+      )
+
+      // When
+      val text = dependency.render(scribe)
+
+      // Then
+      assertThat(text).isEqualTo("implementation(deps.foo.bar)\n")
+    }
+
+    @Test fun `can render dependency with nonstandard extension`() {
+      // Given
+      val dependency = Dependency(
+        configuration = "implementation",
+        dependency = "com:foo:1.0",
+        ext = "aar",
+      )
+
+      // When
+      val text = dependency.render(scribe)
+
+      // Then
+      assertThat(text).isEqualTo("implementation(name = \"com:foo:1.0\", ext = \"aar\")\n")
+    }
+
+    @Test fun `can render testFixtures to external dependency`() {
+      // Given
+      val dependency = Dependency(
+        configuration = "implementation",
+        dependency = "com:foo:1.0",
+        capability = "test-fixtures"
+      )
+
+      // When
+      val text = dependency.render(scribe)
+
+      // Then
+      assertThat(text).isEqualTo("implementation(testFixtures(\"com:foo:1.0\"))\n")
+    }
+
+    @Test fun `can render testFixtures to local dependency`() {
+      // Given
+      val dependency = Dependency(
+        configuration = "implementation",
+        dependency = ":foo",
+        capability = "test-fixtures"
+      )
+
+      // When
+      val text = dependency.render(scribe)
+
+      // Then
+      assertThat(text).isEqualTo("implementation(testFixtures(project(\":foo\")))\n")
+    }
+
+    @Test fun `can render platform to external dependency`() {
+      // Given
+      val dependency = Dependency(
+        configuration = "implementation",
+        dependency = "com:foo:1.0",
+        capability = "platform"
+      )
+
+      // When
+      val text = dependency.render(scribe)
+
+      // Then
+      assertThat(text).isEqualTo("implementation(platform(\"com:foo:1.0\"))\n")
+    }
+
+    @Test fun `can render platform to local dependency`() {
+      // Given
+      val dependency = Dependency(
+        configuration = "implementation",
+        dependency = ":foo",
+        capability = "platform"
+      )
+
+      // When
+      val text = dependency.render(scribe)
+
+      // Then
+      assertThat(text).isEqualTo("implementation(platform(project(\":foo\")))\n")
+    }
+
+    @Test fun `can render enforcedPlatform to external dependency`() {
+      // Given
+      val dependency = Dependency(
+        configuration = "implementation",
+        dependency = "com:foo:1.0",
+        capability = "enforcedPlatform"
+      )
+
+      // When
+      val text = dependency.render(scribe)
+
+      // Then
+      assertThat(text).isEqualTo("implementation(enforcedPlatform(\"com:foo:1.0\"))\n")
+    }
+
+    @Test fun `can render enforcedPlatform to local dependency`() {
+      // Given
+      val dependency = Dependency(
+        configuration = "implementation",
+        dependency = ":foo",
+        capability = "enforcedPlatform"
+      )
+
+      // When
+      val text = dependency.render(scribe)
+
+      // Then
+      assertThat(text).isEqualTo("implementation(enforcedPlatform(project(\":foo\")))\n")
+    }
+
+    @Test fun `can render custom capability to external dependency`() {
+      // Given
+      val dependency = Dependency(
+        configuration = "implementation",
+        dependency = "com:foo:1.0",
+        capability = "myFeature"
+      )
+
+      // When
+      val text = dependency.render(scribe)
+
+      // Then
+      assertThat(text)
+        .isEqualTo("implementation(\"com:foo:1.0\") { capabilities { requireCapabilities(\"myFeature\") } }\n")
+    }
+
+    @Test fun `can render custom capability to internal dependency`() {
+      // Given
+      val dependency = Dependency(
+        configuration = "implementation",
+        dependency = ":foo",
+        capability = "myFeature"
+      )
+
+      // When
+      val text = dependency.render(scribe)
+
+      // Then
+      assertThat(text).isEqualTo(
+        "implementation(project(\":foo\")) { capabilities { requireCapabilities(\"myFeature\") } }\n"
+      )
+    }
+
+    @Test fun `can render custom capability to dependency with nonstandard extension`() {
+      // Given
+      val dependency = Dependency(
+        configuration = "implementation",
+        dependency = "com:foo:1.0",
+        capability = "myFeature",
+        ext = "aar"
+      )
+
+      // When
+      val text = dependency.render(scribe)
+
+      // Then
+      assertThat(text).isEqualTo(
+        "implementation(name = \"com:foo:1.0\", ext = \"aar\") { capabilities { requireCapabilities(\"myFeature\") } }\n"
+      )
+    }
+
+    @Test fun `can render dependencies block`() {
+      // Given
+      val dependencies =
+        Dependencies(
+          Dependency("antlr", "org.antlr:antlr4:4.8-1"),
+          implementation("commons-io:commons-io:2.6"),
+        )
+
+      // When
+      val text = dependencies.render(scribe)
+
+      // Then
+      assertThat(text).isEqualTo(
+        """
+          dependencies {
+            antlr("org.antlr:antlr4:4.8-1")
+            implementation("commons-io:commons-io:2.6")
+          }
+          
+        """.trimIndent()
+      )
+    }
+  }
+
+  @Nested inner class BuildscriptBlockTest {
+    @Test fun `can render buildscript block`() {
+      // Given
+      val repositories = Repositories.DEFAULT_PLUGINS
+      val dependencies = Dependencies(
+        Dependency("antlr", "org.antlr:antlr4:4.8-1"),
+        implementation("commons-io:commons-io:2.6")
+      )
+      val buildscriptBlock = BuildscriptBlock(repositories, dependencies)
+
+      // When
+      val text = buildscriptBlock.render(scribe)
+
+      // Then
+      assertThat(text).isEqualTo(
+        """
+          buildscript {
+            repositories {
+              maven { url = uri("") }
+              gradlePluginPortal()
+              mavenCentral()
+              google()
+            }
+            dependencies {
+              antlr("org.antlr:antlr4:4.8-1")
+              implementation("commons-io:commons-io:2.6")
+            }
+          }
+          
+        """.trimIndent()
+      )
+    }
+  }
+
+  @Nested inner class BuildScriptTest {
+    @Test fun `can render a build script that has a group without a version`() {
+      // Given
+      val group = "com.group"
+      val buildScript = BuildScript(
+        group = group,
+      )
+
+      // When
+      val text = buildScript.render(scribe)
+
+      // Then
+      assertThat(text).isEqualTo("group = \"$group\"\n\n")
+    }
+
+    @Test fun `can render a build script that has a version without a group`() {
+      // Given
+      val version = "1.0"
+      val buildScript = BuildScript(
+        version = version,
+      )
+
+      // When
+      val text = buildScript.render(scribe)
+
+      // Then
+      assertThat(text).isEqualTo("version = \"$version\"\n\n")
+    }
+
+    @Test fun `can render a build script`() {
+      // Given
+      val buildscriptBlock = BuildscriptBlock(
+        Repositories.DEFAULT_PLUGINS,
+        Dependencies(
+          Dependency("antlr", "org.antlr:antlr4:4.8-1"),
+          implementation("commons-io:commons-io:2.6"),
+        )
+      )
+      val plugins = Plugins(Plugin.application, Plugin.groovy)
+      val group = "com.group"
+      val version = "1.0"
+      val dependencies = Dependencies(Dependency("api", ":magic"))
+      val androidBlock = AndroidBlock(
+        namespace = "ankh.morpork"
+      )
+
+      val buildScript = BuildScript(
+        buildscript = buildscriptBlock,
+        plugins = plugins,
+        group = group,
+        version = version,
+        dependencies = dependencies,
+        android = androidBlock,
+        sourceSets = SourceSets.ofNames("corpos", "nomad", "streetKid"),
+        java = Java.ofFeatures(Feature.ofName("cyber"), Feature.ofName("punk")),
+        // TODO(tsr): withGroovy() and withKotlin()
+        // additions = """
+        //   ext.magic = "octarine"
+        //
+        // """.trimIndent()
+      )
+
+      // When
+      val text = buildScript.render(scribe)
+
+      // Then
+      assertThat(text).isEqualTo(
+        """
+          buildscript {
+            repositories {
+              maven { url = uri("") }
+              gradlePluginPortal()
+              mavenCentral()
+              google()
+            }
+            dependencies {
+              antlr("org.antlr:antlr4:4.8-1")
+              implementation("commons-io:commons-io:2.6")
+            }
+          }
+          
+          plugins {
+            id("application")
+            id("groovy")
+          }
+          
+          group = "$group"
+          version = "$version"
+          
+          android {
+            namespace "ankh.morpork"
+            compileSdkVersion = 34
+            defaultConfig {
+              applicationId "com.example"
+              minSdkVersion = 21
+              targetSdkVersion = 29
+              versionCode = 1
+              versionName = "1.0"
+            }
+            compileOptions {
+              sourceCompatibility = JavaVersion.VERSION_1_8
+              targetCompatibility = JavaVersion.VERSION_1_8
+            }
+          }
+          
+          sourceSets {
+            create("cyber")
+            create("punk")
+            create("corpos")
+            create("nomad")
+            create("streetKid")
+          }
+          
+          java {
+            registerFeature("cyber") {
+              usingSourceSet(sourceSets["cyber"])
+            }
+            registerFeature("punk") {
+              usingSourceSet(sourceSets["punk"])
+            }
+          }
+          
+          dependencies {
+            api(project(":magic"))
+          }
+
+        """.trimIndent()
+      )
+    }
+  }
+
+  @Nested inner class PluginsTest {
+    @Test fun `can render a plugin with a version`() {
+      // Given
+      val plugin = Plugin("magic", "1.0")
+
+      // Expect
+      assertThat(plugin.render(scribe)).isEqualTo("id(\"magic\") version \"1.0\"\n")
+    }
+
+    @Test fun `can render a plugin without a version`() {
+      // Given
+      val plugin = Plugin("magic")
+
+      // Expect
+      assertThat(plugin.render(scribe)).isEqualTo("id(\"magic\")\n")
+    }
+
+    @Test fun `can render a plugin with a version and apply false`() {
+      // Given
+      val plugin = Plugin("magic", "1.0", false)
+
+      // Expect
+      assertThat(plugin.render(scribe)).isEqualTo("id(\"magic\") version \"1.0\" apply false\n")
+    }
+
+    @Test fun `can render a plugin without a version and apply false`() {
+      // Given
+      val plugin = Plugin(id = "magic", apply = false)
+
+      // Expect
+      assertThat(plugin.render(scribe)).isEqualTo("id(\"magic\") apply false\n")
+    }
+
+    @Test fun `can render plugins block`() {
+      // Given
+      val plugins = Plugins(
+        Plugin("magic", "1.0"),
+        Plugin("meaning-of-life", "2.0"),
+      )
+
+      // Expect
+      assertThat(plugins.render(scribe)).isEqualTo(
+        """
+          plugins {
+            id("magic") version "1.0"
+            id("meaning-of-life") version "2.0"
+          }
+          
+        """.trimIndent()
+      )
+    }
+  }
+}


### PR DESCRIPTION
This isn't how I'd like the final implementation to look, but it unblocks Kotlin DSL usage and demonstrates concrete usages. We can try to push the implementation details into Scribe etc later.