### PR TITLE
fix: Do not dotty for path matching and remove prefix and suffix from binary class name

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/models.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/models.kt
@@ -147,10 +147,10 @@ internal data class AbiExclusions(
 
   fun excludesAnnotation(fqcn: String): Boolean = annotationRegexes.any { it.containsMatchIn(fqcn.dotty()) }
   fun excludesClass(fqcn: String) = classRegexes.any { it.containsMatchIn(fqcn.dotty()) }
-  fun excludesPath(path: String) = pathRegexes.any { it.containsMatchIn(path.dotty()) }
+  fun excludesPath(path: String) = pathRegexes.any { it.containsMatchIn(path) }
 
   // The user-facing regex expects FQCNs to be delimited with dots, not slashes
-  private fun String.dotty() = replace('/', '.')
+  private fun String.dotty() = replace('/', '.').removeSurrounding("L", ";")
 
   companion object {
     val NONE = AbiExclusions()
@@ -172,7 +172,7 @@ internal data class UsagesExclusions(
   }
 
   // The user-facing regex expects FQCNs to be delimited with dots, not slashes
-  private fun String.dotty() = replace('/', '.')
+  private fun String.dotty() = replace('/', '.').removeSurrounding("L", ";")
 
   companion object {
     val NONE = UsagesExclusions()


### PR DESCRIPTION
For path matching the path was dottied too, which feels wrong,
I guess this was just copy & paste and path matching cannot be configured right now anyway,
so just fixed it while changing that code.

The main problem I'm trying to fix with this PR is, that I tried to do `excludeAnnotations("""^\Qorg.spockframework.runtime.model.SpecMetadata\E$""")`
which did not match because the "L" prefix and the ";" suffix from the binary class name are still present.
This PR removes the "L" prefix and the ";" suffix when dottying class names.
