### PR TITLE
Avoid cross-project access of the 'group' property

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TestFixturesTestProject2.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TestFixturesTestProject2.groovy
@@ -105,7 +105,7 @@ final class TestFixturesTestProject2 extends AbstractProject {
   private final Set<Advice> expectedConsumerAdvice() {
     [
       Advice.ofChange(projectCoordinates(producerProjectPath), 'api', 'implementation'),
-      Advice.ofRemove(projectCoordinates(producerProjectPath, 'org.example.producer:producer-test-fixtures'), 'api')
+      Advice.ofRemove(projectCoordinates(producerProjectPath, ':producer-test-fixtures'), 'api')
     ]
   }
 

--- a/src/main/kotlin/com/autonomousapps/internal/utils/gradleStrings.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/gradleStrings.kt
@@ -4,6 +4,7 @@ package com.autonomousapps.internal.utils
 
 import com.autonomousapps.internal.GradleVersions
 import com.autonomousapps.model.*
+import com.autonomousapps.model.GradleVariantIdentification.Companion.ROOT
 import org.gradle.api.GradleException
 import org.gradle.api.artifacts.*
 import org.gradle.api.artifacts.Dependency
@@ -22,6 +23,7 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
 import org.gradle.api.provider.Provider
+import org.gradle.internal.component.external.model.ProjectDerivedCapability
 import org.gradle.internal.component.local.model.OpaqueComponentArtifactIdentifier
 import org.gradle.internal.component.local.model.OpaqueComponentIdentifier
 import java.io.File
@@ -98,7 +100,7 @@ internal fun Configuration.rootCoordinates(): Coordinates = incoming.resolutionR
 internal fun ResolvedComponentResult.rootCoordinates(): Coordinates {
   return id
     // For the root, the 'GradleVariantIdentification' is always empty as there is only one root (which we match later)
-    .toCoordinates(GradleVariantIdentification(setOf("ROOT"), emptyMap()))
+    .toCoordinates(GradleVariantIdentification(ROOT, emptyMap()))
 }
 
 /** Converts this [ComponentIdentifier] to group-artifact-version (GAV) coordinates in a tuple of (GA, V?). */
@@ -300,4 +302,7 @@ internal fun ResolvedVariantResult?.toGradleVariantIdentification(): GradleVaria
   )
 }
 
-private fun Capability.toGA() = "$group:$name".intern()
+private fun Capability.toGA() = when(this) {
+  is ProjectDerivedCapability -> ":$name".intern()
+  else -> "$group:$name".intern()
+}

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeDominatorTreeTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeDominatorTreeTask.kt
@@ -17,6 +17,7 @@ import com.autonomousapps.internal.utils.fromJson
 import com.autonomousapps.internal.utils.fromJsonSet
 import com.autonomousapps.internal.utils.getAndDelete
 import com.autonomousapps.model.*
+import com.autonomousapps.model.GradleVariantIdentification.Companion.ROOT
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
@@ -148,7 +149,7 @@ abstract class ComputeDominatorTreeTask : DefaultTask() {
       }
 
       val graphView = graphView.fromJson<DependencyGraphView>()
-      val project = ProjectCoordinates(projectPath.get(), GradleVariantIdentification(setOf("ROOT"), emptyMap()), ":")
+      val project = ProjectCoordinates(projectPath.get(), GradleVariantIdentification(ROOT, emptyMap()), ":")
       val tree = DominanceTree(graphView.graph, project)
 
       val nodeWriter = BySize(

--- a/src/main/kotlin/com/autonomousapps/tasks/ReasonTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ReasonTask.kt
@@ -8,6 +8,7 @@ import com.autonomousapps.internal.reason.DependencyAdviceExplainer
 import com.autonomousapps.internal.reason.ModuleAdviceExplainer
 import com.autonomousapps.internal.utils.*
 import com.autonomousapps.model.*
+import com.autonomousapps.model.GradleVariantIdentification.Companion.ROOT
 import com.autonomousapps.model.intermediates.BundleTrace
 import com.autonomousapps.model.intermediates.Usage
 import org.gradle.api.DefaultTask
@@ -183,7 +184,7 @@ abstract class ReasonTask @Inject constructor(
 
     override fun execute() {
       val reason = DependencyAdviceExplainer(
-        project = ProjectCoordinates(projectPath, GradleVariantIdentification(setOf("ROOT"), emptyMap()), ":"),
+        project = ProjectCoordinates(projectPath, GradleVariantIdentification(ROOT, emptyMap()), ":"),
         requestedId = requestedCoord,
         target = coord,
         usages = usages,


### PR DESCRIPTION
We need to do special handling for "capabilities without group" already. So this works along these lines and makes the plugin (more) compatible with project isolation (#1091).