### PR TITLE
chore: no group for 'internal' tasks.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
@@ -16,7 +16,6 @@ import org.gradle.api.Project
 import org.gradle.api.logging.Logger
 
 internal const val TASK_GROUP_DEP = "dependency-analysis"
-internal const val TASK_GROUP_DEP_INTERNAL = "dependency-analysis-internal"
 
 /** For use in contexts where a logger isn't easily available */
 internal val PROJECT_LOGGER: Logger = getLogger<DependencyAnalysisPlugin>()

--- a/src/main/kotlin/com/autonomousapps/tasks/AndroidScoreTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/AndroidScoreTask.kt
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.tasks
 
-import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.internal.utils.bufferWriteJson
 import com.autonomousapps.internal.utils.fromJson
 import com.autonomousapps.internal.utils.getAndDelete
@@ -23,7 +22,6 @@ abstract class AndroidScoreTask @Inject constructor(
 ) : DefaultTask() {
 
   init {
-    group = TASK_GROUP_DEP_INTERNAL
     description = "Infers if Android project could instead be a JVM project"
   }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/ArtifactsReportTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ArtifactsReportTask.kt
@@ -4,7 +4,6 @@
 
 package com.autonomousapps.tasks
 
-import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.internal.utils.bufferWriteJsonSet
 import com.autonomousapps.internal.utils.filterNonGradle
 import com.autonomousapps.internal.utils.getAndDelete
@@ -27,7 +26,6 @@ import org.gradle.api.tasks.*
 abstract class ArtifactsReportTask : DefaultTask() {
 
   init {
-    group = TASK_GROUP_DEP_INTERNAL
     description = "Produces a report that lists all direct and transitive dependencies, along with their artifacts"
   }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/AssetSourceExploderTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/AssetSourceExploderTask.kt
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.tasks
 
-import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.internal.utils.bufferWriteJsonSet
 import com.autonomousapps.internal.utils.getAndDelete
 import com.autonomousapps.internal.utils.mapToSet
@@ -24,7 +23,6 @@ abstract class AssetSourceExploderTask @Inject constructor(
 ) : DefaultTask() {
 
   init {
-    group = TASK_GROUP_DEP_INTERNAL
     description = "Produces a report of all assets in this project"
   }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/ClassListExploderTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ClassListExploderTask.kt
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.tasks
 
-import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.internal.ClassFilesParser
 import com.autonomousapps.internal.utils.bufferWriteJsonSet
 import com.autonomousapps.internal.utils.filterToClassFiles
@@ -24,7 +23,6 @@ abstract class ClassListExploderTask @Inject constructor(
 ) : AndroidClassesTask() {
 
   init {
-    group = TASK_GROUP_DEP_INTERNAL
     description = "Produces a report of all classes referenced by a given set of class files"
   }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/CodeSourceExploderTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/CodeSourceExploderTask.kt
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.tasks
 
-import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.internal.parse.SourceListener
 import com.autonomousapps.internal.utils.bufferWriteJsonSet
 import com.autonomousapps.internal.utils.getAndDelete
@@ -28,7 +27,6 @@ abstract class CodeSourceExploderTask @Inject constructor(
 ) : DefaultTask() {
 
   init {
-    group = TASK_GROUP_DEP_INTERNAL
     description = "Parses Java and Kotlin source to detect source-only usages"
   }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeAdviceTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeAdviceTask.kt
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.tasks
 
-import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.advice.PluginAdvice
 import com.autonomousapps.extension.DependenciesHandler
 import com.autonomousapps.graph.Graphs.children
@@ -39,7 +38,6 @@ abstract class ComputeAdviceTask @Inject constructor(
 ) : DefaultTask() {
 
   init {
-    group = TASK_GROUP_DEP_INTERNAL
     description = "Merges dependency usage reports from variant-specific computations"
   }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeUsagesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeUsagesTask.kt
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.tasks
 
-import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.internal.utils.*
 import com.autonomousapps.model.*
 import com.autonomousapps.model.declaration.Bucket
@@ -28,7 +27,6 @@ abstract class ComputeUsagesTask @Inject constructor(
 ) : DefaultTask() {
 
   init {
-    group = TASK_GROUP_DEP_INTERNAL
     description = "Computes actual dependency usage"
   }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/DetectRedundantJvmPluginTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/DetectRedundantJvmPluginTask.kt
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.tasks
 
-import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.advice.PluginAdvice
 import com.autonomousapps.extension.Behavior
 import com.autonomousapps.extension.Ignore
@@ -24,7 +23,6 @@ import org.gradle.api.tasks.TaskAction
 abstract class DetectRedundantJvmPluginTask : DefaultTask() {
 
   init {
-    group = TASK_GROUP_DEP_INTERNAL
     description = "Produces a report about redundant jvm plugins that have been applied"
   }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/ExplodeJarTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ExplodeJarTask.kt
@@ -4,7 +4,6 @@
 
 package com.autonomousapps.tasks
 
-import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.internal.JarExploder
 import com.autonomousapps.internal.utils.bufferWriteJsonSet
 import com.autonomousapps.internal.utils.fromJsonList
@@ -28,7 +27,6 @@ abstract class ExplodeJarTask @Inject constructor(
 ) : DefaultTask() {
 
   init {
-    group = TASK_GROUP_DEP_INTERNAL
     description = "Explodes a jar and exposes its capabilities"
   }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/FilterAdviceTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FilterAdviceTask.kt
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.tasks
 
-import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.advice.PluginAdvice
 import com.autonomousapps.extension.Behavior
 import com.autonomousapps.extension.Ignore
@@ -29,7 +28,6 @@ abstract class FilterAdviceTask @Inject constructor(
 ) : DefaultTask() {
 
   init {
-    group = TASK_GROUP_DEP_INTERNAL
     description = "Filter merged advice based on user preferences"
   }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/FindAndroidAssetProviders.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindAndroidAssetProviders.kt
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.tasks
 
-import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.internal.utils.bufferWriteJsonSet
 import com.autonomousapps.internal.utils.getAndDelete
 import com.autonomousapps.internal.utils.toCoordinates
@@ -17,7 +16,6 @@ import org.gradle.api.tasks.*
 abstract class FindAndroidAssetProviders : DefaultTask() {
 
   init {
-    group = TASK_GROUP_DEP_INTERNAL
     description = "Produces a report of dependencies that supply Android assets"
   }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/FindAndroidLinters.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindAndroidLinters.kt
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.tasks
 
-import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.internal.LINT_ISSUE_REGISTRY_PATH
 import com.autonomousapps.internal.MANIFEST_PATH
 import com.autonomousapps.internal.utils.bufferWriteJsonSet
@@ -30,7 +29,6 @@ import java.util.zip.ZipFile
 abstract class FindAndroidLinters : DefaultTask() {
 
   init {
-    group = TASK_GROUP_DEP_INTERNAL
     description = "Produces a report of dependencies that supply Android linters"
   }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/FindAndroidResTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindAndroidResTask.kt
@@ -4,7 +4,6 @@
 
 package com.autonomousapps.tasks
 
-import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.internal.utils.*
 import com.autonomousapps.model.AndroidResCapability
 import com.autonomousapps.model.Coordinates
@@ -26,7 +25,6 @@ import java.util.concurrent.atomic.AtomicBoolean
 abstract class FindAndroidResTask : DefaultTask() {
 
   init {
-    group = TASK_GROUP_DEP_INTERNAL
     description = "Produces a report of all R import candidates from set of dependencies"
   }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/FindDeclarationsTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindDeclarationsTask.kt
@@ -3,7 +3,6 @@
 package com.autonomousapps.tasks
 
 import com.autonomousapps.Flags.shouldAnalyzeTests
-import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.internal.NoVariantOutputPaths
 import com.autonomousapps.internal.utils.ModuleInfo
 import com.autonomousapps.internal.utils.bufferWriteJsonSet
@@ -26,7 +25,6 @@ import org.gradle.api.tasks.*
 abstract class FindDeclarationsTask : DefaultTask() {
 
   init {
-    group = TASK_GROUP_DEP_INTERNAL
     description = "Produces a report of all dependencies and the configurations on which they are declared"
   }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/FindDeclaredProcsTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindDeclaredProcsTask.kt
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.tasks
 
-import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.internal.ANNOTATION_PROCESSOR_PATH
 import com.autonomousapps.internal.utils.bufferWriteJsonList
 import com.autonomousapps.internal.utils.getAndDelete
@@ -53,7 +52,6 @@ import javax.tools.JavaFileObject
 abstract class FindDeclaredProcsTask : DefaultTask() {
 
   init {
-    group = TASK_GROUP_DEP_INTERNAL
     description = "Produces a report of all supported annotation types and their annotation processors"
   }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/FindInlineMembersTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindInlineMembersTask.kt
@@ -4,7 +4,6 @@
 
 package com.autonomousapps.tasks
 
-import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.internal.KotlinMetadataVisitor
 import com.autonomousapps.internal.asm.ClassReader
 import com.autonomousapps.internal.utils.*
@@ -37,7 +36,6 @@ abstract class FindInlineMembersTask @Inject constructor(
 ) : DefaultTask() {
 
   init {
-    group = TASK_GROUP_DEP_INTERNAL
     description = "Produces a report of dependencies that contribute used inline members"
   }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/FindNativeLibsTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindNativeLibsTask.kt
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.tasks
 
-import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.internal.utils.*
 import com.autonomousapps.model.intermediates.NativeLibDependency
 import org.gradle.api.DefaultTask
@@ -16,7 +15,6 @@ import org.gradle.api.tasks.*
 abstract class FindNativeLibsTask : DefaultTask() {
 
   init {
-    group = TASK_GROUP_DEP_INTERNAL
     description = "Produces a report of all dependencies that supply native libs"
   }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/FindServiceLoadersTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindServiceLoadersTask.kt
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.tasks
 
-import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.internal.ANNOTATION_PROCESSOR_PATH
 import com.autonomousapps.internal.SERVICE_LOADER_PATH
 import com.autonomousapps.internal.utils.*
@@ -33,7 +32,6 @@ import java.util.zip.ZipFile
 abstract class FindServiceLoadersTask : DefaultTask() {
 
   init {
-    group = TASK_GROUP_DEP_INTERNAL
     description = "Produces a report of all dependencies that include Java ServiceLoaders"
   }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/GenerateBuildHealthTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/GenerateBuildHealthTask.kt
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.tasks
 
-import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.extension.DependenciesHandler.Companion.toLambda
 import com.autonomousapps.internal.advice.DslKind
 import com.autonomousapps.internal.advice.ProjectHealthConsoleReportBuilder
@@ -24,7 +23,6 @@ import org.gradle.api.tasks.*
 abstract class GenerateBuildHealthTask : DefaultTask() {
 
   init {
-    group = TASK_GROUP_DEP_INTERNAL
     description = "Generates json report for build health"
   }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/GenerateProjectHealthReportTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/GenerateProjectHealthReportTask.kt
@@ -4,7 +4,6 @@
 
 package com.autonomousapps.tasks
 
-import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.extension.DependenciesHandler.Companion.toLambda
 import com.autonomousapps.internal.advice.DslKind
 import com.autonomousapps.internal.advice.ProjectHealthConsoleReportBuilder
@@ -27,7 +26,6 @@ abstract class GenerateProjectHealthReportTask @Inject constructor(
 ) : DefaultTask() {
 
   init {
-    group = TASK_GROUP_DEP_INTERNAL
     description = "Generates console report for project health"
   }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/GraphViewTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/GraphViewTask.kt
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.tasks
 
-import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.internal.externalArtifactsFor
 import com.autonomousapps.internal.graph.GraphViewBuilder
 import com.autonomousapps.internal.graph.GraphWriter
@@ -30,7 +29,6 @@ import org.gradle.api.tasks.*
 abstract class GraphViewTask : DefaultTask() {
 
   init {
-    group = TASK_GROUP_DEP_INTERNAL
     description = "Constructs a variant-specific view of this project's dependency graph"
   }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/ManifestComponentsExtractionTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ManifestComponentsExtractionTask.kt
@@ -4,7 +4,6 @@
 
 package com.autonomousapps.tasks
 
-import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.internal.ManifestParser
 import com.autonomousapps.internal.utils.bufferWriteJsonSet
 import com.autonomousapps.internal.utils.getAndDelete
@@ -23,7 +22,6 @@ import org.gradle.api.tasks.*
 abstract class ManifestComponentsExtractionTask : DefaultTask() {
 
   init {
-    group = TASK_GROUP_DEP_INTERNAL
     description = "Produces a report of packages, from other components, that are included via Android manifests"
   }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/SynthesizeDependenciesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/SynthesizeDependenciesTask.kt
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.tasks
 
-import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.internal.utils.*
 import com.autonomousapps.model.*
 import com.autonomousapps.model.intermediates.*
@@ -24,7 +23,6 @@ abstract class SynthesizeDependenciesTask @Inject constructor(
 ) : DefaultTask() {
 
   init {
-    group = TASK_GROUP_DEP_INTERNAL
     description = "Re-synthesize dependencies from analysis"
   }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/SynthesizeProjectViewTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/SynthesizeProjectViewTask.kt
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.tasks
 
-import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.internal.UsagesExclusions
 import com.autonomousapps.internal.utils.*
 import com.autonomousapps.model.*
@@ -28,7 +27,6 @@ abstract class SynthesizeProjectViewTask @Inject constructor(
 ) : DefaultTask() {
 
   init {
-    group = TASK_GROUP_DEP_INTERNAL
     description = "Synthesizes project usages information into a single view"
   }
 


### PR DESCRIPTION
This will make the output of the 'tasks' task more concise.