### PR TITLE
Fix typo in AGP missing message

### DIFF
--- a/src/main/kotlin/com/autonomousapps/services/GlobalDslService.kt
+++ b/src/main/kotlin/com/autonomousapps/services/GlobalDslService.kt
@@ -65,7 +65,7 @@ abstract class GlobalDslService @Inject constructor(
             id("${BuildHealthPlugin.ID}") version "<<version>>"
             
             // Optional
-            id("org.jetbrains.kotlin.android)" version "<<version>>" apply false
+            id("org.jetbrains.kotlin.android") version "<<version>>" apply false
           }
       """.trimIndent()
     } else {
@@ -86,7 +86,7 @@ abstract class GlobalDslService @Inject constructor(
             id("$DEPENDENCY_ANALYSIS_PLUGIN") version "<<version>>"
             
             // Optional
-            id("org.jetbrains.kotlin.android)" version "<<version>>" apply false
+            id("org.jetbrains.kotlin.android") version "<<version>>" apply false
           }
       """.trimIndent()
     }


### PR DESCRIPTION
I ran into this error while integrating the plugin, took a chance to send a small PR