### PR TITLE
fix: when building 'dependencyUsages', merge usages of the same dependency at different versions.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/BundleSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/BundleSpec.groovy
@@ -71,7 +71,7 @@ final class BundleSpec extends AbstractJvmSpec {
 
     // TODO reason needs to be updated to show that the -jvm variant is used
     expect:
-    build(gradleVersion, gradleProject.rootDir, ':consumer:reason', '--id', 'com.squareup.okio:okio')
+    build(gradleVersion, gradleProject.rootDir, ':consumer:reason', '--id', 'com.squareup.okio:okio:3.0.0')
 
     where:
     gradleVersion << [GradleVersion.current()]

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/TestDuplicatedDependenciesSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/TestDuplicatedDependenciesSpec.groovy
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.jvm
 
+import com.autonomousapps.jvm.projects.ClasspathConfusionProject
 import com.autonomousapps.jvm.projects.DuplicatedDependenciesProject
 
 import static com.autonomousapps.utils.Runner.build
@@ -16,6 +17,26 @@ final class TestDuplicatedDependenciesSpec extends AbstractJvmSpec {
 
     when:
     build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+
+  def "don't suggest removing test dependency which is also on main classpath (#gradleVersion)"() {
+    given:
+    def project = new ClasspathConfusionProject()
+    gradleProject = project.gradleProject
+
+    when:
+    build(
+      gradleVersion,
+      gradleProject.rootDir,
+      'buildHealth',
+      ':consumer:reason', '--id', 'org.apache.commons:commons-collections4:4.4'
+    )
 
     then:
     assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/ClasspathConfusionProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/ClasspathConfusionProject.groovy
@@ -1,0 +1,93 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.gradle.Dependency
+import com.autonomousapps.model.Advice
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.actualProjectAdvice
+import static com.autonomousapps.AdviceHelper.moduleCoordinates
+import static com.autonomousapps.AdviceHelper.projectAdviceForDependencies
+import static com.autonomousapps.kit.gradle.Dependency.project
+
+final class ClasspathConfusionProject extends AbstractProject {
+
+  private static final oldCommonsCollectionsApi = new Dependency(
+    'api',
+    'org.apache.commons:commons-collections4:4.3'
+  )
+  private static final commonsCollectionsTestImplementation = new Dependency(
+    'testImplementation',
+    'org.apache.commons:commons-collections4:4.4'
+  )
+
+  final GradleProject gradleProject
+
+  ClasspathConfusionProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newGradleProjectBuilder()
+      .withSubproject('consumer') { s ->
+        s.sources = consumerSources
+        s.withBuildScript { bs ->
+          bs.plugins = javaLibrary
+          bs.dependencies = [
+            // Brings along a different version of commons collections on main classpath
+            project('implementation', ':producer'),
+
+            // We do in fact use it here, and don't want to remove it
+            // The bug is this report of an unused dependency:
+            //   testImplementation 'org.apache.commons:commons-collections4:4.3'
+            // Not only is it used, we're actually using v4.4. So, two bugs!
+            commonsCollectionsTestImplementation,
+          ]
+        }
+      }
+      .withSubproject('producer') { s ->
+        s.withBuildScript { bs ->
+          bs.plugins = javaLibrary
+          // Expose this different version of the dep to consumers
+          bs.dependencies = [oldCommonsCollectionsApi]
+        }
+      }
+      .write()
+  }
+
+  private List<Source> consumerSources = [
+    Source.java(
+      '''\
+      package com.example;
+        
+      import org.apache.commons.collections4.Bag;
+      import org.apache.commons.collections4.bag.HashBag;
+      
+      public class Test {
+        public void compute() {
+          Bag<String> bag = new HashBag<>();
+        }
+      }
+      '''
+    )
+      .withPath('com.example', 'Test')
+      .withSourceSet('test')
+      .build()
+  ]
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  private final Set<Advice> consumerAdvice = []
+  private final Set<Advice> producerAdvice = [
+    Advice.ofRemove(moduleCoordinates(oldCommonsCollectionsApi), 'api')
+  ]
+
+  final Set<ProjectAdvice> expectedBuildHealth = [
+    projectAdviceForDependencies(':consumer', consumerAdvice),
+    projectAdviceForDependencies(':producer', producerAdvice),
+  ]
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/DuplicatedDependenciesProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/DuplicatedDependenciesProject.groovy
@@ -60,7 +60,7 @@ final class DuplicatedDependenciesProject extends AbstractProject {
 
   private final Set<Advice> projAdvice = [
     // This test project makes sure that the 'runtimeOnly' dependency does not shadow the 'implementation'
-    // dependency to the same module during analysis. Which in the past let to a wrong advice
+    // dependency to the same module during analysis. Which in the past led to a wrong advice
     // (remove implementation dependency). Reporting duplicated declarations, and recommending removing the ones that
     // do not add anything, is out of scope right now.
     // Advice.ofRemove(moduleCoordinates(commonsCollectionsRuntimeOnly), commonsCollectionsRuntimeOnly.configuration)

--- a/src/main/kotlin/com/autonomousapps/internal/utils/coordinatesStrings.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/coordinatesStrings.kt
@@ -38,18 +38,20 @@ internal fun <T> String.matchesKey(mapEntry: Map.Entry<String, T>): Boolean {
 }
 
 internal fun <T> String.equalsKey(mapEntry: Map.Entry<String, T>): Boolean {
-  val tokens = mapEntry.key.firstCoordinatesKeySegment().split(":")
-  if (tokens.size == 3) {
-    // "groupId:artifactId:version" => "groupId:artifactId"
-    if ("${tokens[0]}:${tokens[1]}" == this) {
-      return true
-    }
+  val firstSegment = mapEntry.key.firstCoordinatesKeySegment()
+  val tokens = firstSegment.split(":")
+
+  // module coordinates, "group:artifact:version"
+  if (tokens.size == 3 && this == firstSegment) {
+    return true
   }
-  return mapEntry.key.firstCoordinatesKeySegment() == this || mapEntry.key.secondCoordinatesKeySegment() == this
+
+  return firstSegment == this || mapEntry.key.secondCoordinatesKeySegment() == this
 }
 
 private fun <T> String.startsWithKey(mapEntry: Map.Entry<String, T>) =
-  mapEntry.key.firstCoordinatesKeySegment().startsWith(this) || mapEntry.key.secondCoordinatesKeySegment()?.startsWith(this) == true
+  mapEntry.key.firstCoordinatesKeySegment().startsWith(this)
+    || mapEntry.key.secondCoordinatesKeySegment()?.startsWith(this) == true
 
 /** First key segment is always 'group:name' coordinates */
 internal fun String.firstCoordinatesKeySegment(): String =

--- a/src/main/kotlin/com/autonomousapps/model/declaration/Declaration.kt
+++ b/src/main/kotlin/com/autonomousapps/model/declaration/Declaration.kt
@@ -26,6 +26,10 @@ internal data class Declaration(
 ) {
 
   val bucket: Bucket by unsafeLazy { Bucket.of(configurationName) }
-  fun variant(supportedSourceSets: Set<String>, hasCustomSourceSets: Boolean): Variant? =
-    Variant.of(configurationName, supportedSourceSets, hasCustomSourceSets)
+
+  fun gav(): String = if (version != null) "$identifier:$version" else identifier
+
+  fun variant(supportedSourceSets: Set<String>, hasCustomSourceSets: Boolean): Variant? {
+    return Variant.of(configurationName, supportedSourceSets, hasCustomSourceSets)
+  }
 }

--- a/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
+++ b/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
@@ -386,11 +386,11 @@ internal class StandardTransform(
 
 private fun Set<Declaration>.forCoordinates(coordinates: Coordinates): Set<Declaration> {
   return asSequence()
-    .filter {
-      it.identifier == coordinates.identifier ||
+    .filter { declaration ->
+      declaration.identifier == coordinates.identifier
         // In the special case of IncludedBuildCoordinates, the declaration might be a 'project(...)' dependency
         // if subprojects inside an included build depend on each other.
-        (coordinates is IncludedBuildCoordinates) && it.identifier == coordinates.resolvedProject.identifier
+        || (coordinates is IncludedBuildCoordinates) && declaration.identifier == coordinates.resolvedProject.identifier
     }
     .filter { it.isJarDependency() && it.gradleVariantIdentification.variantMatches(coordinates) }
     .toSet()

--- a/src/test/kotlin/com/autonomousapps/tasks/ReasonTaskTest.kt
+++ b/src/test/kotlin/com/autonomousapps/tasks/ReasonTaskTest.kt
@@ -58,7 +58,7 @@ class ReasonTaskTest {
 
   @Test
   fun shouldMatchEqualLibrary() {
-    val key = findFilteredDependencyKey(entries, "com.squareup.okio:okio")
+    val key = findFilteredDependencyKey(entries, "com.squareup.okio:okio:3.0.0")
     assertEquals("com.squareup.okio:okio:3.0.0", key)
   }
 

--- a/src/test/kotlin/com/autonomousapps/transform/StandardTransformTest.kt
+++ b/src/test/kotlin/com/autonomousapps/transform/StandardTransformTest.kt
@@ -713,6 +713,7 @@ internal class StandardTransformTest {
       )
       val declarations = Declaration(
         identifier = id,
+        version = "4.13.2",
         configurationName = "implementation",
         gradleVariantIdentification = emptyGVI
       ).intoSet()
@@ -736,6 +737,7 @@ internal class StandardTransformTest {
       )
       val declarations = Declaration(
         identifier = id,
+        version = "4.13.2",
         configurationName = "implementation",
         gradleVariantIdentification = emptyGVI
       ).intoSet()
@@ -761,16 +763,19 @@ internal class StandardTransformTest {
       val declarations = setOf(
         Declaration(
           identifier = id,
+          version = "4.13.2",
           configurationName = "implementation",
           gradleVariantIdentification = emptyGVI
         ),
         Declaration(
           identifier = id,
+          version = "4.13.2",
           configurationName = "testImplementation",
           gradleVariantIdentification = emptyGVI
         ),
         Declaration(
           identifier = id,
+          version = "4.13.2",
           configurationName = "androidTestImplementation",
           gradleVariantIdentification = emptyGVI
         ),
@@ -802,6 +807,7 @@ internal class StandardTransformTest {
       )
       val declarations = Declaration(
         identifier = id,
+        version = "1.0",
         configurationName = "implementation",
         gradleVariantIdentification = emptyGVI
       ).intoSet()
@@ -826,6 +832,7 @@ internal class StandardTransformTest {
       )
       val declarations = Declaration(
         identifier = id,
+        version = "1.0",
         configurationName = "implementation",
         gradleVariantIdentification = emptyGVI
       ).intoSet()
@@ -847,6 +854,7 @@ internal class StandardTransformTest {
       )
       val declarations = Declaration(
         identifier = id,
+        version = "4.4",
         configurationName = "testImplementation",
         gradleVariantIdentification = emptyGVI
       ).intoSet()
@@ -871,11 +879,13 @@ internal class StandardTransformTest {
       val declarations = setOf(
         Declaration(
           identifier = id,
+          version = "1.0",
           configurationName = "implementation",
           gradleVariantIdentification = emptyGVI
         ),
         Declaration(
           identifier = id,
+          version = "1.0",
           configurationName = "testImplementation",
           gradleVariantIdentification = emptyGVI
         )
@@ -901,11 +911,13 @@ internal class StandardTransformTest {
       val declarations = setOf(
         Declaration(
           identifier = id,
+          version = "1.0",
           configurationName = "implementation",
           gradleVariantIdentification = emptyGVI
         ),
         Declaration(
           identifier = id,
+          version = "1.0",
           configurationName = "testImplementation",
           gradleVariantIdentification = emptyGVI
         )
@@ -931,11 +943,13 @@ internal class StandardTransformTest {
       val declarations = setOf(
         Declaration(
           identifier = id,
+          version = "1.0",
           configurationName = "implementation",
           gradleVariantIdentification = emptyGVI
         ),
         Declaration(
           identifier = id,
+          version = "1.0",
           configurationName = "androidTestImplementation",
           gradleVariantIdentification = emptyGVI
         )
@@ -1033,6 +1047,7 @@ internal class StandardTransformTest {
       ).intoSet()
       val declarations = Declaration(
         identifier = identifier,
+        version = resolvedVersion,
         configurationName = "androidTestImplementation",
         gradleVariantIdentification = emptyGVI
       ).intoSet()


### PR DESCRIPTION
This resolves an issue when two versions of a dependency are in the various dependency graphs
(e.g., main and test). Without this, we were getting erroneous advice to remove used dependencies,
and then correct advice to re-add used-transitive dependencies. Additionally, the 'reason' results
were confusing and incorrect for a similar reason. As the simplest solution, require full GAV when
requesting the 'reason for' some advice in this circumstance.

There is still one minor issue in the reason output, which is it'll print the shortest path to all
versions of a given dep, even when a specific version is requested.