### PR TITLE
Sort output of findDeclarations

### DIFF
--- a/src/main/kotlin/com/autonomousapps/tasks/FindDeclarationsTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindDeclarationsTask.kt
@@ -114,6 +114,8 @@ abstract class FindDeclarationsTask : DefaultTask() {
             )
           }
         }
+        .sortedWith(compareBy<Declaration> { it.configurationName }
+          .thenComparing { it -> it.identifier })
         .toSet()
     }
   }


### PR DESCRIPTION
## Reason behind this change

The result of `findDeclarations` task is reproducible if inputs are not changed.
But while debugging there is needed to compare task output (JSON pretty print reformat first) between different executions and it's not convenient to compare non-ordered elements.