### PR TITLE
Update to AGP 8.6 stable and 8.7 alpha09

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
@@ -20,15 +20,15 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
   protected static final AGP_8_3 = AgpVersion.version('8.3.2')
   protected static final AGP_8_4 = AgpVersion.version('8.4.2')
   protected static final AGP_8_5 = AgpVersion.version('8.5.2')
-  protected static final AGP_8_6 = AgpVersion.version('8.6.0-rc01')
-  protected static final AGP_8_7 = AgpVersion.version('8.7.0-alpha06')
+  protected static final AGP_8_6 = AgpVersion.version('8.6.0')
+  protected static final AGP_8_7 = AgpVersion.version('8.7.0-alpha09')
 
   protected static final AGP_LATEST = AGP_8_7
 
   /**
    * TODO(tsr): this doc is perpetually out of date.
    *
-   * {@code AGP_8_0} represents the minimum stable _tested_ version. {@code AGP_8_5} represents the maximum stable
+   * {@code AGP_8_0} represents the minimum stable _tested_ version. {@code AGP_8_6} represents the maximum stable
    * _tested_ version. We also test against the latest alpha, {@code AGP_8_7} at time of writing. DAGP may work with
    * other versions of AGP, but they aren't tested, primarily for CI performance reasons.
    *
@@ -36,7 +36,7 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
    */
   protected static final SUPPORTED_AGP_VERSIONS = [
     AGP_8_0,
-    AGP_8_5,
+    AGP_8_6,
     AGP_8_7,
   ]
 

--- a/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
@@ -15,7 +15,7 @@ internal class AgpVersion private constructor(val version: String) : Comparable<
   companion object {
 
     @JvmStatic val AGP_MIN = version("8.0.0")
-    @JvmStatic val AGP_MAX = version("8.5.2")
+    @JvmStatic val AGP_MAX = version("8.6.0")
 
     @JvmStatic fun current(): AgpVersion = AgpVersion(agpVersion())
     @JvmStatic fun version(version: String): AgpVersion = AgpVersion(version)


### PR DESCRIPTION
This PR updates AGP to its latest stable version `8.6.0`, and to its latest alpha version `8.7.0-alpha09`.