### PR TITLE
Fix ArtifactsReportTask caching for included builds

### DIFF
--- a/src/main/kotlin/com/autonomousapps/tasks/ArtifactsReportTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ArtifactsReportTask.kt
@@ -11,6 +11,7 @@ import com.autonomousapps.model.PhysicalArtifact
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.artifacts.ArtifactCollection
+import org.gradle.api.capabilities.Capability
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
@@ -52,6 +53,16 @@ abstract class ArtifactsReportTask : DefaultTask() {
   @PathSensitive(PathSensitivity.ABSOLUTE)
   @InputFiles
   fun getClasspathArtifactFiles(): FileCollection = artifacts.artifactFiles
+
+  /**
+   * For included builds the capabilities can reflect actual full dependency project name which
+   * can be different depending on root build project.
+   */
+  @Input
+  fun getClasspathCapabilities(): Set<Capability> = artifacts.asSequence()
+          .filterNonGradle()
+          .flatMap { it.variant.capabilities }
+          .toSet()
 
   /**
    * [PhysicalArtifact]s used to compile or run main source.


### PR DESCRIPTION
## Problem statement
We've observed an issue with our isolated (included) builds: the `projectHealth` was producing illegal advices to remove a dependency - and these advices were breaking the compilation. Worth to mention that problem only happened with cache enabled.

## Root cause analysis
Finally, after debugging it was found that the root problem is in the `ArtifactsReportTask` and it's related to caching. With equal (from the Gradle perspective) task inputs it was reusing inappropriate cached task output from another isolated builds.
The detailed analysis highlighted key differences in generated `build/reports/dependency-analysis/{sourceSet}/intermediates/artifacts.json` file (taken from cache vs no build cache):
* `coordinates.identifier` which can be different depending on current root build project (prefix)
* `coordinates.resolvedProject.gradleVariantIdentification.capabilities` - same - different prefix, depends on current root build project

## Solution
All possible ways to address the problem are to extend the task inputs - the input should be reproducible, but different for different isolated builds. Options considered:
* ~~include root project name as a task input~~ (does not cover all cases)
* ~~include root project full path as a task input~~ (does not cover all cases)
* ~~include relative path from current project to root (like "..") (explained below)~~ (does not cover all cases)
* include variant `capabilities` as task input as they reflect the difference of isolated builds (explained below)

In this PR you can see the root absolute project path as input and there are few comments why this solution seems to be valid:
* the generated `artifacts.json` contains absolute file paths, so it seems to be reasonable to make inputs absolute-path sensitive e.g. to distinguish CI/CD and local builds where such paths are usually different
* the `ArtifactsReportTask` already has an absolute-path sensitive input:
```kotlin
@PathSensitive(PathSensitivity.ABSOLUTE)
@InputFiles
fun getClasspathArtifactFiles(): FileCollection = artifacts.artifactFiles
```

## Additional notes
This seems to be related to https://github.com/autonomousapps/dependency-analysis-gradle-plugin/pull/916 authored by @jjohannes where there was an effort to address the problem. Unfortunately, the task input parameter `buildPath` always has value `":"`, so it's equal input for Gradle - and this fix was not enough.

## Testing
I'm not quite sure how to write a proper functional test scenario for this change, advices are welcome.
This change is validated on our (pretty big) project.

## Alternative solution: relative path to root
Using absolute root path as input is motivated, but still there is an opportunity to declare relative path from current project of task to root project (note: not vice versa). It means, that in most cases such Input parameter will have value like `".."` or `"../.."`. But for included builds it will look like `"../../included/composite-project"`

## Alternative solution: Set<Capability> Input
I'm not quite sure, but perhaps the `capabilities` as input parameter can be an alternative solution:
```kotlin
@Input
fun getClasspathCapabilities(): Set<Capability> = artifacts.asSequence()
    .filterNonGradle()
    .flatMap { it.variant.capabilities }
    .toSet()
```
Elements of this collection are different depending on current root project, the difference is in the field `group` (has specific prefix).
This was an initial implementation that worked pretty well. But I'd like to not to complicate things too early.