### PR TITLE
fix: improve separation of "annotation" vs "not-annotation" in bytecode analysis.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TypealiasProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TypealiasProject.groovy
@@ -37,7 +37,7 @@ final class TypealiasProject extends AbstractProject {
           bs.plugins = kotlin
           bs.dependencies = [
             project('implementation', ':alias'),
-            project('api', ':producer')
+            project('api', ':producer'),
           ]
         }
       }
@@ -89,7 +89,7 @@ final class TypealiasProject extends AbstractProject {
       """
     )
       .withPath('com.example.consumer', 'Consumer')
-      .build()
+      .build(),
   ]
 
   private aliasSources = [

--- a/src/main/kotlin/com/autonomousapps/model/ProjectVariant.kt
+++ b/src/main/kotlin/com/autonomousapps/model/ProjectVariant.kt
@@ -25,6 +25,16 @@ data class ProjectVariant(
   val testInstrumentationRunner: String?
 ) {
 
+  /**
+   * For typealiases, we check for presence in the bytecode in any context, annotation or otherwise. We do not check
+   * usages in Android res.
+   */
+  val usedClassesBySrc: Set<String> by unsafeLazy {
+    codeSource.flatMapToSet {
+      it.usedNonAnnotationClasses + it.usedAnnotationClasses
+    }
+  }
+
   val usedNonAnnotationClassesBySrc: Set<String> by unsafeLazy {
     codeSource.flatMapToSet {
       it.usedNonAnnotationClasses

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeUsagesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeUsagesTask.kt
@@ -355,7 +355,7 @@ private class GraphVisitor(
     typealiasCapability: TypealiasCapability,
     context: GraphViewVisitor.Context,
   ): Boolean {
-    val usedClasses = context.project.usedNonAnnotationClasses.asSequence().filter { usedClass ->
+    val usedClasses = context.project.usedClassesBySrc.asSequence().filter { usedClass ->
       typealiasCapability.typealiases.any { ta ->
         ta.typealiases.map { "${ta.packageName}.${it.name}" }.contains(usedClass)
       }


### PR DESCRIPTION
This resolves an issue where an annotation library was inaccurately showing up in the
"add to implementation" advice, while also preserving the correct behavior around
Kotlin typealiases.