### PR TITLE
chore: use asm-relocated 9.7.1.0.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 antlr-shadowed = "4.10.1.6"
-asm-relocated = "9.6.0.1"
+asm-relocated = "9.7.1.0"
 caffeine = "3.1.8"
 commons-io = "2.16.0"
 dagp = "1.33.0"


### PR DESCRIPTION
Resolves https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1297.