### PR TITLE
Bump gradle-script-grammar to v0.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 antlr-shadowed = "4.10.1.6"
 asm-relocated = "9.6.0.1"
-grammar = "0.2"
+grammar = "0.3"
 java = "11"
 junit = "5.8.2"
 kotlin = "1.9.10"


### PR DESCRIPTION
### Description
- Bumps [gradle-script-grammar](https://github.com/autonomousapps/gradle-script-grammar) to `v0.3` to leverage [support for multiple closures](https://github.com/autonomousapps/gradle-script-grammar/pull/1)

### Actual Results
Currently, if you run `fixDependencies` task and you have a dependency with the following syntax:

```groovy
dependencies {
    implementation (libs.spotify.authSdk) {
        artifact {
            type = "aar"
        }
    }
    api libs.androidx.constraintLayout
    implementation projects.common.kotlinxCoroutines
    implementation libs.kotlinx.coroutines.rx2
}
```
the dependencies will be rewritten as:

```groovy
dependencies {
    implementation (libs.spotify.authSdk) {
        artifact {
            type = "aar"
        }
    api libs.androidx.constraintLayout
    implementation projects.common.kotlinxCoroutines
    implementation libs.kotlinx.coroutines.rx2
}
```
**Notice there's a missing curly brace.**

### Expected Results
Running `fixDependencies` should be able to handle multiple closures, which is supported in gradle-script-grammar `v0.3`