### PR TITLE
Explicit memory settings

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,9 @@
 # Copyright (c) 2024. Tony Robalik.
 # SPDX-License-Identifier: Apache-2.0
-org.gradle.jvmargs=-Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError -XX:MaxMetaspaceSize=1024m
+org.gradle.jvmargs=-Xmx6G \
+  -Dfile.encoding=UTF-8 \
+  -XX:+HeapDumpOnOutOfMemoryError \
+  -XX:MaxMetaspaceSize=1024m
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.configuration-cache=true


### PR DESCRIPTION
We build the project in a container with 10G memory and in most cases it hangs in a random place (occasionally it passes successfully).
The main assumption here is default memory settings resolved from environment. After some experiments I've found that this simple change stabilizes the build (reproducible).