### PR TITLE
fix: make file relativizing work properly on Windows

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/utils/Files.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/Files.kt
@@ -6,7 +6,7 @@ import java.io.File
 
 internal object Files {
   fun relativize(file: File, after: String): String {
-    return file.absolutePath.substringAfter(after)
+    return file.absoluteFile.invariantSeparatorsPath.substringAfter(after)
   }
 
   fun asPackagePath(file: File): String {


### PR DESCRIPTION
The file relativizing only worked properly on *nix systems.
On Windows even executing the tests failed with the code before this PR.
The PR makes the method work consistently on all operating systems.
