### PR TITLE
test: validate that we can ignore the androidTest source set...

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/android/AndroidTestSourceSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AndroidTestSourceSpec.groovy
@@ -3,6 +3,7 @@
 package com.autonomousapps.android
 
 import com.autonomousapps.android.projects.AndroidTestSourceProject
+import com.autonomousapps.android.projects.AndroidTestsAreIgnorableProject
 import org.gradle.util.GradleVersion
 
 import static com.autonomousapps.advice.truth.BuildHealthSubject.buildHealth
@@ -32,6 +33,24 @@ final class AndroidTestSourceSpec extends AbstractAndroidSpec {
   def "kapt is used for android tests (#gradleVersion AGP #agpVersion)"() {
     given:
     def project = new AndroidTestSourceProject(agpVersion as String, true)
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion as GradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertAbout(buildHealth())
+      .that(project.actualBuildHealth())
+      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+
+    where:
+    [gradleVersion, agpVersion] << gradleAgpMatrix()
+  }
+
+  // https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1079
+  def "can ignore androidTest source set (#gradleVersion AGP #agpVersion)"() {
+    given:
+    def project = new AndroidTestsAreIgnorableProject(agpVersion as String)
     gradleProject = project.gradleProject
 
     when:

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidTestsAreIgnorableProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidTestsAreIgnorableProject.groovy
@@ -1,0 +1,58 @@
+package com.autonomousapps.android.projects
+
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.android.AndroidManifest
+import com.autonomousapps.kit.gradle.dependencies.Plugins
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.actualProjectAdvice
+import static com.autonomousapps.AdviceHelper.emptyProjectAdviceFor
+import static com.autonomousapps.kit.gradle.dependencies.Dependencies.commonsCollections
+
+final class AndroidTestsAreIgnorableProject extends AbstractAndroidProject {
+
+  final GradleProject gradleProject
+
+  AndroidTestsAreIgnorableProject(String agpVersion) {
+    super(agpVersion)
+    gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newAndroidGradleProjectBuilder(agpVersion)
+      .withRootProject { r ->
+        r.withBuildScript { bs ->
+          bs.withGroovy(
+            '''\
+            dependencyAnalysis {
+              issues {
+                all {
+                  ignoreSourceSet("androidTest")
+                }
+              }
+            }
+            '''
+          )
+        }
+      }
+      .withAndroidSubproject('lib') { lib ->
+        lib.manifest = AndroidManifest.defaultLib('my.android.lib')
+        lib.withBuildScript { bs ->
+          bs.plugins = [Plugins.androidLib, Plugins.dependencyAnalysisNoVersion]
+          bs.android = defaultAndroidLibBlock(false, 'my.android.lib')
+          bs.dependencies = [
+            commonsCollections('androidTestImplementation'),
+          ]
+        }
+      }
+      .write()
+  }
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  Set<ProjectAdvice> expectedBuildHealth = [
+    emptyProjectAdviceFor(':lib'),
+  ]
+}


### PR DESCRIPTION
...in the same was as we do for JVM source sets.

Resolves https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1079