### PR TITLE
Use `assertThat` instead of `assertAbout`

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/android/ConfigurationCacheSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/ConfigurationCacheSpec.groovy
@@ -5,7 +5,6 @@ import com.autonomousapps.internal.android.AgpVersion
 import org.gradle.util.GradleVersion
 
 import static com.autonomousapps.advice.truth.BuildHealthSubject.buildHealth
-import static com.autonomousapps.kit.truth.BuildTaskSubject.buildTasks
 import static com.autonomousapps.kit.truth.TestKitTruth.assertThat
 import static com.autonomousapps.utils.Runner.build
 import static com.google.common.truth.Truth.assertAbout
@@ -30,7 +29,7 @@ final class ConfigurationCacheSpec extends AbstractAndroidSpec {
       .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
 
     and: 'generateBuildHealth succeeded'
-    assertAbout(buildTasks()).that(result.task(':generateBuildHealth')).succeeded()
+    assertThat(result).task(':generateBuildHealth').succeeded()
 
     when: 'We build again'
     result = build(
@@ -45,7 +44,7 @@ final class ConfigurationCacheSpec extends AbstractAndroidSpec {
       .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
 
     and: 'generateBuildHealth was up-to-date'
-    assertAbout(buildTasks()).that(result.task(':generateBuildHealth')).upToDate()
+    assertThat(result).task(':generateBuildHealth').upToDate()
 
     and: 'This plugin is compatible with the configuration cache'
     if (AgpVersion.version(agpVersion as String) > AgpVersion.version('8.0')) {

--- a/src/functionalTest/groovy/com/autonomousapps/android/ReasonSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/ReasonSpec.groovy
@@ -4,11 +4,9 @@ import com.autonomousapps.android.projects.AndroidTestDependenciesProject
 import com.autonomousapps.utils.Colors
 import org.gradle.testkit.runner.BuildResult
 
-import static com.autonomousapps.kit.truth.BuildTaskSubject.buildTasks
 import static com.autonomousapps.kit.truth.TestKitTruth.assertThat as assertThatResult
 import static com.autonomousapps.utils.Runner.build
 import static com.autonomousapps.utils.Runner.buildAndFail
-import static com.google.common.truth.Truth.assertAbout
 import static com.google.common.truth.Truth.assertThat
 
 @SuppressWarnings("GroovyAssignabilityCheck")
@@ -69,7 +67,7 @@ final class ReasonSpec extends AbstractAndroidSpec {
     )
 
     then:
-    assertAbout(buildTasks()).that(result.task(':proj:reason')).failed()
+    assertThatResult(result).task(':proj:reason').failed()
     assertThatResult(result).output()
       .contains("There is no dependency with coordinates ':life:the-universe:and-everything' in this project.")
 
@@ -90,7 +88,7 @@ final class ReasonSpec extends AbstractAndroidSpec {
     )
 
     then:
-    assertAbout(buildTasks()).that(result.task(':proj:reason')).succeeded()
+    assertThatResult(result).task(':proj:reason').succeeded()
     assertThat(Colors.decolorize(result.output))
       .contains(
         """\

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/FindDeclarationsSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/FindDeclarationsSpec.groovy
@@ -2,9 +2,8 @@ package com.autonomousapps.jvm
 
 import com.autonomousapps.jvm.projects.FindDeclarationsProject
 
-import static com.autonomousapps.kit.truth.BuildTaskSubject.buildTasks
+import static com.autonomousapps.kit.truth.TestKitTruth.assertThat
 import static com.autonomousapps.utils.Runner.build
-import static com.google.common.truth.Truth.assertAbout
 
 final class FindDeclarationsSpec extends AbstractJvmSpec {
 
@@ -18,14 +17,14 @@ final class FindDeclarationsSpec extends AbstractJvmSpec {
     def result = build(gradleVersion, gradleProject.rootDir, task)
 
     then: 'Task was successful'
-    assertAbout(buildTasks()).that(result.task(task)).succeeded()
+    assertThat(result).task(task).succeeded()
 
     when: 'We mutate the build script and build again'
     project.mutateBuildScript()
     result = build(gradleVersion, gradleProject.rootDir, task)
 
     then: 'Task was not up to date'
-    assertAbout(buildTasks()).that(result.task(task)).succeeded()
+    assertThat(result).task(task).succeeded()
 
     where:
     gradleVersion << gradleVersions()

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/GraphViewCacheSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/GraphViewCacheSpec.groovy
@@ -3,9 +3,8 @@ package com.autonomousapps.jvm
 import com.autonomousapps.jvm.projects.GraphViewCacheProject
 import org.gradle.util.GradleVersion
 
-import static com.autonomousapps.kit.truth.BuildTaskSubject.buildTasks
+import static com.autonomousapps.kit.truth.TestKitTruth.assertThat
 import static com.autonomousapps.utils.Runner.build
-import static com.google.common.truth.Truth.assertAbout
 
 final class GraphViewCacheSpec extends AbstractJvmSpec {
 
@@ -20,12 +19,12 @@ final class GraphViewCacheSpec extends AbstractJvmSpec {
     def result = build(gradleVersion, gradleProject.rootDir, task, '--build-cache', '-Dv=0.3.0-alpha27')
 
     then: 'Task executed'
-    assertAbout(buildTasks()).that(result.task(task)).succeeded()
+    assertThat(result).task(task).succeeded()
 
     when: 'Second build'
     result = build(gradleVersion, gradleProject.rootDir, 'clean', task, '--build-cache', '-Dv=0.3.0-alpha28')
 
     then: 'Task executed (not FROM_CACHE)'
-    assertAbout(buildTasks()).that(result.task(task)).succeeded()
+    assertThat(result).task(task).succeeded()
   }
 }

--- a/testkit/gradle-testkit-plugin/src/functionalTest/kotlin/com/autonomousapps/PluginTest.kt
+++ b/testkit/gradle-testkit-plugin/src/functionalTest/kotlin/com/autonomousapps/PluginTest.kt
@@ -7,10 +7,7 @@ import com.autonomousapps.kit.Source
 import com.autonomousapps.kit.gradle.*
 import com.autonomousapps.kit.gradle.Dependency.Companion.classpath
 import com.autonomousapps.kit.gradle.Dependency.Companion.project
-import com.autonomousapps.kit.truth.BuildResultSubject.Companion.buildResults
-import com.autonomousapps.kit.truth.BuildTaskListSubject.Companion.buildTaskList
-import com.autonomousapps.kit.truth.BuildTaskSubject.Companion.buildTasks
-import com.google.common.truth.Truth.assertAbout
+import com.autonomousapps.kit.truth.TestKitTruth.Companion.assertThat
 import org.gradle.util.GradleVersion
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -43,55 +40,54 @@ internal class PluginTest {
     // Then the installation tasks ran in order, followed by the test task
     // We do the checks in separate pieces to account for some allowable non-deterministic ordering
     // :build-logic:lib before :plugin
-    assertAbout(buildTaskList()).that(result.tasks).containsAtLeastPathsIn(
+    assertThat(result).getTasks().containsAtLeastPathsIn(
       ":build-logic:lib:publishAllPublicationsToFunctionalTestRepository",
       ":build-logic:lib:installForFunctionalTest",
       ":plugin:installForFunctionalTest",
       ":plugin:functionalTest",
     ).inOrder()
     // :lib before :plugin
-    assertAbout(buildTaskList()).that(result.tasks).containsAtLeastPathsIn(
+    assertThat(result).getTasks().containsAtLeastPathsIn(
       ":lib:publishAllPublicationsToFunctionalTestRepository",
       ":lib:installForFunctionalTest",
       ":plugin:installForFunctionalTest",
       ":plugin:functionalTest",
     ).inOrder()
     // all :plugin tasks in order
-    assertAbout(buildTaskList()).that(result.tasks).containsAtLeastPathsIn(
+    assertThat(result).getTasks().containsAtLeastPathsIn(
       ":plugin:publishAllPublicationsToFunctionalTestRepository",
       ":plugin:installForFunctionalTest",
       ":plugin:functionalTest",
     ).inOrder()
 
-    assertAbout(buildTasks())
-      .that(result.task(":build-logic:lib:publishAllPublicationsToFunctionalTestRepository"))
+    assertThat(result)
+      .task(":build-logic:lib:publishAllPublicationsToFunctionalTestRepository")
       .succeeded()
-    assertAbout(buildTasks())
-      .that(result.task(":build-logic:lib:installForFunctionalTest"))
+    assertThat(result)
+      .task(":build-logic:lib:installForFunctionalTest")
       .succeeded()
 
     // and the main build installation tasks were successful
-    assertAbout(buildTasks())
-      .that(result.task(":lib:publishAllPublicationsToFunctionalTestRepository"))
+    assertThat(result)
+      .task(":lib:publishAllPublicationsToFunctionalTestRepository")
       .succeeded()
-    assertAbout(buildTasks())
-      .that(result.task(":lib:installForFunctionalTest"))
+    assertThat(result)
+      .task(":lib:installForFunctionalTest")
       .succeeded()
-    assertAbout(buildTasks())
-      .that(result.task(":plugin:publishAllPublicationsToFunctionalTestRepository"))
+    assertThat(result)
+      .task(":plugin:publishAllPublicationsToFunctionalTestRepository")
       .succeeded()
-    assertAbout(buildTasks())
-      .that(result.task(":plugin:installForFunctionalTest"))
+    assertThat(result)
+      .task(":plugin:installForFunctionalTest")
       .succeeded()
 
     // and the test task succeeded
-    assertAbout(buildTasks())
-      .that(result.task(":plugin:functionalTest"))
+    assertThat(result)
+      .task(":plugin:functionalTest")
       .succeeded()
 
     // And there was no warning about multiple publications overwriting each other
-    assertAbout(buildResults())
-      .that(result).output()
+    assertThat(result).output()
       // For example:
       // Multiple publications with coordinates 'the-project:plugin:unspecified' are published to repository 'FunctionalTest'. The publications 'pluginMaven' in project ':plugin' and 'testKitSupportForJava' in project ':plugin' will overwrite each other!
       .doesNotContainMatch("Multiple publications with coordinates.+will overwrite each other!")


### PR DESCRIPTION
There are a lot more places where `assertAbout` is used but groovy doesn't allow to import multiple functions with the same name. I didn't change those because probable `assertThat` is better than alias imports. Other option it to don't import `Truth.assertThat` and in the places where `Truth` is used call them like `Truth.assertThat(...)`.

Anyway, these changes are the easier ones and it should make the code easier to read and provide better error messages.