### PR TITLE
Update latest tested AGP version to 8.6.0-beta01

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ agp = "8.0.2"
 #agp = "8.3.2" # Provides `Sources.manifests`
 #agp = "8.4.2"
 #agp = "8.5.0
-#agp = "8.6.0-alpha06"
+#agp = "8.6.0-beta01"
 agp-common = "31.2.0"
 
 [libraries]

--- a/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
@@ -20,7 +20,7 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
   protected static final AGP_8_3 = AgpVersion.version('8.3.2')
   protected static final AGP_8_4 = AgpVersion.version('8.4.2')
   protected static final AGP_8_5 = AgpVersion.version('8.5.0')
-  protected static final AGP_8_6 = AgpVersion.version('8.6.0-alpha06')
+  protected static final AGP_8_6 = AgpVersion.version('8.6.0-beta01')
 
   protected static final AGP_LATEST = AGP_8_6
 


### PR DESCRIPTION
This PR bumps the latest tested AGP version from 8.6.0-alpha06 to 8.6.0-beta01.