### PR TITLE
Fix `test.yml` workflow reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,13 +91,14 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: `❌ ${{ github.workflow }} workflow failed:
-            
+
                 * Root buildHealth         : ${{ steps.gradle-buildhealth.outputs.build-scan-url }}
-                * TestKit buildHealth      : ${{ steps.gradle-testkit-buildhealth.outputs.build-scan-url }}`
+                * TestKit buildHealth      : ${{ steps.gradle-testkit-buildhealth.outputs.build-scan-url }}
                 * Non-functional tests     : ${{ steps.gradle-test.outputs.build-scan-url }}
                 * TestKit check            : ${{ steps.gradle-testkit-check.outputs.build-scan-url }}
                 * JVM functional tests     : ${{ steps.gradle-jvm-check.outputs.build-scan-url }}
                 * Android functional tests : ${{ steps.gradle-android-check.outputs.build-scan-url }}
+                `
             })
 
       - name: Publish snapshot


### PR DESCRIPTION
This PR fixes a small issue introduced in https://github.com/autonomousapps/dependency-analysis-gradle-plugin/pull/1218

Currently, the `Maybe add Build Scan URLs as PR comment` step may fail with the following error:
<img width="1109" alt="Screenshot 2024-07-25 at 13 43 09" src="https://github.com/user-attachments/assets/855674a6-8c22-43b8-a5df-ab5e71849c9e">
