### PR TITLE
fix: ugly workaround for issue 1116.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/ArbitraryFileProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/ArbitraryFileProject.groovy
@@ -34,6 +34,10 @@ final class ArbitraryFileProject extends AbstractAndroidProject {
           bs.plugins = androidLibPlugin
           bs.android = defaultAndroidLibBlock(false)
           bs.withGroovy("""
+          // TODO: do this in a dedicated test
+          //  https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1116
+          tasks.whenTaskAdded {}
+
           afterEvaluate {
             tasks.withType(com.android.build.gradle.tasks.MergeResources).configureEach {
               aaptEnv.set("FOO")

--- a/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
@@ -173,7 +173,9 @@ internal class ProjectPlugin(private val project: Project) {
           )
           isDataBindingEnabled.set(dependencyAnalyzer.isDataBindingEnabled)
           isViewBindingEnabled.set(dependencyAnalyzer.isViewBindingEnabled)
-          analyzeDependencies(dependencyAnalyzer)
+          afterEvaluate {
+            analyzeDependencies(dependencyAnalyzer)
+          }
         }
 
         unitTestSourceSets?.let { sourceSets ->
@@ -186,7 +188,9 @@ internal class ProjectPlugin(private val project: Project) {
           )
           isDataBindingEnabled.set(dependencyAnalyzer.isDataBindingEnabled)
           isViewBindingEnabled.set(dependencyAnalyzer.isViewBindingEnabled)
-          analyzeDependencies(dependencyAnalyzer)
+          afterEvaluate {
+            analyzeDependencies(dependencyAnalyzer)
+          }
         }
 
         androidTestSourceSets?.let { sourceSets ->
@@ -199,7 +203,9 @@ internal class ProjectPlugin(private val project: Project) {
           )
           isDataBindingEnabled.set(dependencyAnalyzer.isDataBindingEnabled)
           isViewBindingEnabled.set(dependencyAnalyzer.isViewBindingEnabled)
-          analyzeDependencies(dependencyAnalyzer)
+          afterEvaluate {
+            analyzeDependencies(dependencyAnalyzer)
+          }
         }
       }
     }
@@ -234,7 +240,9 @@ internal class ProjectPlugin(private val project: Project) {
           )
           isDataBindingEnabled.set(dependencyAnalyzer.isDataBindingEnabled)
           isViewBindingEnabled.set(dependencyAnalyzer.isViewBindingEnabled)
-          analyzeDependencies(dependencyAnalyzer)
+          afterEvaluate {
+            analyzeDependencies(dependencyAnalyzer)
+          }
         }
 
         unitTestSourceSets?.let { sourceSets ->
@@ -247,7 +255,9 @@ internal class ProjectPlugin(private val project: Project) {
           )
           isDataBindingEnabled.set(dependencyAnalyzer.isDataBindingEnabled)
           isViewBindingEnabled.set(dependencyAnalyzer.isViewBindingEnabled)
-          analyzeDependencies(dependencyAnalyzer)
+          afterEvaluate {
+            analyzeDependencies(dependencyAnalyzer)
+          }
         }
 
         androidTestSourceSets?.let { sourceSets ->
@@ -260,7 +270,9 @@ internal class ProjectPlugin(private val project: Project) {
           )
           isDataBindingEnabled.set(dependencyAnalyzer.isDataBindingEnabled)
           isViewBindingEnabled.set(dependencyAnalyzer.isViewBindingEnabled)
-          analyzeDependencies(dependencyAnalyzer)
+          afterEvaluate {
+            analyzeDependencies(dependencyAnalyzer)
+          }
         }
       }
     }


### PR DESCRIPTION
Basic hypothesis is that tasks.whenTaskAdded eagerly realizes all tasks, which forces DAGP tasks to be configured too soon. Some of them have dependencies on AGP tasks that are registered later in the build lifecycle. This workaround uses afterEvaluate as a bandaid. Preferable would be using some Android- specific version of SourceSetContainer to get lazy access to compiled class files, instead of relying on tasks directly.

Resolves https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1116