### PR TITLE
Update test kit to use minSdk, targetSdk, compileSdk, and an equals after applicationId and namespace

### DIFF
--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/android/AndroidBlock.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/android/AndroidBlock.kt
@@ -50,13 +50,13 @@ public class AndroidBlock @JvmOverloads constructor(
   private fun renderKotlin(scribe: Scribe): String = scribe.block(this) { s ->
     if (namespace != null) {
       s.line {
-        it.append("namespace \"")
+        it.append("namespace = \"")
         it.append(namespace)
         it.append("\"")
       }
     }
     s.line {
-      it.append("compileSdkVersion = ")
+      it.append("compileSdk = ")
       it.append(compileSdkVersion)
     }
     defaultConfig.render(s)

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/android/DefaultConfig.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/android/DefaultConfig.kt
@@ -68,16 +68,16 @@ public class DefaultConfig @JvmOverloads constructor(
   private fun renderKotlin(scribe: Scribe): String = scribe.block(this) { s ->
     if (applicationId != null) {
       s.line {
-        it.append("applicationId ")
+        it.append("applicationId = ")
         it.appendQuoted(applicationId)
       }
     }
     s.line {
-      it.append("minSdkVersion = ")
+      it.append("minSdk = ")
       it.append(minSdkVersion)
     }
     s.line {
-      it.append("targetSdkVersion = ")
+      it.append("targetSdk = ")
       it.append(targetSdkVersion)
     }
     s.line {

--- a/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestKotlin.kt
+++ b/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestKotlin.kt
@@ -498,12 +498,12 @@ internal class ScribeTestKotlin {
           version = "$version"
           
           android {
-            namespace "ankh.morpork"
-            compileSdkVersion = 34
+            namespace = "ankh.morpork"
+            compileSdk = 34
             defaultConfig {
-              applicationId "com.example"
-              minSdkVersion = 21
-              targetSdkVersion = 29
+              applicationId = "com.example"
+              minSdk = 21
+              targetSdk = 29
               versionCode = 1
               versionName = "1.0"
             }


### PR DESCRIPTION
I was using testkit to create an android project locally, and I didn't see anyway to overwrite the default values for the `android` block.