### PR TITLE
Add latest AGP versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,9 @@ agp = "8.0.2"
 #agp = "8.1.4
 #agp = "8.2.1"
 #agp = "8.3.2" # Provides `Sources.manifests`
-#agp = "8.4.1"
+#agp = "8.4.2"
+#agp = "8.5.0
+#agp = "8.6.0-alpha05"
 agp-common = "31.2.0"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ agp = "8.0.2"
 #agp = "8.3.2" # Provides `Sources.manifests`
 #agp = "8.4.2"
 #agp = "8.5.0
-#agp = "8.6.0-alpha05"
+#agp = "8.6.0-alpha06"
 agp-common = "31.2.0"
 
 [libraries]

--- a/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
@@ -20,7 +20,7 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
   protected static final AGP_8_3 = AgpVersion.version('8.3.2')
   protected static final AGP_8_4 = AgpVersion.version('8.4.2')
   protected static final AGP_8_5 = AgpVersion.version('8.5.0')
-  protected static final AGP_8_6 = AgpVersion.version('8.6.0-alpha05')
+  protected static final AGP_8_6 = AgpVersion.version('8.6.0-alpha06')
 
   protected static final AGP_LATEST = AGP_8_6
 

--- a/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
@@ -18,15 +18,17 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
   protected static final AGP_8_1 = AgpVersion.version('8.1.4')
   protected static final AGP_8_2 = AgpVersion.version('8.2.0')
   protected static final AGP_8_3 = AgpVersion.version('8.3.2')
-  protected static final AGP_8_4 = AgpVersion.version('8.4.1')
+  protected static final AGP_8_4 = AgpVersion.version('8.4.2')
+  protected static final AGP_8_5 = AgpVersion.version('8.5.0')
+  protected static final AGP_8_6 = AgpVersion.version('8.6.0-alpha05')
 
-  protected static final AGP_LATEST = AGP_8_4
+  protected static final AGP_LATEST = AGP_8_6
 
   /**
    * TODO(tsr): this doc is perpetually out of date.
    *
-   * {@code AGP_8_0} represents the minimum stable _tested_ version. {@code AGP_8_1} represents the maximum stable
-   * _tested_ version. We also test against the latest alpha, {@code AGP_8_2} at time of writing. DAGP may work with
+   * {@code AGP_8_0} represents the minimum stable _tested_ version. {@code AGP_8_5} represents the maximum stable
+   * _tested_ version. We also test against the latest alpha, {@code AGP_8_6} at time of writing. DAGP may work with
    * other versions of AGP, but they aren't tested, primarily for CI performance reasons.
    *
    * @see <a href="https://maven.google.com/web/index.html?q=build#com.android.tools.build:gradle">AGP releases</a>
@@ -37,6 +39,7 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
     AGP_8_2,
     AGP_8_3,
     AGP_8_4,
+    AGP_8_5,
   ]
 
   protected static List<AgpVersion> agpVersions(AgpVersion minAgpVersion = AgpVersion.AGP_MIN) {

--- a/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
@@ -40,6 +40,7 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
     AGP_8_3,
     AGP_8_4,
     AGP_8_5,
+    AGP_8_6,
   ]
 
   protected static List<AgpVersion> agpVersions(AgpVersion minAgpVersion = AgpVersion.AGP_MIN) {

--- a/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
@@ -15,7 +15,7 @@ internal class AgpVersion private constructor(val version: String) : Comparable<
   companion object {
 
     @JvmStatic val AGP_MIN = version("8.0.0")
-    @JvmStatic val AGP_MAX = version("8.4.1")
+    @JvmStatic val AGP_MAX = version("8.5.0")
 
     @JvmStatic fun current(): AgpVersion = AgpVersion(agpVersion())
     @JvmStatic fun version(version: String): AgpVersion = AgpVersion(version)


### PR DESCRIPTION
This PR adds the latest AGP versions:
- Bump AGP 8.4.x to 8.4.2.
- Add AGP 8.5.0, and mark it as the latest supported version.
- Add AGP 8.6.0-alpha06, and mark it as the latest APG version.