### PR TITLE
feat: detect duplicate classfiles on compile and runtime classpaths.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/AbstractFunctionalSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/AbstractFunctionalSpec.groovy
@@ -19,11 +19,13 @@ abstract class AbstractFunctionalSpec extends Specification {
   protected static final GRADLE_8_10 = GradleVersion.version('8.10.2')
   protected static final GRADLE_8_11 = GradleVersion.version('8.11-rc-1')
 
+  protected static final GRADLE_LATEST = GRADLE_8_10
+
   // For faster CI times, we only test min + max. Testing all would be preferable, but we don't have till the heat death
   // of the universe.
   protected static final SUPPORTED_GRADLE_VERSIONS = [
     GradleVersions.minGradleVersion,
-    GRADLE_8_10,
+    GRADLE_LATEST,
 //    GRADLE_8_11,
   ]
 

--- a/src/functionalTest/groovy/com/autonomousapps/AdviceHelper.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/AdviceHelper.groovy
@@ -63,7 +63,7 @@ final class AdviceHelper {
   }
 
   static ProjectAdvice emptyProjectAdviceFor(String projectPath) {
-    return new ProjectAdvice(projectPath, [] as Set<Advice>, [] as Set<PluginAdvice>, [] as Set<ModuleAdvice>, false)
+    return new ProjectAdvice(projectPath, [] as Set<Advice>, [] as Set<PluginAdvice>, [] as Set<ModuleAdvice>, Warning.empty(), false)
   }
 
   static ProjectAdvice projectAdviceForDependencies(String projectPath, Set<Advice> advice) {
@@ -71,7 +71,7 @@ final class AdviceHelper {
   }
 
   static ProjectAdvice projectAdviceForDependencies(String projectPath, Set<Advice> advice, boolean shouldFail) {
-    return new ProjectAdvice(projectPath, advice, [] as Set<PluginAdvice>, [] as Set<ModuleAdvice>, shouldFail)
+    return new ProjectAdvice(projectPath, advice, [] as Set<PluginAdvice>, [] as Set<ModuleAdvice>, Warning.empty(), shouldFail)
   }
 
   static ProjectAdvice projectAdvice(String projectPath, Set<Advice> advice, Set<PluginAdvice> pluginAdvice) {
@@ -91,7 +91,7 @@ final class AdviceHelper {
     Set<ModuleAdvice> moduleAdvice,
     boolean shouldFail
   ) {
-    return new ProjectAdvice(projectPath, advice, pluginAdvice, moduleAdvice, shouldFail)
+    return new ProjectAdvice(projectPath, advice, pluginAdvice, moduleAdvice, Warning.empty(), shouldFail)
   }
 
   /**

--- a/src/functionalTest/groovy/com/autonomousapps/android/AndroidKotlinInlineSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AndroidKotlinInlineSpec.groovy
@@ -28,7 +28,7 @@ final class AndroidKotlinInlineSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()
@@ -45,7 +45,7 @@ final class AndroidKotlinInlineSpec extends AbstractAndroidSpec {
     then: 'We detect the inline usage from Android -> JVM'
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     when:
     def result = build(gradleVersion as GradleVersion, gradleProject.rootDir, ':consumer:reason', '--id', ':producer')

--- a/src/functionalTest/groovy/com/autonomousapps/android/AndroidTestDependenciesSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AndroidTestDependenciesSpec.groovy
@@ -35,7 +35,7 @@ final class AndroidTestDependenciesSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()
@@ -53,7 +53,7 @@ final class AndroidTestDependenciesSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()

--- a/src/functionalTest/groovy/com/autonomousapps/android/AndroidTestSourceSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AndroidTestSourceSpec.groovy
@@ -23,7 +23,7 @@ final class AndroidTestSourceSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()
@@ -41,7 +41,7 @@ final class AndroidTestSourceSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()
@@ -59,7 +59,7 @@ final class AndroidTestSourceSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()

--- a/src/functionalTest/groovy/com/autonomousapps/android/ArbitraryFileSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/ArbitraryFileSpec.groovy
@@ -22,7 +22,7 @@ final class ArbitraryFileSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()

--- a/src/functionalTest/groovy/com/autonomousapps/android/BundleSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/BundleSpec.groovy
@@ -23,7 +23,7 @@ final class BundleSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()
@@ -40,7 +40,7 @@ final class BundleSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()

--- a/src/functionalTest/groovy/com/autonomousapps/android/CompileOnlySpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/CompileOnlySpec.groovy
@@ -21,7 +21,7 @@ final class CompileOnlySpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()

--- a/src/functionalTest/groovy/com/autonomousapps/android/ConfigurationCacheSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/ConfigurationCacheSpec.groovy
@@ -29,7 +29,7 @@ final class ConfigurationCacheSpec extends AbstractAndroidSpec {
     then: 'buildHealth produces expected results'
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     and: 'generateBuildHealth succeeded'
     assertAbout(buildTasks()).that(result.task(':generateBuildHealth')).succeeded()
@@ -44,7 +44,7 @@ final class ConfigurationCacheSpec extends AbstractAndroidSpec {
     then: 'buildHealth produces expected results'
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     and: 'generateBuildHealth was up-to-date'
     assertAbout(buildTasks()).that(result.task(':generateBuildHealth')).upToDate()

--- a/src/functionalTest/groovy/com/autonomousapps/android/DaggerSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/DaggerSpec.groovy
@@ -25,7 +25,7 @@ final class DaggerSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that([actualProjectAdvice(projectName)] as Set<Advice>)
-      .isEquivalentIgnoringModuleAdvice([project.expectedAdvice])
+      .isEquivalentIgnoringModuleAdviceAndWarnings([project.expectedAdvice])
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()

--- a/src/functionalTest/groovy/com/autonomousapps/android/DataBindingUsagesExclusionsSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/DataBindingUsagesExclusionsSpec.groovy
@@ -22,7 +22,7 @@ final class DataBindingUsagesExclusionsSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()
@@ -39,7 +39,7 @@ final class DataBindingUsagesExclusionsSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()

--- a/src/functionalTest/groovy/com/autonomousapps/android/DependenciesSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/DependenciesSpec.groovy
@@ -26,7 +26,7 @@ final class DependenciesSpec extends AbstractAndroidSpec {
     then: 'should add core three-ten-bp lib'
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()
@@ -54,7 +54,7 @@ final class DependenciesSpec extends AbstractAndroidSpec {
     then: 'no advice'
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBundleBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBundleBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()
@@ -71,7 +71,7 @@ final class DependenciesSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(AdviceHelper.actualProjectAdvice(gradleProject))
-      .isEquivalentIgnoringModuleAdvice([AdviceHelper.emptyProjectAdviceFor(':app')])
+      .isEquivalentIgnoringModuleAdviceAndWarnings([AdviceHelper.emptyProjectAdviceFor(':app')])
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()
@@ -88,7 +88,7 @@ final class DependenciesSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(AdviceHelper.actualProjectAdvice(gradleProject))
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()

--- a/src/functionalTest/groovy/com/autonomousapps/android/ExternalApplicationSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/ExternalApplicationSpec.groovy
@@ -22,7 +22,7 @@ final class ExternalApplicationSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()

--- a/src/functionalTest/groovy/com/autonomousapps/android/HasJavaAndKotlinSourcesSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/HasJavaAndKotlinSourcesSpec.groovy
@@ -23,7 +23,7 @@ final class HasJavaAndKotlinSourcesSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()

--- a/src/functionalTest/groovy/com/autonomousapps/android/IgnoredVariantSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/IgnoredVariantSpec.groovy
@@ -24,7 +24,7 @@ final class IgnoredVariantSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth())
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth())
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()
@@ -41,7 +41,7 @@ final class IgnoredVariantSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth())
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth())
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()
@@ -58,7 +58,7 @@ final class IgnoredVariantSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth())
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth())
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()

--- a/src/functionalTest/groovy/com/autonomousapps/android/LintJarSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/LintJarSpec.groovy
@@ -24,7 +24,7 @@ final class LintJarSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(AdviceHelper.actualProjectAdvice(gradleProject))
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()
@@ -41,7 +41,7 @@ final class LintJarSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(AdviceHelper.actualProjectAdvice(gradleProject))
-      .isEquivalentIgnoringModuleAdvice([TimberProject.removeTimberAdvice()])
+      .isEquivalentIgnoringModuleAdviceAndWarnings([TimberProject.removeTimberAdvice()])
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()

--- a/src/functionalTest/groovy/com/autonomousapps/android/NoOpSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/NoOpSpec.groovy
@@ -22,7 +22,7 @@ final class NoOpSpec extends AbstractAndroidSpec {
     then: 'there is no advice'
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()

--- a/src/functionalTest/groovy/com/autonomousapps/android/ResSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/ResSpec.groovy
@@ -26,7 +26,7 @@ final class ResSpec extends AbstractAndroidSpec {
     and:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()
@@ -43,7 +43,7 @@ final class ResSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()
@@ -60,7 +60,7 @@ final class ResSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()
@@ -77,7 +77,7 @@ final class ResSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()
@@ -94,7 +94,7 @@ final class ResSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()
@@ -112,7 +112,7 @@ final class ResSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()
@@ -129,7 +129,7 @@ final class ResSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()
@@ -146,7 +146,7 @@ final class ResSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << [gradleAgpMatrix().last()]
@@ -163,7 +163,7 @@ final class ResSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()
@@ -181,7 +181,7 @@ final class ResSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()

--- a/src/functionalTest/groovy/com/autonomousapps/android/ServiceLoaderSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/ServiceLoaderSpec.groovy
@@ -22,7 +22,7 @@ final class ServiceLoaderSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()

--- a/src/functionalTest/groovy/com/autonomousapps/android/SettingsSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/SettingsSpec.groovy
@@ -25,7 +25,7 @@ final class SettingsSpec extends AbstractAndroidSpec {
     and:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrixSettingsApi()

--- a/src/functionalTest/groovy/com/autonomousapps/android/TestDependenciesSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/TestDependenciesSpec.groovy
@@ -24,7 +24,7 @@ final class TestDependenciesSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth())
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth())
 
     where:
     [gradleVersion, agpVersion, analyzeTests] << gradleAgpMatrixPlus([true, false])

--- a/src/functionalTest/groovy/com/autonomousapps/android/TestSourceSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/TestSourceSpec.groovy
@@ -23,7 +23,7 @@ final class TestSourceSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()
@@ -40,7 +40,7 @@ final class TestSourceSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()

--- a/src/functionalTest/groovy/com/autonomousapps/android/VariantSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/VariantSpec.groovy
@@ -22,7 +22,7 @@ final class VariantSpec extends AbstractAndroidSpec {
     then:
     assertAbout(buildHealth())
       .that(project.actualBuildHealth())
-      .isEquivalentIgnoringModuleAdvice(project.expectedBuildHealth())
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth())
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/DuplicateClasspathSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/DuplicateClasspathSpec.groovy
@@ -56,7 +56,7 @@ final class DuplicateClasspathSpec extends AbstractJvmSpec {
     and:
     assertAbout(buildHealth())
       .that(project.actualProjectAdvice())
-      .isEquivalentIgnoringModuleAdvice(project.expectedProjectAdvice)
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedProjectAdvice)
 
     where:
     gradleVersion << [GRADLE_LATEST]

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/DuplicateClasspathSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/DuplicateClasspathSpec.groovy
@@ -1,0 +1,64 @@
+package com.autonomousapps.jvm
+
+import com.autonomousapps.jvm.projects.DuplicateClasspathProject
+import org.gradle.testkit.runner.TaskOutcome
+
+import static com.autonomousapps.advice.truth.BuildHealthSubject.buildHealth
+import static com.autonomousapps.utils.Runner.build
+import static com.autonomousapps.utils.Runner.buildAndFail
+import static com.google.common.truth.Truth.assertAbout
+import static com.google.common.truth.Truth.assertThat
+
+final class DuplicateClasspathSpec extends AbstractJvmSpec {
+
+  def "duplicates on the classpath can lead to build failures (#gradleVersion)"() {
+    given:
+    def project = new DuplicateClasspathProject()
+    gradleProject = project.gradleProject
+
+    when:
+    // This first invocation "fixes" the dependency declarations
+    build(gradleVersion, gradleProject.rootDir, ':consumer:fixDependencies')
+    // This second invocation fails because the fix (+ sort) causes the JVM to load the wrong class during compilation.
+    def result = buildAndFail(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(result.task(':consumer:compileJava').outcome).isEqualTo(TaskOutcome.FAILED)
+
+    where:
+    gradleVersion << [GRADLE_LATEST]
+  }
+
+  def "buildHealth reports duplicates (#gradleVersion)"() {
+    given:
+    def project = new DuplicateClasspathProject()
+    gradleProject = project.gradleProject
+
+    when:
+    def result = build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(result.output).contains(
+      '''\
+        Warnings
+        Some of your classpaths have duplicate classes, which means the compile and runtime behavior can be sensitive to the classpath order.
+        
+        Source set: main
+        \\--- compile classpath
+             +--- com/example/producer/Producer$Inner.class is provided by multiple dependencies: [:producer-1, :producer-2]
+             \\--- com/example/producer/Producer.class is provided by multiple dependencies: [:producer-1, :producer-2]
+        \\--- runtime classpath
+             +--- com/example/producer/Producer$Inner.class is provided by multiple dependencies: [:producer-1, :producer-2]
+             \\--- com/example/producer/Producer.class is provided by multiple dependencies: [:producer-1, :producer-2]'''
+        .stripIndent()
+    )
+
+    and:
+    assertAbout(buildHealth())
+      .that(project.actualProjectAdvice())
+      .isEquivalentIgnoringModuleAdvice(project.expectedProjectAdvice)
+
+    where:
+    gradleVersion << [GRADLE_LATEST]
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/DuplicateClasspathProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/DuplicateClasspathProject.groovy
@@ -1,0 +1,167 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.model.Advice
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.*
+import static com.autonomousapps.kit.gradle.Dependency.project
+
+final class DuplicateClasspathProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  DuplicateClasspathProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newGradleProjectBuilder()
+    // :consumer uses the Producer class.
+    // This class is provided by both
+    // 1. :producer-2, which is a direct dependency, and
+    // 2. :producer-1, which is a transitive dependency (of :unused)
+    // These classes have incompatible definitions. :consumer _requires_ the version provided by :producer-2.
+      .withSubproject('consumer') { s ->
+        s.sources = sourcesConsumer
+        s.withBuildScript { bs ->
+          bs.plugins = javaLibrary + plugins.gradleDependenciesSorter
+          bs.dependencies(
+            project('implementation', ':unused'),
+            project('implementation', ':producer-2'),
+          )
+
+          // We need to sort the dependencies after rewriting so that the classpath loads the class with the
+          // incompatible definition, causing `:consumer:compileJava` to fail.
+          bs.withGroovy(
+            '''\
+              tasks.named { it == 'fixDependencies' }.configureEach {
+                finalizedBy('sortDependencies')
+              }
+            '''
+          )
+        }
+      }
+    // Used
+      .withSubproject('producer-1') { s ->
+        s.sources = sourcesProducer1
+        s.withBuildScript { bs ->
+          bs.plugins = javaLibrary
+        }
+      }
+    // Unused, except its transitive is
+      .withSubproject('unused') { s ->
+        s.sources = sourcesUnused
+        s.withBuildScript { bs ->
+          bs.plugins = javaLibrary
+          bs.dependencies(
+            project('api', ':producer-1'),
+          )
+        }
+      }
+    // Used?
+      .withSubproject('producer-2') { s ->
+        s.sources = sourcesProducer2
+        s.withBuildScript { bs ->
+          bs.plugins = javaLibrary
+        }
+      }
+      .write()
+  }
+
+  private static final List<Source> sourcesConsumer = [
+    Source.java(
+      '''\
+        package com.example.consumer;
+
+        import com.example.producer.Producer;
+        import com.example.producer.Producer.Inner;
+
+        public class Consumer {
+          private Producer producer = new Producer("Emma", "Goldman");
+          private Producer.Inner inner;
+        }
+      '''
+    )
+      .withPath('com.example.consumer', 'Consumer')
+      .build(),
+  ]
+
+  private static final List<Source> sourcesProducer1 = [
+    Source.java(
+      '''\
+        package com.example.producer;
+
+        public class Producer {
+          
+          private final String name;
+          
+          public Producer(String name) {
+            this.name = name;
+          }
+          
+          public static class Inner {}
+        }
+      '''
+    )
+      .withPath('com.example.producer', 'Producer')
+      .build(),
+  ]
+
+  // Same class file as sourcesProducer1, incompatible definition
+  private static final List<Source> sourcesProducer2 = [
+    Source.java(
+      '''\
+        package com.example.producer;
+
+        public class Producer {
+          private final String firstName;
+          private final String lastName;
+          
+          public Producer(String firstName, String lastName) {
+            this.firstName = firstName;
+            this.lastName = lastName;
+          }
+          
+          public static class Inner {}
+        }
+      '''
+    )
+      .withPath('com.example.producer', 'Producer')
+      .build(),
+  ]
+
+  private static final List<Source> sourcesUnused = [
+    Source.java(
+      '''\
+        package com.example.unused;
+
+        import com.example.producer.Producer;
+
+        public class Unused {
+          public Producer producer;
+        }
+      '''
+    )
+      .withPath('com.example.unused', 'Unused')
+      .build(),
+  ]
+
+  Set<ProjectAdvice> actualProjectAdvice() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  private final Set<Advice> consumerAdvice = [
+    Advice.ofRemove(projectCoordinates(':unused'), 'implementation'),
+    Advice.ofAdd(projectCoordinates(':producer-1'), 'implementation')
+  ]
+
+  final Set<ProjectAdvice> expectedProjectAdvice = [
+    projectAdviceForDependencies(':consumer', consumerAdvice),
+    emptyProjectAdviceFor(':unused'),
+    emptyProjectAdviceFor(':producer-1'),
+    emptyProjectAdviceFor(':producer-2'),
+  ]
+}

--- a/src/functionalTest/kotlin/com/autonomousapps/advice/truth/BuildHealthSubject.kt
+++ b/src/functionalTest/kotlin/com/autonomousapps/advice/truth/BuildHealthSubject.kt
@@ -77,9 +77,8 @@ class BuildHealthSubject private constructor(
       .comparingElementsUsing(DEPENDENCY_EQUIVALENCE)
       .containsExactlyElementsIn(pairs(expected))
   }
-
-  // TODO: rename, it also ignores Warnings now.
-  fun isEquivalentIgnoringModuleAdvice(expected: Iterable<ProjectAdvice>) {
+  
+  fun isEquivalentIgnoringModuleAdviceAndWarnings(expected: Iterable<ProjectAdvice>) {
     if (actual == null) failWithActual(simpleFact("build health was null"))
     assertThat(actual)
       .comparingElementsUsing(DEPENDENCY_EQUIVALENCE)

--- a/src/functionalTest/kotlin/com/autonomousapps/advice/truth/BuildHealthSubject.kt
+++ b/src/functionalTest/kotlin/com/autonomousapps/advice/truth/BuildHealthSubject.kt
@@ -78,6 +78,7 @@ class BuildHealthSubject private constructor(
       .containsExactlyElementsIn(pairs(expected))
   }
 
+  // TODO: rename, it also ignores Warnings now.
   fun isEquivalentIgnoringModuleAdvice(expected: Iterable<ProjectAdvice>) {
     if (actual == null) failWithActual(simpleFact("build health was null"))
     assertThat(actual)

--- a/src/functionalTest/kotlin/com/autonomousapps/kit/gradle/dependencies/PluginProvider.kt
+++ b/src/functionalTest/kotlin/com/autonomousapps/kit/gradle/dependencies/PluginProvider.kt
@@ -18,6 +18,8 @@ class PluginProvider(
   val dependencyAnalysis: Plugin = Plugin(dagpId, pluginUnderTestVersion)
   val dependencyAnalysisNoVersion: Plugin = Plugin(dagpId)
 
+  val gradleDependenciesSorter: Plugin = Plugin("com.squareup.sort-dependencies", "0.10")
+
   val androidAppId: String = "com.android.application"
   val androidLibId: String = "com.android.library"
   val androidApp: Plugin = Plugin(androidAppId, androidVersion)

--- a/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
@@ -25,6 +25,8 @@ internal class OutputPaths(
   val compileArtifactsPath = file("${intermediatesDir}/artifacts.json")
   val runtimeArtifactsPath = file("${intermediatesDir}/artifacts-runtime.json")
   val externalDependenciesPath = file("${intermediatesDir}/external-dependencies.txt")
+  val duplicateCompileClasspathPath = file("${intermediatesDir}/duplicate-classes-compile.json")
+  val duplicateCompileRuntimePath = file("${intermediatesDir}/duplicate-classes-runtime.json")
   val allDeclaredDepsPath = file("${intermediatesDir}/exploded-jars.json")
   val inlineUsagePath = file("${intermediatesDir}/inline-usage.json")
   val typealiasUsagePath = file("${intermediatesDir}/typealias-usage.json")

--- a/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
@@ -37,26 +37,31 @@ internal fun ZipFile.asClassFiles(): Set<ZipEntry> {
 
 internal fun ZipFile.asSequenceOfClassFiles(): Sequence<ZipEntry> {
   return entries().asSequence().filter {
-    it.name.endsWith(".class") && it.name != "module-info.class"
+    it.name.endsWith(".class") && !it.name.endsWith("module-info.class")
   }
 }
 
 /** Filters a collection of [ZipEntry]s to contain only class files (and not the module-info.class file). */
 internal fun Iterable<ZipEntry>.filterToSetOfClassFiles(): Set<ZipEntry> {
   return filterToSet {
-    it.name.endsWith(".class") && it.name != "module-info.class"
+    it.name.endsWith(".class") && !it.name.endsWith("module-info.class")
   }
 }
 
 /** Filters a collection of [ZipEntry]s to contain only class files (and not the module-info.class file). */
 internal fun Iterable<ZipEntry>.asSequenceOfClassFiles(): Sequence<ZipEntry> {
   return asSequence().filter {
-    it.name.endsWith(".class") && it.name != "module-info.class"
+    it.name.endsWith(".class") && !it.name.endsWith("module-info.class")
   }
 }
 
+// Can't use Iterable<File> because of signature clash with Iterable<ZipEntry> above.
+internal fun Collection<File>.asSequenceOfClassFiles(): Sequence<File> {
+  return asSequence().filter { it.extension == "class" && !it.name.endsWith("module-info.class") }
+}
+
 internal fun Iterable<File>.filterToClassFiles(): List<File> {
-  return filter { it.extension == "class" && it.name != "module-info.class" }
+  return filter { it.extension == "class" && !it.name.endsWith("module-info.class") }
 }
 
 /** Filters a [FileCollection] to contain only class files. */

--- a/src/main/kotlin/com/autonomousapps/model/DuplicateClass.kt
+++ b/src/main/kotlin/com/autonomousapps/model/DuplicateClass.kt
@@ -1,0 +1,26 @@
+package com.autonomousapps.model
+
+import com.autonomousapps.internal.utils.LexicographicIterableComparator
+import com.autonomousapps.model.declaration.Variant
+import com.squareup.moshi.JsonClass
+
+/**
+ * A fully-qualified [classReference] (`/`-delimited) that is provided by multiple [dependencies], and associated with a
+ * [variant].
+ */
+@JsonClass(generateAdapter = false)
+data class DuplicateClass(
+  val variant: Variant,
+  val classpathName: String,
+  val classReference: String,
+  val dependencies: Set<Coordinates>,
+) : Comparable<DuplicateClass> {
+
+  override fun compareTo(other: DuplicateClass): Int {
+    return compareBy(DuplicateClass::variant)
+      .thenBy(DuplicateClass::classpathName)
+      .thenBy(DuplicateClass::classReference)
+      .thenBy(LexicographicIterableComparator()) { it.dependencies }
+      .compare(this, other)
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/model/ProjectAdvice.kt
+++ b/src/main/kotlin/com/autonomousapps/model/ProjectAdvice.kt
@@ -11,6 +11,7 @@ data class ProjectAdvice(
   val dependencyAdvice: Set<Advice> = emptySet(),
   val pluginAdvice: Set<PluginAdvice> = emptySet(),
   val moduleAdvice: Set<ModuleAdvice> = emptySet(),
+  val warning: Warning = Warning.empty(),
   /** True if there is any advice in a category for which the user has declared they want the build to fail. */
   val shouldFail: Boolean = false
 ) : Comparable<ProjectAdvice> {

--- a/src/main/kotlin/com/autonomousapps/model/ProjectVariant.kt
+++ b/src/main/kotlin/com/autonomousapps/model/ProjectVariant.kt
@@ -25,16 +25,6 @@ data class ProjectVariant(
   val testInstrumentationRunner: String?
 ) {
 
-  /**
-   * For typealiases, we check for presence in the bytecode in any context, annotation or otherwise. We do not check
-   * usages in Android res.
-   */
-  val usedClassesBySrc: Set<String> by unsafeLazy {
-    codeSource.flatMapToSet {
-      it.usedNonAnnotationClasses + it.usedAnnotationClasses
-    }
-  }
-
   val usedNonAnnotationClassesBySrc: Set<String> by unsafeLazy {
     codeSource.flatMapToSet {
       it.usedNonAnnotationClasses
@@ -47,9 +37,24 @@ data class ProjectVariant(
     }
   }
 
+  /**
+   * For typealiases, we check for presence in the bytecode in any context, annotation or otherwise. We do not check
+   * usages in Android res.
+   */
+  val usedClassesBySrc: Set<String> by unsafeLazy {
+    usedNonAnnotationClassesBySrc + usedAnnotationClassesBySrc
+  }
+
   val usedClassesByRes: Set<String> by unsafeLazy {
     androidResSource.flatMapToSet {
       it.usedClasses
+    }
+  }
+
+  /** All class references from any context. */
+  val usedClasses: Set<String> by unsafeLazy {
+    codeSource.flatMapToSet {
+      usedClassesBySrc + usedClassesByRes
     }
   }
 

--- a/src/main/kotlin/com/autonomousapps/model/Warning.kt
+++ b/src/main/kotlin/com/autonomousapps/model/Warning.kt
@@ -1,0 +1,13 @@
+package com.autonomousapps.model
+
+import com.squareup.moshi.JsonClass
+
+/** Warnings about the project for which the plugin cannot yet make universally actionable advice. */
+@JsonClass(generateAdapter = false)
+data class Warning(val duplicateClasses: Set<DuplicateClass>) {
+
+  internal companion object {
+    @JvmStatic
+    fun empty() = Warning(emptySet())
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/tasks/DiscoverClasspathDuplicationTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/DiscoverClasspathDuplicationTask.kt
@@ -1,0 +1,105 @@
+package com.autonomousapps.tasks
+
+import com.autonomousapps.TASK_GROUP_DEP
+import com.autonomousapps.internal.utils.*
+import com.autonomousapps.model.Coordinates
+import com.autonomousapps.model.DuplicateClass
+import com.autonomousapps.model.ProjectVariant
+import org.gradle.api.DefaultTask
+import org.gradle.api.artifacts.ArtifactCollection
+import org.gradle.api.artifacts.result.ResolvedArtifactResult
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.*
+import java.util.TreeSet
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+
+@CacheableTask
+abstract class DiscoverClasspathDuplicationTask : DefaultTask() {
+
+  init {
+    group = TASK_GROUP_DEP
+  }
+
+  internal fun description(name: String) {
+    description = "Discovers duplicates on the $name classpath"
+    classpathName.set(name)
+  }
+
+  private lateinit var classpath: ArtifactCollection
+
+  fun setClasspath(artifacts: ArtifactCollection) {
+    this.classpath = artifacts
+  }
+
+  @Classpath
+  fun getClasspath(): FileCollection = classpath.artifactFiles
+
+  @get:Input
+  abstract val classpathName: Property<String>
+
+  @get:PathSensitive(PathSensitivity.NONE)
+  @get:InputFile
+  abstract val syntheticProject: RegularFileProperty
+
+  @get:OutputFile
+  abstract val output: RegularFileProperty
+
+  @TaskAction fun action() {
+    val output = output.getAndDelete()
+
+    val project = syntheticProject.fromJson<ProjectVariant>()
+    val duplicates = ClasspathAnalyzer(project, classpathName.get(), classpath).duplicates()
+
+    output.writeText(duplicates.toJson())
+  }
+
+  internal class ClasspathAnalyzer(
+    private val project: ProjectVariant,
+    private val classpathName: String,
+    artifacts: ArtifactCollection,
+  ) {
+
+    // map of class files to dependencies that contain them
+    private val duplicatesMap = newSetMultimap<String, Coordinates>()
+
+    init {
+      artifacts
+        .filterNonGradle()
+        .filter { it.file.name.endsWith(".jar") }
+        .forEach(::inspectJar)
+    }
+
+    fun duplicates(): Set<DuplicateClass> {
+      return duplicatesMap.asMap()
+        // Find all class files provided by more than one dependency
+        .filterValues { it.size > 1 }
+        // only warn about duplicates if it's about a class that's actually used.
+        .filterKeys {
+          // println("USED CLASSES: ${project.usedClasses}")
+          it.replace('/', '.').removeSuffix(".class") in project.usedClasses
+        }
+        .mapTo(TreeSet()) { (classReference, dependency) ->
+          DuplicateClass(
+            variant = project.variant,
+            classpathName = classpathName,
+            classReference = classReference,
+            dependencies = dependency.toSortedSet(),
+          )
+        }
+    }
+
+    private fun inspectJar(artifact: ResolvedArtifactResult) {
+      val zip = ZipFile(artifact.file)
+
+      val coordinates = artifact.toCoordinates()
+
+      // Create multimap of classname to [dependencies]
+      zip.asSequenceOfClassFiles()
+        .map(ZipEntry::getName)
+        .forEach { duplicatesMap.put(it, coordinates) }
+    }
+  }
+}

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/BuildScript.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/BuildScript.kt
@@ -76,6 +76,7 @@ public class BuildScript(
       }
 
       appendLine(additions)
+      appendLine()
     }
 
     if (!dependencies.isEmpty) {

--- a/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestGroovy.kt
+++ b/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestGroovy.kt
@@ -471,7 +471,6 @@ internal class ScribeTestGroovy {
         java = Java.ofFeatures(Feature.ofName("cyber"), Feature.ofName("punk")),
         additions = """
           ext.magic = "octarine"
-          
         """.trimIndent()
       )
 


### PR DESCRIPTION
At this point, not sure what to do but warn. Providing more detailed advice would require much more information about the _structure_ of the class files, which is a problem we've avoided till now. We'd basically need an AST and an understanding of how the classes are used, vs simply seeing the classes referenced in bytecode.

Follow-ups:
1. Enable filtering.
2. Turn warning into error by resolving issue mentioned in paragraph above.