### PR TITLE
Sort output of graphView and findDeclarations

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/graph/GraphViewBuilder.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/graph/GraphViewBuilder.kt
@@ -61,11 +61,15 @@ internal class GraphViewBuilder(
       .filterNot { it.isJavaPlatform() }
       // Sometimes there is a self-dependency?
       .filterNot { it.toCoordinates() == rootId }
-      .forEach { dependencyResult ->
+      .map {
         // Might be from an included build, in which case the coordinates reflect the _requested_ dependency instead of
         // the _resolved_ dependency.
-        val depId = dependencyResult.toCoordinates()
-
+        Pair(it, it.toCoordinates())
+      }
+      // make reproducible output friendly to compare between executions
+      .sortedWith(compareBy<Pair<ResolvedDependencyResult, Coordinates>> { pair -> pair.second.javaClass.simpleName }
+        .thenComparing { pair -> pair.second.identifier })
+      .forEach { (dependencyResult, depId) ->
         // add an edge
         graphBuilder.putEdge(rootId, depId)
 

--- a/src/main/kotlin/com/autonomousapps/tasks/FindDeclarationsTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindDeclarationsTask.kt
@@ -114,6 +114,8 @@ abstract class FindDeclarationsTask : DefaultTask() {
             )
           }
         }
+        .sortedWith(compareBy<Declaration> { it.configurationName }
+          .thenComparing { it -> it.identifier })
         .toSet()
     }
   }


### PR DESCRIPTION
## Reason behind this change

The result of `findDeclarations` and `graphViewX` tasks should be reproducible if inputs are not changed.
Also while debugging there is needed to compare task output (JSON pretty print reformat first) between different executions and it's not convenient to compare non-ordered elements.