### PR TITLE
Test against AGP 8.7.0-alpha06

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ agp = "8.0.2"
 #agp = "8.4.2"
 #agp = "8.5.2"
 #agp = "8.6.0-rc01"
-#agp = "8.7.0-alpha04"
+#agp = "8.7.0-alpha05"
 agp-common = "31.2.0"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ agp = "8.0.2"
 #agp = "8.4.2"
 #agp = "8.5.2"
 #agp = "8.6.0-beta01"
-#agp = "8.7.0-alpha01"
+#agp = "8.7.0-alpha02"
 agp-common = "31.2.0"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ agp = "8.0.2"
 #agp = "8.3.2" # Provides `Sources.manifests`
 #agp = "8.4.2"
 #agp = "8.5.2"
-#agp = "8.6.0-beta01"
+#agp = "8.6.0-beta02"
 #agp = "8.7.0-alpha02"
 agp-common = "31.2.0"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ agp = "8.0.2"
 #agp = "8.4.2"
 #agp = "8.5.2"
 #agp = "8.6.0-beta01"
+#agp = "8.7.0-alpha01"
 agp-common = "31.2.0"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,8 +26,8 @@ agp = "8.0.2"
 #agp = "8.3.2" # Provides `Sources.manifests`
 #agp = "8.4.2"
 #agp = "8.5.2"
-#agp = "8.6.0-beta02"
-#agp = "8.7.0-alpha02"
+#agp = "8.6.0-rc01"
+#agp = "8.7.0-alpha04"
 agp-common = "31.2.0"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,13 +21,6 @@ spock = "2.3-groovy-3.0"
 truth = "1.4.2"
 
 agp = "8.0.2"
-#agp = "8.1.4
-#agp = "8.2.1"
-#agp = "8.3.2" # Provides `Sources.manifests`
-#agp = "8.4.2"
-#agp = "8.5.2"
-#agp = "8.6.0-rc01"
-#agp = "8.7.0-alpha05"
 agp-common = "31.2.0"
 
 [libraries]

--- a/src/functionalTest/groovy/com/autonomousapps/AbstractFunctionalSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/AbstractFunctionalSpec.groovy
@@ -21,12 +21,14 @@ abstract class AbstractFunctionalSpec extends Specification {
   protected static final GRADLE_8_5 = GradleVersion.version('8.5')
   protected static final GRADLE_8_6 = GradleVersion.version('8.6')
   protected static final GRADLE_8_7 = GradleVersion.version('8.7')
+  protected static final GRADLE_8_8 = GradleVersion.version('8.8')
+  protected static final GRADLE_8_9 = GradleVersion.version('8.9')
 
   // For faster CI times, we only test min + max. Testing all would be preferable, but we don't have till the heat death
   // of the universe.
   protected static final SUPPORTED_GRADLE_VERSIONS = [
     GradleVersions.minGradleVersion,
-    GRADLE_8_7,
+    GRADLE_8_9,
   ]
 
   protected GradleProject gradleProject = null

--- a/src/functionalTest/groovy/com/autonomousapps/AbstractFunctionalSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/AbstractFunctionalSpec.groovy
@@ -46,7 +46,16 @@ abstract class AbstractFunctionalSpec extends Specification {
   }
 
   protected static boolean isCompatible(GradleVersion gradleVersion, AgpVersion agpVersion) {
-    if (agpVersion >= AgpVersion.version('8.2.0')) {
+    // See https://developer.android.com/build/releases/gradle-plugin#updating-gradle
+    if (agpVersion >= AgpVersion.version('8.7.0')) {
+      return gradleVersion >= GradleVersion.version('8.9')
+    } else if (agpVersion >= AgpVersion.version('8.5.0')) {
+      return gradleVersion >= GradleVersion.version('8.7')
+    } else if (agpVersion >= AgpVersion.version('8.4.0')) {
+      return gradleVersion >= GradleVersion.version('8.6')
+    } else if (agpVersion >= AgpVersion.version('8.3.0')) {
+      return gradleVersion >= GradleVersion.version('8.4')
+    } else if (agpVersion >= AgpVersion.version('8.2.0')) {
       return gradleVersion >= GradleVersion.version('8.1')
     } else if (agpVersion >= AgpVersion.version('8.0.0')) {
       return gradleVersion >= GradleVersion.version('8.0')

--- a/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
@@ -21,7 +21,7 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
   protected static final AGP_8_4 = AgpVersion.version('8.4.2')
   protected static final AGP_8_5 = AgpVersion.version('8.5.2')
   protected static final AGP_8_6 = AgpVersion.version('8.6.0-rc01')
-  protected static final AGP_8_7 = AgpVersion.version('8.7.0-alpha04')
+  protected static final AGP_8_7 = AgpVersion.version('8.7.0-alpha05')
 
   protected static final AGP_LATEST = AGP_8_7
 

--- a/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
@@ -20,8 +20,8 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
   protected static final AGP_8_3 = AgpVersion.version('8.3.2')
   protected static final AGP_8_4 = AgpVersion.version('8.4.2')
   protected static final AGP_8_5 = AgpVersion.version('8.5.2')
-  protected static final AGP_8_6 = AgpVersion.version('8.6.0-beta02')
-  protected static final AGP_8_7 = AgpVersion.version('8.7.0-alpha02')
+  protected static final AGP_8_6 = AgpVersion.version('8.6.0-rc01')
+  protected static final AGP_8_7 = AgpVersion.version('8.7.0-alpha04')
 
   protected static final AGP_LATEST = AGP_8_7
 

--- a/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
@@ -20,7 +20,7 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
   protected static final AGP_8_3 = AgpVersion.version('8.3.2')
   protected static final AGP_8_4 = AgpVersion.version('8.4.2')
   protected static final AGP_8_5 = AgpVersion.version('8.5.2')
-  protected static final AGP_8_6 = AgpVersion.version('8.6.0-beta01')
+  protected static final AGP_8_6 = AgpVersion.version('8.6.0-beta02')
   protected static final AGP_8_7 = AgpVersion.version('8.7.0-alpha02')
 
   protected static final AGP_LATEST = AGP_8_7

--- a/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
@@ -21,7 +21,7 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
   protected static final AGP_8_4 = AgpVersion.version('8.4.2')
   protected static final AGP_8_5 = AgpVersion.version('8.5.2')
   protected static final AGP_8_6 = AgpVersion.version('8.6.0-rc01')
-  protected static final AGP_8_7 = AgpVersion.version('8.7.0-alpha05')
+  protected static final AGP_8_7 = AgpVersion.version('8.7.0-alpha06')
 
   protected static final AGP_LATEST = AGP_8_7
 

--- a/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
@@ -36,12 +36,7 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
    */
   protected static final SUPPORTED_AGP_VERSIONS = [
     AGP_8_0,
-    AGP_8_1,
-    AGP_8_2,
-    AGP_8_3,
-    AGP_8_4,
     AGP_8_5,
-    AGP_8_6,
     AGP_8_7,
   ]
 

--- a/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
@@ -8,7 +8,7 @@ import com.autonomousapps.internal.android.AgpVersion
 import org.gradle.util.GradleVersion
 
 /**
- * @see <a href="https://maven.google.com/web/m_index.html?q=com.android.tools.build#com.android.tools.build:gradle">AGP artifacts</a>
+ * @see <a href="https://maven.google.com/web/index.html?#com.android.tools.build:gradle">AGP artifacts</a>
  */
 abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
 
@@ -32,7 +32,7 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
    * _tested_ version. We also test against the latest alpha, {@code AGP_8_7} at time of writing. DAGP may work with
    * other versions of AGP, but they aren't tested, primarily for CI performance reasons.
    *
-   * @see <a href="https://maven.google.com/web/index.html?q=build#com.android.tools.build:gradle">AGP releases</a>
+   * @see <a href="https://maven.google.com/web/index.html?#com.android.tools.build:gradle">AGP releases</a>
    */
   protected static final SUPPORTED_AGP_VERSIONS = [
     AGP_8_0,

--- a/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
@@ -21,14 +21,15 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
   protected static final AGP_8_4 = AgpVersion.version('8.4.2')
   protected static final AGP_8_5 = AgpVersion.version('8.5.2')
   protected static final AGP_8_6 = AgpVersion.version('8.6.0-beta01')
+  protected static final AGP_8_7 = AgpVersion.version('8.7.0-alpha01')
 
-  protected static final AGP_LATEST = AGP_8_6
+  protected static final AGP_LATEST = AGP_8_7
 
   /**
    * TODO(tsr): this doc is perpetually out of date.
    *
    * {@code AGP_8_0} represents the minimum stable _tested_ version. {@code AGP_8_5} represents the maximum stable
-   * _tested_ version. We also test against the latest alpha, {@code AGP_8_6} at time of writing. DAGP may work with
+   * _tested_ version. We also test against the latest alpha, {@code AGP_8_7} at time of writing. DAGP may work with
    * other versions of AGP, but they aren't tested, primarily for CI performance reasons.
    *
    * @see <a href="https://maven.google.com/web/index.html?q=build#com.android.tools.build:gradle">AGP releases</a>
@@ -41,6 +42,7 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
     AGP_8_4,
     AGP_8_5,
     AGP_8_6,
+    AGP_8_7,
   ]
 
   protected static List<AgpVersion> agpVersions(AgpVersion minAgpVersion = AgpVersion.AGP_MIN) {

--- a/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
@@ -21,7 +21,7 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
   protected static final AGP_8_4 = AgpVersion.version('8.4.2')
   protected static final AGP_8_5 = AgpVersion.version('8.5.2')
   protected static final AGP_8_6 = AgpVersion.version('8.6.0-beta01')
-  protected static final AGP_8_7 = AgpVersion.version('8.7.0-alpha01')
+  protected static final AGP_8_7 = AgpVersion.version('8.7.0-alpha02')
 
   protected static final AGP_LATEST = AGP_8_7
 

--- a/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
@@ -6,7 +6,7 @@ import com.android.Version
 import com.autonomousapps.internal.utils.VersionNumber
 
 /**
- * @see <a href="https://maven.google.com/web/m_index.html?q=com.android.tools.build#com.android.tools.build:gradle">AGP artifacts</a>
+ * @see <a href="https://maven.google.com/web/index.html?#com.android.tools.build:gradle">AGP artifacts</a>
  */
 internal class AgpVersion private constructor(val version: String) : Comparable<AgpVersion> {
 


### PR DESCRIPTION
This PR updates the 8.6.0 branch to rc01, and adds the 8.7.0 branch of AGP to the test matrix.