### PR TITLE
Improve truth tasks

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/AssembleArchivesSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/AssembleArchivesSpec.groovy
@@ -16,7 +16,7 @@ final class AssembleArchivesSpec extends AbstractJvmSpec {
     def result = build(gradleVersion, gradleProject.rootDir, 'proj:assemble')
 
     then: 'only `assemble` ran'
-    assertThat(result).task(":proj:aggregateAdvice").isNull()
+    assertThat(result).doesNotHaveTask(":proj:aggregateAdvice")
     assertThat(result).tasks.containsExactlyPathsIn([
       ":proj:compileJava", ":proj:processResources", ":proj:classes", ":proj:jar", ":proj:assemble"
     ])

--- a/testkit/gradle-testkit-truth/src/main/kotlin/com/autonomousapps/kit/truth/BuildResultSubject.kt
+++ b/testkit/gradle-testkit-truth/src/main/kotlin/com/autonomousapps/kit/truth/BuildResultSubject.kt
@@ -9,6 +9,7 @@ import com.google.common.truth.StringSubject
 import com.google.common.truth.Subject
 import com.google.common.truth.Subject.Factory
 import com.google.common.truth.Truth.assertAbout
+import com.google.errorprone.annotations.CanIgnoreReturnValue
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 
@@ -37,11 +38,16 @@ public class BuildResultSubject private constructor(
     return check("getOutput()").that(actual!!.output)
   }
 
+  @CanIgnoreReturnValue
   public fun task(path: String): BuildTaskSubject {
     if (actual == null) {
       failWithActual(simpleFact("build result was null"))
     }
-    return check("task(%s)", path).about(buildTasks()).that(actual!!.task(path))
+    val tasks = actual!!.tasks.map { it.path }
+
+    check("getTasks()").that(tasks).contains(path)
+
+    return check("task(%s)", path).about(buildTasks()).that(actual.task(path))
   }
 
   public fun doesNotHaveTask(path: String) {

--- a/testkit/gradle-testkit-truth/src/main/kotlin/com/autonomousapps/kit/truth/BuildResultSubject.kt
+++ b/testkit/gradle-testkit-truth/src/main/kotlin/com/autonomousapps/kit/truth/BuildResultSubject.kt
@@ -44,6 +44,15 @@ public class BuildResultSubject private constructor(
     return check("task(%s)", path).about(buildTasks()).that(actual!!.task(path))
   }
 
+  public fun doesNotHaveTask(path: String) {
+    if (actual == null) {
+      failWithActual(simpleFact("build result was null"))
+    }
+    val tasks = actual!!.tasks.map { it.path }
+
+    check("getTasks()").that(tasks).doesNotContain(path)
+  }
+
   public fun getTasks(): BuildTaskListSubject {
     if (actual == null) {
       failWithActual(simpleFact("build result was null"))

--- a/testkit/gradle-testkit-truth/src/main/kotlin/com/autonomousapps/kit/truth/BuildResultSubject.kt
+++ b/testkit/gradle-testkit-truth/src/main/kotlin/com/autonomousapps/kit/truth/BuildResultSubject.kt
@@ -37,11 +37,11 @@ public class BuildResultSubject private constructor(
     return check("getOutput()").that(actual!!.output)
   }
 
-  public fun task(name: String): BuildTaskSubject {
+  public fun task(path: String): BuildTaskSubject {
     if (actual == null) {
       failWithActual(simpleFact("build result was null"))
     }
-    return check("task(%s)", name).about(buildTasks()).that(actual!!.task(name))
+    return check("task(%s)", path).about(buildTasks()).that(actual!!.task(path))
   }
 
   public fun getTasks(): BuildTaskListSubject {


### PR DESCRIPTION
Close #1068

This PR changes a bit the idea behind `BuildResultSubject.task`. It doesn't return a `BuildTaskSubject` with an `actual == null` anymore. Now BuildResultSubject.task fails if the task doesn't exist with a better error message.

Before:
```
Caused by: value of:
    buildResult.task(:proj:compileJava2)
expected to have a value:
    FAILED
but was:
    null
buildResult was:
    Calculating task graph as no cached configuration is available for tasks: proj:assemble
    > Task :proj:processResources NO-SOURCE
    > Task :proj:compileJava
    > Task :proj:classes
    > Task :proj:jar
    > Task :proj:assemble
    
    BUILD SUCCESSFUL in 2s
    2 actionable tasks: 2 executed
    Configuration cache entry stored.
```

After:
```
Caused by: value of:
    buildResult.getTasks()
expected to contain:
    :proj:compileJava2
but was:
    [:proj:compileJava, :proj:processResources, :proj:classes, :proj:jar, :proj:assemble]
buildResult was:
    Calculating task graph as no cached configuration is available for tasks: proj:assemble
    > Task :proj:processResources NO-SOURCE
    > Task :proj:compileJava
    > Task :proj:classes
    > Task :proj:jar
    > Task :proj:assemble
    
    BUILD SUCCESSFUL in 2s
    2 actionable tasks: 2 executed
    Configuration cache entry stored.
```

With only that change it would be impossible to check that a task does not exist. For that reason I added `hasNotTask`. I'm not very happy with the name, any suggestion is more than welcome.

And this function I think that also improves the error message:

Before:
```
Caused by: value of:
    buildResult.task(:proj:compileJava)
expected:
    null
but was:
    :proj:compileJava=SUCCESS
buildResult was:
    Calculating task graph as no cached configuration is available for tasks: proj:assemble
    > Task :proj:processResources NO-SOURCE
    > Task :proj:compileJava
    > Task :proj:classes
    > Task :proj:jar
    > Task :proj:assemble
    
    BUILD SUCCESSFUL in 2s
    2 actionable tasks: 2 executed
    Configuration cache entry stored.
```

After:
```
Caused by: value of:
    buildResult.getTasks()
expected not to contain:
    :proj:compileJava
but was:
    [:proj:processResources, :proj:compileJava, :proj:classes, :proj:jar, :proj:assemble]
buildResult was:
    Calculating task graph as no cached configuration is available for tasks: proj:assemble
    > Task :proj:processResources NO-SOURCE
    > Task :proj:compileJava
    > Task :proj:classes
    > Task :proj:jar
    > Task :proj:assemble
    
    BUILD SUCCESSFUL in 2s
    2 actionable tasks: 2 executed
    Configuration cache entry stored.
```