### PR TITLE
Update latest stable AGP version to 8.5.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ agp = "8.0.2"
 #agp = "8.2.1"
 #agp = "8.3.2" # Provides `Sources.manifests`
 #agp = "8.4.2"
-#agp = "8.5.0
+#agp = "8.5.1"
 #agp = "8.6.0-beta01"
 agp-common = "31.2.0"
 

--- a/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
@@ -19,7 +19,7 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
   protected static final AGP_8_2 = AgpVersion.version('8.2.0')
   protected static final AGP_8_3 = AgpVersion.version('8.3.2')
   protected static final AGP_8_4 = AgpVersion.version('8.4.2')
-  protected static final AGP_8_5 = AgpVersion.version('8.5.0')
+  protected static final AGP_8_5 = AgpVersion.version('8.5.1')
   protected static final AGP_8_6 = AgpVersion.version('8.6.0-beta01')
 
   protected static final AGP_LATEST = AGP_8_6

--- a/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
@@ -15,7 +15,7 @@ internal class AgpVersion private constructor(val version: String) : Comparable<
   companion object {
 
     @JvmStatic val AGP_MIN = version("8.0.0")
-    @JvmStatic val AGP_MAX = version("8.5.0")
+    @JvmStatic val AGP_MAX = version("8.5.1")
 
     @JvmStatic fun current(): AgpVersion = AgpVersion(agpVersion())
     @JvmStatic fun version(version: String): AgpVersion = AgpVersion(version)


### PR DESCRIPTION
This PR updates to the latest stable version of AGP: 8.5.1.
The release notes are available here: https://developer.android.com/studio/releases/fixed-bugs/studio/2024.1.1#android-studio-koala-|-2024.1.1-patch-1