### PR TITLE
feat: allow to force app behavior for pure Java projects

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/ApplicationSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/ApplicationSpec.groovy
@@ -53,4 +53,42 @@ final class ApplicationSpec extends AbstractJvmSpec {
     where:
     gradleVersion << gradleVersions()
   }
+
+  def "can analyze pure java projects when forced to be application (#gradleVersion)"() {
+    given:
+       def plugins = [Plugin.java]
+       def project = new ApplicationProject(plugins, SourceType.JAVA, true)
+       gradleProject = project.gradleProject
+
+    and:
+       gradleProject.projectDir(":proj").resolve("build.gradle")
+
+    when:
+       build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+       assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    where:
+       gradleVersion << gradleVersions()
+  }
+
+  def "does not analyze pure java projects when not forced to be application (#gradleVersion)"() {
+    given:
+       def plugins = [Plugin.java]
+       def project = new ApplicationProject(plugins)
+       gradleProject = project.gradleProject
+
+    and:
+       gradleProject.projectDir(":proj").resolve("build.gradle")
+
+    when:
+       build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+       assertThat(project.actualBuildHealth()).isEmpty()
+
+    where:
+       gradleVersion << gradleVersions()
+  }
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/ApplicationProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/ApplicationProject.groovy
@@ -21,16 +21,19 @@ final class ApplicationProject extends AbstractProject {
 
   private final List<Plugin> plugins
   private final SourceType sourceType
+  private final boolean forced
   private final commonsMath = commonsMath('implementation')
 
   final GradleProject gradleProject
 
   ApplicationProject(
     List<Plugin> plugins = [Plugin.application],
-    SourceType sourceType = SourceType.JAVA
+    SourceType sourceType = SourceType.JAVA,
+    boolean forced = false
   ) {
     this.plugins = plugins + Plugins.dependencyAnalysisNoVersion
     this.sourceType = sourceType
+    this.forced = forced
     this.gradleProject = build()
   }
 
@@ -48,6 +51,11 @@ final class ApplicationProject extends AbstractProject {
           processResources {
             from 'res.txt'
           }
+          ${forced ? '''
+          dependencyAnalysis {
+            app()
+          }
+          ''' : ''}
           """
           )
         }

--- a/src/main/kotlin/com/autonomousapps/AbstractExtension.kt
+++ b/src/main/kotlin/com/autonomousapps/AbstractExtension.kt
@@ -13,6 +13,7 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.property
 
 abstract class AbstractExtension(project: Project) {
 
@@ -30,6 +31,8 @@ abstract class AbstractExtension(project: Project) {
   private val adviceOutput = objects.fileProperty()
   private var postProcessingTask: TaskProvider<out AbstractPostProcessingTask>? = null
 
+  internal var forceAppProject = false
+
   internal fun storeAdviceOutput(provider: Provider<RegularFile>) {
     val output = objects.fileProperty().also {
       it.set(provider)
@@ -44,6 +47,13 @@ abstract class AbstractExtension(project: Project) {
    */
   @Suppress("MemberVisibilityCanBePrivate") // explicit API
   fun adviceOutput(): RegularFileProperty = adviceOutput
+
+  /**
+   * Whether to force the project being treated as an app project even if only the `java` plugin is applied.
+   */
+  fun app() {
+    forceAppProject = true
+  }
 
   /**
    * Register your custom task that post-processes the [ProjectAdvice][com.autonomousapps.model.ProjectAdvice] produced

--- a/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
@@ -527,7 +527,8 @@ internal class ProjectPlugin(private val project: Project) {
     pluginManager.hasPlugin(APPLICATION_PLUGIN) ||
       pluginManager.hasPlugin(SPRING_BOOT_PLUGIN) ||
       pluginManager.hasPlugin(GRETTY_PLUGIN) ||
-      pluginManager.hasPlugin(ANDROID_APP_PLUGIN)
+      pluginManager.hasPlugin(ANDROID_APP_PLUGIN) ||
+      dagpExtension.forceAppProject
 
   /* ===============================================
    * The main work of the plugin happens below here.


### PR DESCRIPTION
Currently if only the `java` plugin is applied, but not one of a small set of known
application-like plugins, a project is not analyzed.

This PR allows to set a property on the extensions that can force application behavior
even if none of the known application-like plugins is applied.
