### PR TITLE
#1114 print build path in projectHealth

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/ProjectHealthSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/ProjectHealthSpec.groovy
@@ -1,0 +1,32 @@
+// Copyright (c) 2024. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.jvm
+
+import com.autonomousapps.jvm.projects.AbiGenericsProject
+import com.autonomousapps.jvm.projects.AbiGenericsProject.SourceKind
+
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertThat
+
+final class ProjectHealthSpec extends AbstractJvmSpec {
+
+  def "projectHealth prints build file path (#gradleVersion)"() {
+    given:
+    def project = new AbiGenericsProject(SourceKind.METHOD)
+    gradleProject = project.gradleProject
+
+    when:
+    def result = build(gradleVersion, gradleProject.rootDir, 'projectHealth')
+
+    then:
+    assertThat(result.output).contains(
+      """${gradleProject.rootDir.getPath()}/proj/build.gradle
+        |Existing dependencies which should be modified to be as indicated:
+        |  api project(':genericsBar') (was implementation)
+        |  api project(':genericsFoo') (was implementation)
+        |""".stripMargin())
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
@@ -931,6 +931,7 @@ internal class ProjectPlugin(private val project: Project) {
     }
 
     tasks.register<ProjectHealthTask>("projectHealth") {
+      buildFilePath.set(project.buildFile.path)
       projectAdvice.set(filterAdviceTask.flatMap { it.output })
       consoleReport.set(generateProjectHealthReport.flatMap { it.output })
     }

--- a/src/main/kotlin/com/autonomousapps/tasks/ProjectHealthTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ProjectHealthTask.kt
@@ -8,6 +8,8 @@ import com.autonomousapps.internal.utils.fromJson
 import com.autonomousapps.model.ProjectAdvice
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -19,6 +21,9 @@ abstract class ProjectHealthTask : DefaultTask() {
     group = TASK_GROUP_DEP
     description = "Prints advice for this project"
   }
+
+  @get:Input
+  abstract val buildFilePath: Property<String>
 
   @get:PathSensitive(PathSensitivity.NONE)
   @get:InputFile
@@ -34,9 +39,13 @@ abstract class ProjectHealthTask : DefaultTask() {
 
     if (projectAdvice.shouldFail) {
       check(consoleReport.isNotBlank()) { "Console report should not be blank if projectHealth should fail" }
-      throw BuildHealthException(consoleReport)
+      throw BuildHealthException(prependBuildPath(consoleReport))
     } else if (consoleReport.isNotBlank()) {
-      logger.quiet(consoleReport)
+      logger.quiet(prependBuildPath(consoleReport))
     }
+  }
+
+  private fun prependBuildPath(consoleReport: String): String {
+    return "${buildFilePath.get()}\n$consoleReport"
   }
 }


### PR DESCRIPTION
Solves #1114 (only `projectHealth`, but not `buildHealth`).
Prints absolute path of according `build.gradle` of the project module. This can be pretty helpful in large multi-module projects, especially when there is no full matching between module name and submodule directory.

Sample task output:
```
> Task :utilities:projectHealth
/Users/morph/Projects/demo-gradle-multi-module/utilities/build.gradle
Unused dependencies which should be removed:
  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
```

## Using absolute path
The absolute path is printed intentionally as it seems to be the best trade-off.
This path is recognized in IDEA to open file in "Navigate to File...":
<img width="674" alt="Screenshot 2024-04-27 at 19 25 50" src="https://github.com/autonomousapps/dependency-analysis-gradle-plugin/assets/2844909/68ce483d-6ee0-4c5c-b8c5-f392c94d1115">
For instance, if relative path is used, there can be ambiguity:
<img width="693" alt="Screenshot 2024-04-27 at 19 26 10" src="https://github.com/autonomousapps/dependency-analysis-gradle-plugin/assets/2844909/9aa48f3d-66e9-4f6d-b34d-be838fd0d3eb">
Also, the relative path is not always in parent directory (for included builds) and printing "../../parent/build.gradle" will not help navigating to the file in the IDE.
