### PR TITLE
test: Android theme containing a period

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidThemeProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidThemeProject.groovy
@@ -44,7 +44,7 @@ final class AndroidThemeProject extends AbstractAndroidProject {
             xmlns:tools="http://schemas.android.com/tools"
             package="com.consumer">
           
-            <application android:theme="@style/AppTheme"/>
+            <application android:theme="@style/AppTheme.Foo"/>
           </manifest>'''.stripIndent()
         )
       }
@@ -61,7 +61,7 @@ final class AndroidThemeProject extends AbstractAndroidProject {
           '''\
           <?xml version="1.0" encoding="utf-8"?>
           <resources>
-            <style name="AppTheme" parent="Theme.AppCompat.Light">
+            <style name="AppTheme.Foo" parent="Theme.AppCompat.Light">
               <item name="colorPrimary">#0568ae</item>
             </style>
           </resources>'''.stripIndent()


### PR DESCRIPTION
This is a reproducer for #1038.

The consumer generates `AttrRef(type = "style", id = "AppTheme.Foo")`.
The producer generates `AttrRef(type = "attr", id = "AppTheme_Foo")`.

https://github.com/autonomousapps/dependency-analysis-gradle-plugin/actions/runs/8265204574/job/22610349535?pr=1146#step:8:393

```
ResSpec > detects theme set in manifest (#gradleVersion AGP #agpVersion) > detects theme set in manifest (Gradle 8.6 AGP 8.4.0-alpha01) FAILED
    org.spockframework.runtime.ConditionFailedWithExceptionError at ResSpec.groovy:131
        Caused by: com.google.common.truth.AssertionErrorWithFacts at ResSpec.groovy:131
```