### PR TITLE
fix: only use new configurations factories from Gradle 8.5.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/AssembleArchivesSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/AssembleArchivesSpec.groovy
@@ -24,6 +24,6 @@ final class AssembleArchivesSpec extends AbstractJvmSpec {
     ])
 
     where:
-    gradleVersion << gradleVersions()
+    gradleVersion << (gradleVersions() + GRADLE_8_4)
   }
 }

--- a/src/main/kotlin/com/autonomousapps/internal/GradleVersions.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/GradleVersions.kt
@@ -10,6 +10,7 @@ internal object GradleVersions {
   private val gradle75: GradleVersion = GradleVersion.version("7.5")
   private val gradle82: GradleVersion = GradleVersion.version("8.2")
   private val gradle84: GradleVersion = GradleVersion.version("8.4")
+  private val gradle85: GradleVersion = GradleVersion.version("8.5")
 
   /** Minimum supported version of Gradle. */
   @JvmField val minGradleVersion: GradleVersion = gradle74
@@ -21,4 +22,5 @@ internal object GradleVersions {
   val isAtLeastGradle75: Boolean = current >= gradle75
   val isAtLeastGradle82: Boolean = current >= gradle82
   val isAtLeastGradle84: Boolean = current >= gradle84
+  val isAtLeastGradle85: Boolean = current >= gradle85
 }

--- a/src/main/kotlin/com/autonomousapps/internal/artifacts/configurations.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/artifacts/configurations.kt
@@ -15,7 +15,7 @@ import org.gradle.api.artifacts.Configuration
  * also [resolvableConfiguration] and [consumableConfiguration].
  */
 internal fun Project.dependencyScopeConfiguration(configurationName: String): NamedDomainObjectProvider<out Configuration> {
-  return if (GradleVersions.isAtLeastGradle84) {
+  return if (GradleVersions.isAtLeastGradle85) {
     configurations.dependencyScope(configurationName)
   } else {
     configurations.register(configurationName) {
@@ -35,7 +35,7 @@ internal fun Project.resolvableConfiguration(
   dependencyScopeConfiguration: Configuration,
   configureAction: Action<in Configuration>,
 ): NamedDomainObjectProvider<out Configuration> {
-  return if (GradleVersions.isAtLeastGradle84) {
+  return if (GradleVersions.isAtLeastGradle85) {
     configurations.resolvable(configurationName) {
       extendsFrom(dependencyScopeConfiguration)
       configureAction.execute(this)
@@ -63,7 +63,7 @@ internal fun Project.consumableConfiguration(
   dependencyScopeConfiguration: Configuration? = null,
   configureAction: Action<in Configuration>,
 ): NamedDomainObjectProvider<out Configuration> {
-  return if (GradleVersions.isAtLeastGradle84) {
+  return if (GradleVersions.isAtLeastGradle85) {
     configurations.consumable(configurationName) {
       dependencyScopeConfiguration?.let { extendsFrom(it) }
       configureAction.execute(this)


### PR DESCRIPTION
There's a bug in 8.4 where isInvisible=false has not been set, leading the inter-project publications to be added to the archives configuration and therefore being added to the assemble task.

See https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/908#issuecomment-1952162799