### PR TITLE
feat: migrate to new, non-deprecated AGP APIs. Min AGP version now 8.0.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,8 +10,11 @@ moshix = "0.19.0"
 okio = "2.10.0"
 retrofit = "2.9.0"
 
-agp = "7.4.2"
-agp-common = "30.4.2"
+agp = "8.0.2"
+#agp = "8.1.4
+#agp = "8.2.1"
+#agp = "8.3.0-beta01" # Provides `Sources.manifests`
+agp-common = "31.2.0"
 
 [libraries]
 agp = { module = "com.android.tools.build:gradle", version.ref = "agp" }

--- a/src/functionalTest/groovy/com/autonomousapps/AbstractProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/AbstractProject.groovy
@@ -7,17 +7,26 @@ import com.autonomousapps.kit.GradleProject
 import com.autonomousapps.kit.gradle.BuildscriptBlock
 import com.autonomousapps.kit.gradle.GradleProperties
 import com.autonomousapps.kit.gradle.dependencies.Plugins
+import com.autonomousapps.utils.DebugAware
 
 @SuppressWarnings('GrMethodMayBeStatic')
 abstract class AbstractProject extends AbstractGradleProject {
 
-  protected static final PRINT_ADVICE = "dependency.analysis.print.build.health=true"
+  protected static final String PRINT_ADVICE = "dependency.analysis.print.build.health=true"
 
   @Override
-  protected GradleProject.Builder newGradleProjectBuilder(GradleProject.DslKind dslKind = GradleProject.DslKind.GROOVY) {
+  protected GradleProject.Builder newGradleProjectBuilder(
+    GradleProject.DslKind dslKind = GradleProject.DslKind.GROOVY
+  ) {
+    def additionalProperties = GradleProperties.of(PRINT_ADVICE)
+    // There is a Gradle bug that makes tests break when the test uses CC and we're also debugging
+    if (!DebugAware.debug) {
+      additionalProperties += GradleProperties.enableConfigurationCache()
+    }
+
     return super.newGradleProjectBuilder(dslKind)
       .withRootProject { r ->
-        r.gradleProperties += GradleProperties.enableConfigurationCache() + PRINT_ADVICE
+        r.gradleProperties += additionalProperties
         r.withBuildScript { bs ->
           bs.plugins(Plugins.dependencyAnalysis, Plugins.kotlinNoApply)
         }

--- a/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
@@ -7,30 +7,36 @@ import com.autonomousapps.fixtures.ProjectDirProvider
 import com.autonomousapps.internal.android.AgpVersion
 import org.gradle.util.GradleVersion
 
+/**
+ * @see <a href="https://maven.google.com/web/m_index.html?q=com.android.tools.build#com.android.tools.build:gradle">AGP artifacts</a>
+ */
 abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
 
   protected ProjectDirProvider androidProject = null
 
-  protected static final AGP_7_3 = AgpVersion.version('7.3.1')
-  protected static final AGP_7_4 = AgpVersion.version('7.4.2')
   protected static final AGP_8_0 = AgpVersion.version('8.0.2')
-  protected static final AGP_8_1 = AgpVersion.version('8.1.0')
-  protected static final AGP_8_2 = AgpVersion.version('8.2.0-alpha16')
+  protected static final AGP_8_1 = AgpVersion.version('8.1.4')
+  protected static final AGP_8_2 = AgpVersion.version('8.2.0')
+  protected static final AGP_8_3 = AgpVersion.version('8.3.0-beta01')
+  protected static final AGP_8_4 = AgpVersion.version('8.4.0-alpha01')
 
-  protected static final AGP_LATEST = AGP_8_2
+  protected static final AGP_LATEST = AGP_8_4
 
   /**
-   * {@code AGP_7_4} represents the minimum stable _tested_ version. {@code AGP_8_1} represents the maximum stable
+   * TODO(tsr): this doc is perpetually out of date.
+   *
+   * {@code AGP_8_0} represents the minimum stable _tested_ version. {@code AGP_8_1} represents the maximum stable
    * _tested_ version. We also test against the latest alpha, {@code AGP_8_2} at time of writing. DAGP may work with
    * other versions of AGP, but they aren't tested, primarily for CI performance reasons.
    *
    * @see <a href="https://maven.google.com/web/index.html?q=build#com.android.tools.build:gradle">AGP releases</a>
    */
   protected static final SUPPORTED_AGP_VERSIONS = [
-    AGP_7_4,
-//    AGP_8_0,
+    AGP_8_0,
     AGP_8_1,
     AGP_8_2,
+    AGP_8_3,
+    AGP_8_4,
   ]
 
   protected static List<AgpVersion> agpVersions(AgpVersion minAgpVersion = AgpVersion.AGP_MIN) {

--- a/src/functionalTest/groovy/com/autonomousapps/android/DuplicateDependencyVersionsSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/DuplicateDependencyVersionsSpec.groovy
@@ -46,6 +46,6 @@ final class DuplicateDependencyVersionsSpec extends AbstractAndroidSpec {
       .contains(project.expectedOutput)
 
     where:
-    [gradleVersion, agpVersion] << multivariableDataPipe([GRADLE_7_5], [AGP_7_3.version])
+    [gradleVersion, agpVersion] << multivariableDataPipe([GRADLE_8_0], [AGP_8_0.version])
   }
 }

--- a/src/functionalTest/groovy/com/autonomousapps/android/IgnoredVariantSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/IgnoredVariantSpec.groovy
@@ -13,7 +13,7 @@ import static com.google.common.truth.Truth.assertAbout
 @SuppressWarnings("GroovyAssignabilityCheck")
 final class IgnoredVariantSpec extends AbstractAndroidSpec {
 
-  def "plugin ignore android variants (#gradleVersion AGP #agpVersion ignored debug)"() {
+  def "can ignore debug variant (#gradleVersion AGP #agpVersion)"() {
     given:
     def project = new DebugVariantIgnoredProject(agpVersion)
     gradleProject = project.gradleProject
@@ -30,7 +30,7 @@ final class IgnoredVariantSpec extends AbstractAndroidSpec {
     [gradleVersion, agpVersion] << gradleAgpMatrix()
   }
 
-  def "plugin ignore android variants (#gradleVersion AGP #agpVersion ignored release)"() {
+  def "can ignore release variant (#gradleVersion AGP #agpVersion)"() {
     given:
     def project = new ReleaseVariantIgnoredProject(agpVersion)
     gradleProject = project.gradleProject
@@ -47,7 +47,7 @@ final class IgnoredVariantSpec extends AbstractAndroidSpec {
     [gradleVersion, agpVersion] << gradleAgpMatrix()
   }
 
-  def "plugin ignore android variants (#gradleVersion AGP #agpVersion ignored all variants)"() {
+  def "can ignore all (debug and release) variants (#gradleVersion AGP #agpVersion)"() {
     given:
     def project = new AllVariantsIgnoredProject(agpVersion)
     gradleProject = project.gradleProject

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AbstractVariantProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AbstractVariantProject.groovy
@@ -15,6 +15,7 @@ import com.autonomousapps.kit.gradle.GradleProperties
 import com.autonomousapps.kit.gradle.Plugin
 import com.autonomousapps.kit.gradle.dependencies.Plugins
 import com.autonomousapps.model.ProjectAdvice
+import com.autonomousapps.utils.DebugAware
 
 import static com.autonomousapps.AdviceHelper.actualProjectAdvice
 import static com.autonomousapps.kit.gradle.dependencies.Dependencies.*
@@ -37,9 +38,15 @@ abstract class AbstractVariantProject extends AbstractAndroidProject {
   }
 
   private GradleProject build() {
+    def properties = projectGradleProperties
+    if (!DebugAware.debug) {
+      // There is a Gradle bug that makes tests break when the test uses CC and we're also debugging
+      properties += GradleProperties.enableConfigurationCache()
+    }
+
     return newAndroidGradleProjectBuilder(agpVersion)
       .withRootProject { root ->
-        root.gradleProperties = projectGradleProperties + GradleProperties.enableConfigurationCache()
+        root.gradleProperties = properties
       }
       .withAndroidSubproject('app') { a ->
         a.sources = sources

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/DataBindingUsagesExclusionsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/DataBindingUsagesExclusionsProject.groovy
@@ -14,7 +14,6 @@ import com.autonomousapps.model.ProjectAdvice
 import static com.autonomousapps.AdviceHelper.*
 import static com.autonomousapps.kit.gradle.Dependency.project
 import static com.autonomousapps.kit.gradle.dependencies.Dependencies.appcompat
-import static com.autonomousapps.kit.gradle.dependencies.Dependencies.kotlinStdLib
 
 final class DataBindingUsagesExclusionsProject extends AbstractAndroidProject {
 
@@ -59,7 +58,6 @@ final class DataBindingUsagesExclusionsProject extends AbstractAndroidProject {
         lib.withBuildScript { bs ->
           bs.plugins = [Plugins.androidLib, Plugins.kotlinAndroid, Plugins.kapt]
           bs.android = defaultAndroidLibBlock(true, 'com.example.lib')
-          bs.dependencies = libDependencies
           bs.withGroovy("android.buildFeatures.dataBinding true")
         }
         lib.sources = libSources
@@ -93,9 +91,8 @@ final class DataBindingUsagesExclusionsProject extends AbstractAndroidProject {
   ]
 
   private List<Dependency> appDependencies = [
-    kotlinStdLib("implementation"),
-    appcompat("implementation"),
-    project("implementation", ":lib"),
+    appcompat('implementation'),
+    project('implementation', ':lib'),
   ]
 
   private libSources = [
@@ -112,10 +109,6 @@ final class DataBindingUsagesExclusionsProject extends AbstractAndroidProject {
           view.text = text
         }""".stripIndent()
     )
-  ]
-
-  private List<Dependency> libDependencies = [
-    kotlinStdLib('api')
   ]
 
   private final Set<ProjectAdvice> expectedBuildHealthWithExclusions = [

--- a/src/main/kotlin/com/autonomousapps/Flags.kt
+++ b/src/main/kotlin/com/autonomousapps/Flags.kt
@@ -4,9 +4,9 @@
 
 package com.autonomousapps
 
-import java.util.Locale
 import org.gradle.api.GradleException
 import org.gradle.api.Project
+import java.util.Locale
 
 object Flags {
 
@@ -18,10 +18,14 @@ object Flags {
   private const val FLAG_TEST_ANALYSIS = "dependency.analysis.test.analysis"
   private const val FLAG_PRINT_BUILD_HEALTH = "dependency.analysis.print.build.health"
   private const val FLAG_PROJECT_INCLUDES = "dependency.analysis.project.includes"
+
   /**
    * Android build variant to not analyze i.e.
    *
+   * ```
+   * # gradle.properties
    * dependency.analysis.android.ignored.variants=release
+   * ```
    */
   private const val FLAG_ANDROID_IGNORED_VARIANTS = "dependency.analysis.android.ignored.variants"
 
@@ -30,7 +34,9 @@ object Flags {
   internal fun Project.shouldAnalyzeTests() = getGradleOrSysProp(FLAG_TEST_ANALYSIS, true)
   internal fun Project.shouldAutoApply() = getGradleOrSysProp(FLAG_AUTO_APPLY, true)
   internal fun Project.printBuildHealth() = getGradlePropForConfiguration(FLAG_PRINT_BUILD_HEALTH, false)
-  internal fun Project.androidIgnoredVariants() = getGradlePropForConfiguration(FLAG_ANDROID_IGNORED_VARIANTS, "").split(",")
+  internal fun Project.androidIgnoredVariants() = getGradlePropForConfiguration(
+    FLAG_ANDROID_IGNORED_VARIANTS, ""
+  ).split(",")
 
   internal fun Project.projectPathRegex(): Regex =
     getGradlePropForConfiguration(FLAG_PROJECT_INCLUDES, ".*").toRegex()
@@ -50,7 +56,9 @@ object Flags {
   internal fun Project.compatibility(): Compatibility {
     return getGradlePropForConfiguration(FLAG_DISABLE_COMPATIBILITY, Compatibility.WARN.name).let {
       @Suppress("DEPRECATION") val value = it.toUpperCase(Locale.US)
-      Compatibility.values().find { it.name == value } ?: error("Unrecognized value '$it' for 'dependency.analysis.compatibility' property. Allowed values are ${Compatibility.values()}")
+      Compatibility.values().find { it.name == value } ?: error(
+        "Unrecognized value '$it' for 'dependency.analysis.compatibility' property. Allowed values are ${Compatibility.values()}"
+      )
     }
   }
 
@@ -61,8 +69,7 @@ object Flags {
   }
 
   private fun Project.getGradlePropForConfiguration(name: String, default: String): String =
-    providers.gradleProperty(name)
-      .getOrElse(default)
+    providers.gradleProperty(name).getOrElse(default)
 
   private fun Project.getGradlePropForConfiguration(name: String, default: Boolean): Boolean =
     getGradlePropForConfiguration(name, default.toString()).toBoolean()
@@ -73,6 +80,9 @@ object Flags {
       .toBoolean()
 
   internal enum class Compatibility {
-    NONE, DEBUG, WARN, ERROR
+    NONE,
+    DEBUG,
+    WARN,
+    ERROR
   }
 }

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidSources.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidSources.kt
@@ -1,0 +1,96 @@
+// Copyright (c) 2024. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.internal.analyzer
+
+import com.android.build.api.artifact.SingleArtifact
+import com.android.build.api.variant.Sources
+import com.autonomousapps.model.declaration.Variant
+import org.gradle.api.Project
+import org.gradle.api.provider.Provider
+import java.io.File
+
+/**
+ * All the relevant sources for a given Android variant, including Java, Kotlin, assets, res, manifest files, and
+ * layouts.
+ */
+internal interface AndroidSources {
+  val variant: Variant
+
+  /** E.g., `debugCompileClasspath` or `debugUnitTestCompileClasspath` */
+  val compileClasspathConfigurationName: String
+
+  /** E.g., `debugRuntimeClasspath` or `debugUnitTestRuntimeClasspath` */
+  val runtimeClasspathConfigurationName: String
+
+  fun getJavaSources(): Provider<Iterable<File>>
+  fun getKotlinSources(): Provider<Iterable<File>>
+  fun getAndroidAssets(): Provider<Iterable<File>>
+  fun getAndroidRes(): Provider<Iterable<File>>
+  fun getManifestFiles(): Provider<Iterable<File>>
+  fun getLayoutFiles(): Provider<Iterable<File>>
+}
+
+@Suppress("UnstableApiUsage")
+internal class DefaultAndroidSources(
+  private val project: Project,
+  private val agpVariant: com.android.build.api.variant.Variant,
+  private val sources: Sources,
+  override val variant: Variant,
+  override val compileClasspathConfigurationName: String,
+  override val runtimeClasspathConfigurationName: String,
+) : AndroidSources {
+
+  override fun getJavaSources(): Provider<Iterable<File>> {
+    return sources.kotlin?.all
+      ?.map { directories ->
+        directories.map { directory -> directory.asFileTree.matching(Language.filterOf(Language.JAVA)) }
+      }?.map { trees -> trees.flatten() }
+      ?: project.provider { emptyList() }
+  }
+
+  override fun getKotlinSources(): Provider<Iterable<File>> {
+    return sources.kotlin?.all
+      ?.map { directories ->
+        directories.map { directory -> directory.asFileTree.matching(Language.filterOf(Language.KOTLIN)) }
+      }?.map { trees -> trees.flatten() }
+      ?: project.provider { emptyList() }
+  }
+
+  override fun getAndroidAssets(): Provider<Iterable<File>> {
+    return sources.assets?.all
+      ?.map { layers -> layers.flatten() }
+      ?.map { directories -> directories.map { directory -> directory.asFileTree } }
+      ?.map { trees -> trees.flatten() }
+      ?: project.provider { emptyList() }
+  }
+
+  override fun getAndroidRes(): Provider<Iterable<File>> {
+    return sources.res?.all
+      ?.map { layers -> layers.flatten() }
+      ?.map { directories ->
+        directories.map { directory -> directory.asFileTree.matching(Language.filterOf(Language.XML)) }
+      }
+      ?.map { trees -> trees.flatten() }
+      ?: project.provider { emptyList() }
+  }
+
+  override fun getLayoutFiles(): Provider<Iterable<File>> {
+    return sources.res?.all
+      ?.map { layers -> layers.flatten() }
+      ?.map { directories -> directories.map { directory -> directory.asFileTree } }
+      ?.map { fileTrees ->
+        fileTrees.map { fileTree ->
+          fileTree.matching {
+            include("**/layout/**/*.xml")
+          }
+        }.flatten()
+      }
+      ?: project.provider { emptyList() }
+  }
+
+  override fun getManifestFiles(): Provider<Iterable<File>> {
+    return agpVariant.artifacts.get(SingleArtifact.MERGED_MANIFEST).map {
+      listOf(it.asFile)
+    }
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidVariant.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidVariant.kt
@@ -1,0 +1,39 @@
+// Copyright (c) 2024. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.internal.analyzer
+
+import com.android.build.api.variant.HasAndroidTest
+import com.android.build.api.variant.Variant
+import org.gradle.api.Project
+import org.gradle.api.provider.Provider
+
+internal interface AndroidVariant {
+  val flavorName: String
+  val variantName: String
+  val buildType: String
+  val testInstrumentationRunner: Provider<String?>
+}
+
+internal class DefaultAndroidVariant(
+  override val flavorName: String,
+  override val variantName: String,
+  override val buildType: String,
+  override val testInstrumentationRunner: Provider<String?>,
+) : AndroidVariant {
+  constructor(project: Project, variant: Variant) : this(
+    flavorName = variant.flavorName.orEmpty(),
+    variantName = variant.name,
+    buildType = variant.buildType.orEmpty(),
+    testInstrumentationRunner = getTestInstrumentationRunner(project, variant),
+  )
+
+  private companion object {
+    fun getTestInstrumentationRunner(project: Project, variant: Variant): Provider<String?> {
+      return if (variant is HasAndroidTest) {
+        variant.androidTest?.instrumentationRunner ?: project.provider { null }
+      } else {
+        project.provider { null }
+      }
+    }
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/DependencyAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/DependencyAnalyzer.kt
@@ -6,20 +6,18 @@ package com.autonomousapps.internal.analyzer
 
 import com.autonomousapps.internal.OutputPaths
 import com.autonomousapps.model.declaration.SourceSetKind
-import com.autonomousapps.services.InMemoryCache
 import com.autonomousapps.tasks.*
 import org.gradle.api.Project
 import org.gradle.api.UnknownDomainObjectException
 import org.gradle.api.UnknownTaskException
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.file.FileCollection
-import org.gradle.api.file.FileTree
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.named
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import java.io.File
 
 /** Abstraction for differentiating between android-app, android-lib, and java-lib projects.  */
 internal interface DependencyAnalyzer {
@@ -53,17 +51,18 @@ internal interface DependencyAnalyzer {
   val annotationProcessorConfigurationName: String
 
   /** E.g., "androidx.test.runner.AndroidJUnitRunner" */
-  val testInstrumentationRunner: String?
+  val testInstrumentationRunner: Provider<String?>
 
   val attributeValueJar: String
 
-  val kotlinSourceFiles: FileCollection
-  val javaSourceFiles: FileCollection?
-  val groovySourceFiles: FileCollection
-  val scalaSourceFiles: FileCollection
+  /** Kotlin projects have no Java source */
+  val javaSourceFiles: Provider<Iterable<File>>?
+  val kotlinSourceFiles: Provider<Iterable<File>>
+  val groovySourceFiles: Provider<Iterable<File>>
+  val scalaSourceFiles: Provider<Iterable<File>>
 
-  val isDataBindingEnabled: Boolean
-  val isViewBindingEnabled: Boolean
+  val isDataBindingEnabled: Provider<Boolean>
+  val isViewBindingEnabled: Provider<Boolean>
 
   val testJavaCompileName: String
   val testKotlinCompileName: String
@@ -94,16 +93,16 @@ internal interface DependencyAnalyzer {
 
   fun registerAndroidScoreTask(
     synthesizeDependenciesTask: TaskProvider<SynthesizeDependenciesTask>,
-    synthesizeProjectViewTask: TaskProvider<SynthesizeProjectViewTask>
+    synthesizeProjectViewTask: TaskProvider<SynthesizeProjectViewTask>,
   ): TaskProvider<AndroidScoreTask>? = null
 }
 
 internal abstract class AbstractDependencyAnalyzer(
-  protected val project: Project
+  protected val project: Project,
 ) : DependencyAnalyzer {
 
   // Always null for JVM projects. May be null for Android projects.
-  override val testInstrumentationRunner: String? = null
+  override val testInstrumentationRunner: Provider<String?> = project.provider { null }
 
   protected val testJavaCompile by lazy {
     try {

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmProjectAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmProjectAnalyzer.kt
@@ -18,6 +18,7 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.register
+import java.io.File
 
 internal abstract class JvmAnalyzer(
   project: Project,
@@ -39,13 +40,13 @@ internal abstract class JvmAnalyzer(
 
   final override val attributeValueJar = "jar"
 
-  final override val kotlinSourceFiles: FileCollection = getKotlinSources()
-  override val javaSourceFiles: FileCollection? = getJavaSources()
-  final override val groovySourceFiles: FileCollection = getGroovySources()
-  final override val scalaSourceFiles: FileCollection = getScalaSources()
+  final override val kotlinSourceFiles: Provider<Iterable<File>> = getKotlinSources()
+  override val javaSourceFiles: Provider<Iterable<File>>? = getJavaSources()
+  final override val groovySourceFiles: Provider<Iterable<File>> = getGroovySources()
+  final override val scalaSourceFiles: Provider<Iterable<File>> = getScalaSources()
 
-  final override val isDataBindingEnabled: Boolean = false
-  final override val isViewBindingEnabled: Boolean = false
+  final override val isDataBindingEnabled: Provider<Boolean> = project.provider { false }
+  final override val isViewBindingEnabled: Provider<Boolean> = project.provider { false }
 
   override val outputPaths = OutputPaths(project, variantName)
 
@@ -92,10 +93,19 @@ internal abstract class JvmAnalyzer(
     }
   }
 
-  private fun getGroovySources(): FileCollection = getSourceDirectories().matching(Language.filterOf(Language.GROOVY))
-  private fun getJavaSources(): FileCollection = getSourceDirectories().matching(Language.filterOf(Language.JAVA))
-  private fun getKotlinSources(): FileCollection = getSourceDirectories().matching(Language.filterOf(Language.KOTLIN))
-  private fun getScalaSources(): FileCollection = getSourceDirectories().matching(Language.filterOf(Language.SCALA))
+  private fun getGroovySources(): Provider<Iterable<File>> {
+    return project.provider { getSourceDirectories().matching(Language.filterOf(Language.GROOVY)) }
+  }
+  private fun getJavaSources(): Provider<Iterable<File>> {
+    return project.provider { getSourceDirectories().matching(Language.filterOf(Language.JAVA)) }
+  }
+  private fun getKotlinSources(): Provider<Iterable<File>> {
+    return project.provider { getSourceDirectories().matching(Language.filterOf(Language.KOTLIN)) }
+  }
+
+  private fun getScalaSources(): Provider<Iterable<File>> {
+    return project.provider { getSourceDirectories().matching(Language.filterOf(Language.SCALA)) }
+  }
 
   private fun getSourceDirectories(): FileTree {
     val allSource = sourceSet.sourceCode.sourceDirectories
@@ -134,7 +144,7 @@ internal abstract class KotlinJvmAnalyzer(
   sourceSet = KotlinSourceSet(sourceSet, kind),
   hasAbi = hasAbi
 ) {
-  final override val javaSourceFiles: FileTree? = null
+  final override val javaSourceFiles = null
 }
 
 internal class KotlinJvmAppAnalyzer(

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmSourceSet.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmSourceSet.kt
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.internal.analyzer
 
-import com.android.builder.model.SourceProvider
 import com.autonomousapps.model.declaration.SourceSetKind
-import com.autonomousapps.model.declaration.Variant
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.SourceDirectorySet
@@ -62,30 +60,17 @@ internal class KotlinSourceSet(
   override val classesDirs: FileCollection = sourceSet.output.classesDirs
 }
 
-/** All the relevant Java and Kotlin source sets for a given Android variant. */
-internal class VariantSourceSet(
-  val variant: Variant,
-  val androidSourceSets: Set<SourceProvider> = emptySet(),
-  /** E.g., `debugCompileClasspath` or `debugUnitTestCompileClasspath` */
-  val compileClasspathConfigurationName: String,
-  /** E.g., `debugRuntimeClasspath` or `debugUnitTestRuntimeClasspath` */
-  val runtimeClasspathConfigurationName: String,
-)
-
 internal fun SourceSet.java(): FileTree {
-  return java.sourceDirectories.asFileTree.matching {
-    include("**/*.java")
-  }
+  return java.sourceDirectories.asFileTree.matching(Language.filterOf(Language.JAVA))
 }
 
 internal fun JbKotlinSourceSet.kotlin(): FileTree {
-  return kotlin.sourceDirectories.asFileTree.matching {
-    include("**/*.kt")
-  }
+  return kotlin.sourceDirectories.asFileTree.matching(Language.filterOf(Language.KOTLIN))
 }
 
 internal fun SourceSet.groovy(): FileTree? {
-  return extensions.findByType<GroovySourceDirectorySet>()?.sourceDirectories?.asFileTree?.matching {
-    include("**/*.groovy")
-  }
+  return extensions.findByType<GroovySourceDirectorySet>()
+    ?.sourceDirectories
+    ?.asFileTree
+    ?.matching(Language.filterOf(Language.GROOVY))
 }

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/Language.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/Language.kt
@@ -10,6 +10,7 @@ internal enum class Language(val pattern: String) {
   JAVA("**/*.java"),
   KOTLIN("**/*.kt"),
   SCALA("**/*.scala"),
+  XML("**/*.xml"),
   ;
 
   companion object {

--- a/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
@@ -5,14 +5,17 @@ package com.autonomousapps.internal.android
 import com.android.Version
 import com.autonomousapps.internal.utils.VersionNumber
 
+/**
+ * @see <a href="https://maven.google.com/web/m_index.html?q=com.android.tools.build#com.android.tools.build:gradle">AGP artifacts</a>
+ */
 internal class AgpVersion private constructor(val version: String) : Comparable<AgpVersion> {
 
   private val versionNumber = VersionNumber.parse(version)
 
   companion object {
 
-    @JvmStatic val AGP_MIN = version("7.4.2")
-    @JvmStatic val AGP_MAX = version("8.2.0-alpha16")
+    @JvmStatic val AGP_MIN = version("8.0.0")
+    @JvmStatic val AGP_MAX = version("8.4.0-alpha01")
 
     @JvmStatic fun current(): AgpVersion = AgpVersion(agpVersion())
     @JvmStatic fun version(version: String): AgpVersion = AgpVersion(version)

--- a/src/main/kotlin/com/autonomousapps/internal/android/AndroidGradlePlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/android/AndroidGradlePlugin.kt
@@ -7,8 +7,8 @@ import org.gradle.api.provider.Provider
 
 internal interface AndroidGradlePlugin {
   fun getBundleTaskOutput(variantName: String): Provider<RegularFile>
-  fun isViewBindingEnabled(): Boolean
-  fun isDataBindingEnabled(): Boolean
+  fun isViewBindingEnabled(): Provider<Boolean>
+  fun isDataBindingEnabled(): Provider<Boolean>
 
   /**
    * The package name or "namespace" of this Android module.

--- a/src/main/kotlin/com/autonomousapps/internal/android/AndroidGradlePlugin4_2.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/android/AndroidGradlePlugin4_2.kt
@@ -5,17 +5,14 @@
 package com.autonomousapps.internal.android
 
 import com.android.build.api.dsl.CommonExtension
-import com.android.build.gradle.BaseExtension
 import org.gradle.api.Project
 import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Provider
-import org.gradle.kotlin.dsl.the
-import org.gradle.kotlin.dsl.withGroovyBuilder
 
 internal class AndroidGradlePlugin4_2(
   project: Project,
-  agpVersion: String
+  agpVersion: String,
 ) : BaseAndroidGradlePlugin(project, agpVersion) {
 
   override val bundleTaskType: String = "com.android.build.gradle.internal.tasks.BundleLibraryClassesJar"
@@ -32,14 +29,12 @@ internal class AndroidGradlePlugin4_2(
     }
   }
 
-  override fun isViewBindingEnabled(): Boolean = project.the<BaseExtension>().withGroovyBuilder {
-    getProperty("buildFeatures").withGroovyBuilder { getProperty("viewBinding") } as Boolean?
-      ?: false
+  override fun isViewBindingEnabled(): Provider<Boolean> {
+    return project.provider { project.extensions.getByType(CommonExtension::class.java).viewBinding.enable }
   }
 
-  override fun isDataBindingEnabled(): Boolean = project.the<BaseExtension>().withGroovyBuilder {
-    getProperty("buildFeatures").withGroovyBuilder { getProperty("dataBinding") } as Boolean?
-      ?: false
+  override fun isDataBindingEnabled(): Provider<Boolean> {
+    return project.provider { project.extensions.getByType(CommonExtension::class.java).dataBinding.enable }
   }
 
   override fun namespace(): Provider<String> {

--- a/src/main/kotlin/com/autonomousapps/model/ModuleAdvice.kt
+++ b/src/main/kotlin/com/autonomousapps/model/ModuleAdvice.kt
@@ -74,7 +74,7 @@ data class AndroidScore(
       var hasAndroidDependencies = false
 
       scores.forEach {
-        hasAndroidAssets = hasAndroidDependencies || it.hasAndroidAssets
+        hasAndroidAssets = hasAndroidAssets || it.hasAndroidAssets
         hasAndroidRes = hasAndroidRes || it.hasAndroidRes
         hasBuildConfig = hasBuildConfig || it.hasBuildConfig
         usesAndroidClasses = usesAndroidClasses || it.usesAndroidClasses

--- a/src/main/kotlin/com/autonomousapps/tasks/XmlSourceExploderTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/XmlSourceExploderTask.kt
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.tasks
 
-import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.internal.parse.AndroidLayoutParser
 import com.autonomousapps.internal.parse.AndroidManifestParser
 import com.autonomousapps.internal.parse.AndroidResBuilder
@@ -14,13 +13,11 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 import org.gradle.workers.WorkerExecutor
-import java.io.File
 import javax.inject.Inject
 
 /**
@@ -46,13 +43,7 @@ import javax.inject.Inject
 abstract class XmlSourceExploderTask @Inject constructor(
   private val workerExecutor: WorkerExecutor,
   private val layout: ProjectLayout,
-  private val objects: ObjectFactory
 ) : DefaultTask() {
-
-  init {
-    group = TASK_GROUP_DEP_INTERNAL
-    description = "Produces a report of all resources references in this project"
-  }
 
   @get:PathSensitive(PathSensitivity.RELATIVE)
   @get:InputFiles
@@ -73,22 +64,6 @@ abstract class XmlSourceExploderTask @Inject constructor(
 
   @get:OutputFile
   abstract val output: RegularFileProperty
-
-  internal fun layouts(files: List<File>) {
-    for (file in files) {
-      layoutFiles.from(
-        objects.fileTree().from(file)
-          .matching {
-            // At this point in the filtering, there's a mix of directories and files
-            // Can't filter on file extension
-            include { it.path.contains("layout") }
-          }.files
-          // At this point, we have only files. It is safe to filter on extension. We
-          // only want XML files.
-          .filter { it.extension == "xml" }
-      )
-    }
-  }
 
   @TaskAction fun action() {
     workerExecutor.noIsolation().submit(XmlSourceExploderWorkAction::class.java) {


### PR DESCRIPTION
Ahead of migrating to non-deprecated APIs.

TODO:
- [x] Migrate usages for databinding and viewbinding.