### PR TITLE
test: reproduces issue 947

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/CustomSourceSetSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/CustomSourceSetSpec.groovy
@@ -191,9 +191,25 @@ final class CustomSourceSetSpec extends AbstractJvmSpec {
     )
   }
 
-  def "don't suggest moving a dependency from one feature variant to another"() {
+  def "don't suggest moving a dependency from one feature variant to another (#gradleVersion)"() {
     given:
     def project = new FeatureVariantInConsumerTestProject()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+
+  // https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/947
+  def "different versions of same dependency in different source sets are analyzed individually (#gradleVersion)"() {
+    given:
+    def project = new MultiDepSourceSetProject()
     gradleProject = project.gradleProject
 
     when:

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/MultiDepSourceSetProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/MultiDepSourceSetProject.groovy
@@ -1,0 +1,87 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.gradle.Dependency
+import com.autonomousapps.kit.gradle.Feature
+import com.autonomousapps.kit.gradle.Java
+import com.autonomousapps.model.Advice
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.*
+import static com.autonomousapps.kit.gradle.Dependency.implementation
+
+/**
+ * @see <a href="https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/947">Issue 947</a>
+ */
+final class MultiDepSourceSetProject extends AbstractProject {
+
+  private final Dependency okio380 = implementation('com.squareup.okio:okio:3.8.0')
+  private final Dependency okio390 = new Dependency('extraApi', 'com.squareup.okio:okio:3.9.0')
+
+  final GradleProject gradleProject
+
+  MultiDepSourceSetProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newGradleProjectBuilder()
+      .withSubproject('proj') { s ->
+        s.sources = consumerSources
+        s.withBuildScript { bs ->
+          bs.plugins = javaLibrary
+          bs.java = Java.ofFeatures(Feature.ofName('extra'))
+          bs.dependencies = [okio380, okio390]
+        }
+      }
+      .write()
+  }
+
+  private consumerSources = [
+    Source
+      .java(
+        '''
+          package com.example;
+          
+          import okio.Buffer;
+          
+          public class Project {
+            // implementation but should be api (bc public)
+            public Buffer buffer;
+          }
+        '''.stripIndent()
+      )
+      .withPath('com.example', 'Project')
+      .build(),
+    Source
+      .java(
+        '''
+          package com.example.extra;
+          
+          import okio.Buffer;
+          
+          public class Extra {
+            // extraApi but should be extraImplementation (bc private)
+            private Buffer buffer;
+          }
+        '''.stripIndent()
+      )
+      .withPath('com.example.extra', 'Extra')
+      .build(),
+  ]
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  private final Set<Advice> expectedAdvice = [
+    Advice.ofChange(moduleCoordinates(okio380), 'implementation', 'api'),
+    Advice.ofChange(moduleCoordinates(okio390), 'extraApi', 'extraImplementation'),
+  ]
+
+  final Set<ProjectAdvice> expectedBuildHealth = [
+    projectAdviceForDependencies(':proj', expectedAdvice),
+  ]
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/MultiDepSourceSetProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/MultiDepSourceSetProject.groovy
@@ -68,6 +68,7 @@ final class MultiDepSourceSetProject extends AbstractProject {
           }
         '''.stripIndent()
       )
+      .withSourceSet("extra")
       .withPath('com.example.extra', 'Extra')
       .build(),
   ]


### PR DESCRIPTION
https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/947

This test currently fails, producing this erroneous advice:
```
> Task :buildHealth
Advice for :proj
Unused dependencies which should be removed:
  extraApi 'com.squareup.okio:okio:3.9.0'
```

DAGP is suggesting removing the dep on the "extra" source-set's dependency. The main source set depends on v3.8.0. This would lead to a compilation error.