### PR TITLE
fix: DAGP variants have a Category of 'dependency-analysis'.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/CategorySpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/CategorySpec.groovy
@@ -1,0 +1,22 @@
+package com.autonomousapps.jvm
+
+import com.autonomousapps.jvm.projects.CategoryProject
+
+import static com.autonomousapps.utils.Runner.build
+
+// This passes on Gradle 8.6 and failed on Gradle 8.7 (pre-fix)
+// https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1159
+final class CategorySpec extends AbstractJvmSpec {
+
+  def "project bundles are respected (#gradleVersion)"() {
+    given:
+    def project = new CategoryProject()
+    gradleProject = project.gradleProject
+
+    expect:
+    build(gradleVersion, gradleProject.rootDir, 'testCodeCoverageReport')
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/CategoryProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/CategoryProject.groovy
@@ -1,0 +1,48 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.gradle.Plugin
+
+import static com.autonomousapps.kit.gradle.Dependency.project
+
+final class CategoryProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  CategoryProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newGradleProjectBuilder()
+      .withRootProject { r ->
+        r.withBuildScript { bs ->
+          bs.plugins.addAll(Plugin.javaLibrary, Plugin.jacocoReportAggregation)
+          bs.withGroovy(
+            '''\
+            tasks.named('test', Test) {
+              useJUnitPlatform()
+            }
+            '''
+          )
+          bs.dependencies(
+            project('jacocoAggregation', ':project'),
+          )
+        }
+      }
+      .withSubproject('project') { p ->
+        p.withBuildScript { bs ->
+          bs.plugins = javaLibrary + Plugin.jvmTestSuite
+          bs.withGroovy(
+            '''\
+            tasks.named('test', Test) {
+              useJUnitPlatform()
+            }
+            '''
+          )
+        }
+      }
+      .write()
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/internal/artifacts/DagpArtifacts.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/artifacts/DagpArtifacts.kt
@@ -4,12 +4,20 @@ package com.autonomousapps.internal.artifacts
 
 import org.gradle.api.Named
 import org.gradle.api.attributes.Attribute
+import org.gradle.api.attributes.Category
+import org.gradle.api.model.ObjectFactory
 
 internal interface DagpArtifacts : Named {
   companion object {
     @JvmField val DAGP_ARTIFACTS_ATTRIBUTE: Attribute<DagpArtifacts> = Attribute.of(
       "dagp.internal.artifacts", DagpArtifacts::class.java
     )
+
+    @JvmField val CATEGORY_ATTRIBUTE: Attribute<Category> = Category.CATEGORY_ATTRIBUTE
+
+    fun category(objects: ObjectFactory): Category {
+      return objects.named(Category::class.java, "dependency-analysis")
+    }
   }
 
   enum class Kind(

--- a/src/main/kotlin/com/autonomousapps/internal/artifacts/Publisher.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/artifacts/Publisher.kt
@@ -68,6 +68,10 @@ internal class Publisher<T : Named>(
           attr.attribute,
           project.objects.named(attr.attribute.type, attr.attributeName)
         )
+        attribute(
+          DagpArtifacts.CATEGORY_ATTRIBUTE,
+          DagpArtifacts.category(project.objects)
+        )
       }
     }
 

--- a/src/main/kotlin/com/autonomousapps/internal/artifacts/Resolver.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/artifacts/Resolver.kt
@@ -66,6 +66,10 @@ internal class Resolver<T : Named>(
           attr.attribute,
           project.objects.named(attr.attribute.type, attr.attributeName)
         )
+        attribute(
+          DagpArtifacts.CATEGORY_ATTRIBUTE,
+          DagpArtifacts.category(project.objects)
+        )
       }
     }
 }

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/Plugin.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/Plugin.kt
@@ -59,10 +59,12 @@ public class Plugin @JvmOverloads constructor(
     @JvmStatic public val application: Plugin = Plugin("application")
     @JvmStatic public val groovy: Plugin = Plugin("groovy")
     @JvmStatic public val groovyGradle: Plugin = Plugin("groovy-gradle-plugin")
+    @JvmStatic public val jacocoReportAggregation: Plugin = Plugin("jacoco-report-aggregation")
     @JvmStatic public val java: Plugin = Plugin("java")
     @JvmStatic public val javaGradle: Plugin = Plugin("java-gradle-plugin")
     @JvmStatic public val javaLibrary: Plugin = Plugin("java-library")
     @JvmStatic public val javaTestFixtures: Plugin = Plugin("java-test-fixtures")
+    @JvmStatic public val jvmTestSuite: Plugin = Plugin("jvm-test-suite")
     @JvmStatic public val scala: Plugin = Plugin("scala")
     @JvmStatic public val war: Plugin = Plugin("war")
   }


### PR DESCRIPTION
Resolves https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1159