### PR TITLE
fix: handle disjoint classpaths.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/Bundles.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/Bundles.kt
@@ -47,6 +47,7 @@ internal class Bundles private constructor(private val dependencyUsages: Map<Coo
 
   fun hasUsedChild(coordinates: Coordinates): Boolean {
     val children = parentKeyedBundle[coordinates] ?: return false
+
     return children.any { child ->
       dependencyUsages[child].orEmpty().any { it.bucket != Bucket.NONE }
     }
@@ -54,6 +55,7 @@ internal class Bundles private constructor(private val dependencyUsages: Map<Coo
 
   fun findUsedChild(coordinates: Coordinates): Coordinates? {
     val children = parentKeyedBundle[coordinates] ?: return null
+
     return children.find { child ->
       dependencyUsages[child].orEmpty().any { it.bucket != Bucket.NONE }
     }

--- a/src/main/kotlin/com/autonomousapps/model/declaration/Declaration.kt
+++ b/src/main/kotlin/com/autonomousapps/model/declaration/Declaration.kt
@@ -20,6 +20,7 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = false)
 internal data class Declaration(
   val identifier: String,
+  val version: String? = null,
   val configurationName: String,
   val gradleVariantIdentification: GradleVariantIdentification
 ) {

--- a/src/main/kotlin/com/autonomousapps/model/intermediates/Usage.kt
+++ b/src/main/kotlin/com/autonomousapps/model/intermediates/Usage.kt
@@ -31,7 +31,7 @@ internal data class Usage(
 }
 
 internal class UsageBuilder(
-  reports: Set<DependencyTraceReport>,
+  traces: Set<DependencyTraceReport>,
   private val variants: Collection<Variant>
 ) {
 
@@ -42,7 +42,7 @@ internal class UsageBuilder(
     val theDependencyUsages = mutableMapOf<Coordinates, MutableSet<Usage>>()
     val theAnnotationProcessingUsages = mutableMapOf<Coordinates, MutableSet<Usage>>()
 
-    reports.forEach { report ->
+    traces.forEach { report ->
       report.dependencies.forEach { trace ->
         theDependencyUsages.add(report, trace)
       }

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeAdviceTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeAdviceTask.kt
@@ -156,9 +156,9 @@ abstract class ComputeAdviceTask @Inject constructor(
         .run { AndroidScore.ofVariants(this) }
         .toSetOrEmpty()
       val bundleRules = parameters.bundles.get()
-      val reports = parameters.dependencyUsageReports.get().mapToSet { it.fromJson<DependencyTraceReport>() }
+      val traces = parameters.dependencyUsageReports.get().mapToSet { it.fromJson<DependencyTraceReport>() }
       val usageBuilder = UsageBuilder(
-        reports = reports,
+        traces = traces,
         // TODO: it would be clearer to get this from a SyntheticProject
         variants = dependencyGraph.values.map { it.variant }
       )

--- a/src/main/kotlin/com/autonomousapps/tasks/FindDeclarationsTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindDeclarationsTask.kt
@@ -5,6 +5,7 @@ package com.autonomousapps.tasks
 import com.autonomousapps.Flags.shouldAnalyzeTests
 import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.internal.NoVariantOutputPaths
+import com.autonomousapps.internal.utils.ModuleInfo
 import com.autonomousapps.internal.utils.bufferWriteJsonSet
 import com.autonomousapps.internal.utils.getAndDelete
 import com.autonomousapps.internal.utils.toIdentifiers
@@ -57,11 +58,11 @@ abstract class FindDeclarationsTask : DefaultTask() {
 
       task.projectPath.set(project.path)
       task.shouldAnalyzeTest.set(shouldAnalyzeTests)
-      task.declarationContainer.set(computeLocations(project, shouldAnalyzeTests))
+      task.declarationContainer.set(computeDeclarations(project, shouldAnalyzeTests))
       task.output.set(outputPaths.locationsPath)
     }
 
-    private fun computeLocations(project: Project, shouldAnalyzeTests: Boolean): Provider<DeclarationContainer> {
+    private fun computeDeclarations(project: Project, shouldAnalyzeTests: Boolean): Provider<DeclarationContainer> {
       val configurations = project.configurations
       return project.provider {
         DeclarationContainer.of(
@@ -87,11 +88,14 @@ abstract class FindDeclarationsTask : DefaultTask() {
     }
   }
 
-  class DeclarationContainer(@get:Input val mapping: Map<String, Set<Pair<String, GradleVariantIdentification>>>) {
+  class DeclarationContainer(
+    @get:Input
+    val mapping: Map<String, Set<Pair<ModuleInfo, GradleVariantIdentification>>>
+  ) {
 
     companion object {
       internal fun of(
-        mapping: Map<String, Set<Pair<String, GradleVariantIdentification>>>
+        mapping: Map<String, Set<Pair<ModuleInfo, GradleVariantIdentification>>>
       ): DeclarationContainer = DeclarationContainer(mapping)
     }
   }
@@ -102,7 +106,8 @@ abstract class FindDeclarationsTask : DefaultTask() {
         .flatMap { (conf, identifiers) ->
           identifiers.map { id ->
             Declaration(
-              identifier = id.first,
+              identifier = id.first.identifier,
+              version = id.first.version,
               configurationName = conf,
               gradleVariantIdentification = id.second
             )

--- a/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
+++ b/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
@@ -12,6 +12,7 @@ import com.autonomousapps.model.declaration.Bucket
 import com.autonomousapps.model.declaration.Declaration
 import com.autonomousapps.model.declaration.SourceSetKind
 import com.autonomousapps.model.declaration.Variant
+import com.autonomousapps.model.intermediates.Reason
 import com.autonomousapps.model.intermediates.Usage
 import com.google.common.collect.SetMultimap
 import org.gradle.api.attributes.Category
@@ -147,6 +148,8 @@ internal class StandardTransform(
         declarationsForVariant.forEach { decl ->
           if (
             usage.bucket == Bucket.NONE
+            // Don't remove an undeclared usage (this would make no sense)
+            && Reason.Undeclared !in usage.reasons
             // Don't remove a declaration on compileOnly, compileOnlyApi, providedCompile
             && decl.bucket != Bucket.COMPILE_ONLY
             // Don't remove a declaration on runtimeOnly
@@ -157,8 +160,9 @@ internal class StandardTransform(
               declaration = decl
             )
           } else if (
-          // Don't change a match, it's correct!
-            !usage.bucket.matches(decl)
+            usage.bucket != Bucket.NONE
+            // Don't change a match, it's correct!
+            && !usage.bucket.matches(decl)
             // Don't change a declaration on compileOnly, compileOnlyApi, providedCompile
             && decl.bucket != Bucket.COMPILE_ONLY
             // Don't change a declaration on runtimeOnly

--- a/src/test/kotlin/com/autonomousapps/transform/StandardTransformTest.kt
+++ b/src/test/kotlin/com/autonomousapps/transform/StandardTransformTest.kt
@@ -368,6 +368,31 @@ internal class StandardTransformTest {
       assertThat(actual).isEmpty()
     }
 
+    @Test fun `should not remove dependency unused on one variant and undeclared on another`() {
+      val identifier = "com.foo:bar"
+      val usages = usage(
+        bucket = Bucket.NONE,
+        variant = "functionalTest",
+        reasons = setOf(Reason.Undeclared)
+      ).intoSet()
+      val declarations = Declaration(
+        identifier = identifier,
+        version = "1.0",
+        configurationName = "implementation",
+        gradleVariantIdentification = emptyGVI
+      ).intoSet()
+
+      val actual = StandardTransform(
+        ModuleCoordinates(identifier, "2.0", gvi(identifier)),
+        declarations,
+        emptySetMultimap(),
+        supportedSourceSets,
+        ":"
+      ).reduce(usages)
+
+      assertThat(actual).isEmpty()
+    }
+
     @Test fun `should remove unused dependency`() {
       val identifier = "com.foo:bar"
       val usages = setOf(usage(Bucket.NONE, "debug"), usage(Bucket.NONE, "release"))
@@ -478,8 +503,16 @@ internal class StandardTransformTest {
       val id = "com.foo:bar"
       val usages = setOf(usage(Bucket.IMPL, "debug"), usage(Bucket.IMPL, "release"))
       val declarations = setOf(
-        Declaration(id, "debugImplementation", emptyGVI),
-        Declaration(id, "releaseApi", emptyGVI)
+        Declaration(
+          identifier = id,
+          configurationName = "debugImplementation",
+          gradleVariantIdentification = emptyGVI
+        ),
+        Declaration(
+          identifier = id,
+          configurationName = "releaseApi",
+          gradleVariantIdentification = emptyGVI
+        )
       )
 
       val actual = StandardTransform(
@@ -496,8 +529,16 @@ internal class StandardTransformTest {
       val id = "com.foo:bar"
       val usages = setOf(usage(Bucket.IMPL, "debug"), usage(Bucket.IMPL, "release"))
       val declarations = setOf(
-        Declaration(id, "implementation", emptyGVI),
-        Declaration(id, "releaseImplementation", emptyGVI)
+        Declaration(
+          identifier = id,
+          configurationName = "implementation",
+          gradleVariantIdentification = emptyGVI
+        ),
+        Declaration(
+          identifier = id,
+          configurationName = "releaseImplementation",
+          gradleVariantIdentification = emptyGVI
+        )
       )
 
       val actual = StandardTransform(
@@ -552,8 +593,16 @@ internal class StandardTransformTest {
       val id = "com.foo:bar"
       val usages = setOf(usage(Bucket.API, "debug"), usage(Bucket.NONE, "release"))
       val declarations = setOf(
-        Declaration(id, "debugImplementation", emptyGVI),
-        Declaration(id, "releaseApi", emptyGVI)
+        Declaration(
+          identifier = id,
+          configurationName = "debugImplementation",
+          gradleVariantIdentification = emptyGVI
+        ),
+        Declaration(
+          identifier = id,
+          configurationName = "releaseApi",
+          gradleVariantIdentification = emptyGVI
+        )
       )
 
       val actual = StandardTransform(
@@ -570,8 +619,16 @@ internal class StandardTransformTest {
       val id = "com.foo:bar"
       val usages = setOf(usage(Bucket.NONE, "debug"), usage(Bucket.NONE, "release"))
       val declarations = setOf(
-        Declaration(id, "debugImplementation", emptyGVI),
-        Declaration(id, "releaseApi", emptyGVI)
+        Declaration(
+          identifier = id,
+          configurationName = "debugImplementation",
+          gradleVariantIdentification = emptyGVI
+        ),
+        Declaration(
+          identifier = id,
+          configurationName = "releaseApi",
+          gradleVariantIdentification = emptyGVI
+        )
       )
 
       val actual = StandardTransform(
@@ -588,8 +645,16 @@ internal class StandardTransformTest {
       val id = "com.foo:bar"
       val usages = setOf(usage(Bucket.API, "debug"), usage(Bucket.IMPL, "release"))
       val declarations = setOf(
-        Declaration(id, "debugImplementation", emptyGVI),
-        Declaration(id, "releaseApi", emptyGVI)
+        Declaration(
+          identifier = id,
+          configurationName = "debugImplementation",
+          gradleVariantIdentification = emptyGVI
+        ),
+        Declaration(
+          identifier = id,
+          configurationName = "releaseApi",
+          gradleVariantIdentification = emptyGVI
+        )
       )
 
       val actual = StandardTransform(
@@ -609,8 +674,16 @@ internal class StandardTransformTest {
         usage(Bucket.API, "release")
       )
       val declarations = setOf(
-        Declaration(id, "implementation", emptyGVI),
-        Declaration(id, "releaseImplementation", emptyGVI)
+        Declaration(
+          identifier = id,
+          configurationName = "implementation",
+          gradleVariantIdentification = emptyGVI
+        ),
+        Declaration(
+          identifier = id,
+          configurationName = "releaseImplementation",
+          gradleVariantIdentification = emptyGVI
+        )
       )
 
       val actual = StandardTransform(
@@ -638,7 +711,11 @@ internal class StandardTransformTest {
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.TEST),
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.TEST),
       )
-      val declarations = Declaration(id, "implementation", emptyGVI).intoSet()
+      val declarations = Declaration(
+        identifier = id,
+        configurationName = "implementation",
+        gradleVariantIdentification = emptyGVI
+      ).intoSet()
 
       val actual = StandardTransform(
         ModuleCoordinates(id, "4.13.2", gvi(id)), declarations, emptySetMultimap(), supportedSourceSets, ":"
@@ -657,7 +734,11 @@ internal class StandardTransformTest {
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.ANDROID_TEST),
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.ANDROID_TEST),
       )
-      val declarations = Declaration(id, "implementation", emptyGVI).intoSet()
+      val declarations = Declaration(
+        identifier = id,
+        configurationName = "implementation",
+        gradleVariantIdentification = emptyGVI
+      ).intoSet()
 
       val actual = StandardTransform(
         ModuleCoordinates(id, "4.13.2", gvi(id)), declarations, emptySetMultimap(), supportedSourceSets, ":"
@@ -678,9 +759,21 @@ internal class StandardTransformTest {
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.ANDROID_TEST),
       )
       val declarations = setOf(
-        Declaration(id, "implementation", emptyGVI),
-        Declaration(id, "testImplementation", emptyGVI),
-        Declaration(id, "androidTestImplementation", emptyGVI),
+        Declaration(
+          identifier = id,
+          configurationName = "implementation",
+          gradleVariantIdentification = emptyGVI
+        ),
+        Declaration(
+          identifier = id,
+          configurationName = "testImplementation",
+          gradleVariantIdentification = emptyGVI
+        ),
+        Declaration(
+          identifier = id,
+          configurationName = "androidTestImplementation",
+          gradleVariantIdentification = emptyGVI
+        ),
       )
 
       val actual =
@@ -707,7 +800,11 @@ internal class StandardTransformTest {
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.TEST),
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.TEST),
       )
-      val declarations = Declaration(id, "implementation", emptyGVI).intoSet()
+      val declarations = Declaration(
+        identifier = id,
+        configurationName = "implementation",
+        gradleVariantIdentification = emptyGVI
+      ).intoSet()
 
       val actual = StandardTransform(
         ModuleCoordinates(id, "1.0", gvi(id)), declarations, emptySetMultimap(), supportedSourceSets, ":"
@@ -727,7 +824,11 @@ internal class StandardTransformTest {
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.ANDROID_TEST),
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.ANDROID_TEST),
       )
-      val declarations = Declaration(id, "implementation", emptyGVI).intoSet()
+      val declarations = Declaration(
+        identifier = id,
+        configurationName = "implementation",
+        gradleVariantIdentification = emptyGVI
+      ).intoSet()
 
       val actual = StandardTransform(
         ModuleCoordinates(id, "1.0", gvi(id)), declarations, emptySetMultimap(), supportedSourceSets, ":"
@@ -744,7 +845,11 @@ internal class StandardTransformTest {
       val usages = setOf(
         usage(bucket = Bucket.RUNTIME_ONLY, variant = "test", kind = SourceSetKind.TEST),
       )
-      val declarations = Declaration(id, "testImplementation", emptyGVI).intoSet()
+      val declarations = Declaration(
+        identifier = id,
+        configurationName = "testImplementation",
+        gradleVariantIdentification = emptyGVI
+      ).intoSet()
 
       val actual = StandardTransform(
         ModuleCoordinates(id, "4.4", gvi(id)), declarations, emptySetMultimap(), supportedSourceSets, ":"
@@ -764,8 +869,16 @@ internal class StandardTransformTest {
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.TEST),
       )
       val declarations = setOf(
-        Declaration(id, "implementation", emptyGVI),
-        Declaration(id, "testImplementation", emptyGVI)
+        Declaration(
+          identifier = id,
+          configurationName = "implementation",
+          gradleVariantIdentification = emptyGVI
+        ),
+        Declaration(
+          identifier = id,
+          configurationName = "testImplementation",
+          gradleVariantIdentification = emptyGVI
+        )
       )
 
       val actual = StandardTransform(
@@ -786,8 +899,16 @@ internal class StandardTransformTest {
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.TEST),
       )
       val declarations = setOf(
-        Declaration(id, "implementation", emptyGVI),
-        Declaration(id, "testImplementation", emptyGVI)
+        Declaration(
+          identifier = id,
+          configurationName = "implementation",
+          gradleVariantIdentification = emptyGVI
+        ),
+        Declaration(
+          identifier = id,
+          configurationName = "testImplementation",
+          gradleVariantIdentification = emptyGVI
+        )
       )
 
       val actual = StandardTransform(
@@ -808,8 +929,16 @@ internal class StandardTransformTest {
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.ANDROID_TEST),
       )
       val declarations = setOf(
-        Declaration(id, "implementation", emptyGVI),
-        Declaration(id, "androidTestImplementation", emptyGVI)
+        Declaration(
+          identifier = id,
+          configurationName = "implementation",
+          gradleVariantIdentification = emptyGVI
+        ),
+        Declaration(
+          identifier = id,
+          configurationName = "androidTestImplementation",
+          gradleVariantIdentification = emptyGVI
+        )
       )
 
       val actual = StandardTransform(
@@ -830,7 +959,11 @@ internal class StandardTransformTest {
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.TEST),
       )
       val declarations = setOf(
-        Declaration(id, "testImplementation", emptyGVI)
+        Declaration(
+          identifier = id,
+          configurationName = "testImplementation",
+          gradleVariantIdentification = emptyGVI
+        )
       )
 
       val actual = StandardTransform(
@@ -851,7 +984,11 @@ internal class StandardTransformTest {
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.ANDROID_TEST),
       )
       val declarations = setOf(
-        Declaration(id, "androidTestImplementation", emptyGVI)
+        Declaration(
+          identifier = id,
+          configurationName = "androidTestImplementation",
+          gradleVariantIdentification = emptyGVI
+        )
       )
 
       val actual = StandardTransform(
@@ -928,7 +1065,11 @@ internal class StandardTransformTest {
         kind = SourceSetKind.MAIN,
         reasons = Reason.Unused.intoSet()
       ).intoSet()
-      val declarations = Declaration(id, "kapt", emptyGVI).intoSet()
+      val declarations = Declaration(
+        identifier = id,
+        configurationName = "kapt",
+        gradleVariantIdentification = emptyGVI
+      ).intoSet()
 
       val actual = StandardTransform(
         ModuleCoordinates(id, "2.40.5", gvi(id)), declarations, emptySetMultimap(), supportedSourceSets, ":", true
@@ -954,7 +1095,11 @@ internal class StandardTransformTest {
           kind = SourceSetKind.MAIN
         )
       )
-      val declarations = Declaration(id, "kapt", emptyGVI).intoSet()
+      val declarations = Declaration(
+        identifier = id,
+        configurationName = "kapt",
+        gradleVariantIdentification = emptyGVI
+      ).intoSet()
 
       val actual = StandardTransform(
         ModuleCoordinates(id, "2.40.5", gvi(id)), declarations, emptySetMultimap(), supportedSourceSets, ":", false


### PR DESCRIPTION
If the main source set has a used dependency, and a custom source set has an unused transitive dependency, and these are at different versions, StandardTransform was advising the removal of the used dependency. Now we check that the usage is not undeclared before adding to the set of remove-advice.