### PR TITLE
fix: when rewriting dependencies, don't require a version string.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/parse/GradleBuildScriptDependenciesRewriter.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/parse/GradleBuildScriptDependenciesRewriter.kt
@@ -169,7 +169,7 @@ internal class GradleBuildScriptDependenciesRewriter private constructor(
         .removeSuffix("'").removeSuffix("\"")
     }
 
-    val normalizedGav = when (ctxDependency.dependencyKind()) {
+    val normalizedDeclaration = when (ctxDependency.dependencyKind()) {
       // strip "project()" (where parens are optional because Groovy)
       // strip double or single quotes as well
       DependencyKind.PROJECT -> dependency.normalize("project")
@@ -183,7 +183,9 @@ internal class GradleBuildScriptDependenciesRewriter private constructor(
     }
 
     return advice.find {
-      it.coordinates.gav() == normalizedGav && it.fromConfiguration == currentConfiguration
+      // normalizedDeclaration will not always have a version string
+      (it.coordinates.gav() == normalizedDeclaration || it.coordinates.identifier == normalizedDeclaration)
+        && it.fromConfiguration == currentConfiguration
     }
   }
 

--- a/src/test/kotlin/com/autonomousapps/internal/parse/GradleBuildScriptDependenciesRewriterTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/parse/GradleBuildScriptDependenciesRewriterTest.kt
@@ -123,6 +123,7 @@ internal class GradleBuildScriptDependenciesRewriterTest {
         dependencies {
           implementation 'heart:of-gold:1.+'
           api project(':marvin')
+          api(libs.fordPrefect)
               
           testImplementation('pan-galactic:gargle-blaster:2.0-SNAPSHOT') {
             because "life's too short not to"
@@ -134,6 +135,7 @@ internal class GradleBuildScriptDependenciesRewriterTest {
     )
     val advice = setOf(
       Advice.ofChange(Coordinates.of(":marvin"), "api", "compileOnly"),
+      Advice.ofChange(Coordinates.of("ford:prefect:1.0"), "api", "implementation"),
       Advice.ofRemove(Coordinates.of("pan-galactic:gargle-blaster:2.0-SNAPSHOT"), "testImplementation"),
       Advice.ofAdd(Coordinates.of(":sad-robot"), "runtimeOnly"),
       Advice.ofAdd(Coordinates.of("magrathea:asleep:1000000"), "implementation"),
@@ -149,6 +151,7 @@ internal class GradleBuildScriptDependenciesRewriterTest {
           when (it) {
             ":sad-robot" -> "':depressed-robot'"
             "magrathea:asleep:1000000" -> "deps.magrathea"
+            "ford:prefect" -> "libs.fordPrefect"
             else -> it
           }
         }
@@ -157,6 +160,7 @@ internal class GradleBuildScriptDependenciesRewriterTest {
         when (it) {
           "':depressed-robot'" -> ":sad-robot"
           "deps.magrathea" -> "magrathea:asleep:1000000"
+          "libs.fordPrefect" -> "ford:prefect"
           else -> it
         }
       }
@@ -182,6 +186,7 @@ internal class GradleBuildScriptDependenciesRewriterTest {
         dependencies {
           implementation 'heart:of-gold:1.+'
           compileOnly project(':marvin')
+          implementation(libs.fordPrefect)
           implementation deps.magrathea
           runtimeOnly project(':depressed-robot')
         }


### PR DESCRIPTION
Necessary to support, e.g., version catalog references.