### PR TITLE
Update Kotlin DSL rewriting functionality to use KotlinEditor

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -119,6 +119,8 @@ dependencies {
 
   implementation(project(":graph-support"))
   implementation(libs.kotlin.stdlib.jdk8)
+  implementation(libs.kotlin.editor.core)
+  implementation(libs.kotlin.editor.grammar)
   implementation(libs.moshi.kotlin)
   implementation(libs.moshix.sealed.reflect)
   implementation(libs.okio)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -119,8 +119,7 @@ dependencies {
 
   implementation(project(":graph-support"))
   implementation(libs.kotlin.stdlib.jdk8)
-  implementation(libs.kotlin.editor.core)
-  implementation(libs.kotlin.editor.grammar)
+  implementation(libs.kotlin.editor.relocated)
   implementation(libs.moshi.kotlin)
   implementation(libs.moshix.sealed.reflect)
   implementation(libs.okio)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ kotlin = "1.9.25"
 
 # Cannot be called kotlin-editor as it causes `libs.versions.kotlin.get()` to fail
 kotlineditor-core = "0.10"
-kotlineditor-relocated = "0.10.0-SNAPSHOT"
+kotlineditor-relocated = "0.10.0"
 
 kotlinx-metadata = "0.9.0"
 moshi = "1.15.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+antlr-base = "4.10.1"
 antlr-shadowed = "4.10.1.6"
 asm-relocated = "9.7.1.0"
 caffeine = "3.1.8"
@@ -11,7 +12,11 @@ guava = "33.1.0-jre"
 java = "11"
 junit = "5.10.2"
 kotlin = "1.9.25"
-kotlineditor = "0.10" # Cannot be called kotlin-editor as it causes `libs.versions.kotlin.get()` to fail
+
+# Cannot be called kotlin-editor as it causes `libs.versions.kotlin.get()` to fail
+kotlineditor = "0.10"
+kotlineditor-shaded = "0.10.0-SNAPSHOT"
+
 kotlinx-metadata = "0.9.0"
 moshi = "1.15.1"
 moshix = "0.25.1"
@@ -27,6 +32,9 @@ agp-common = "31.2.0"
 [libraries]
 agp = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 android-tools-common = { module = "com.android.tools:common", version.ref = "agp-common" }
+
+antlr-core = { module = "org.antlr:antlr4", version.ref = "antlr-base" }
+antlr-runtime = { module = "org.antlr:antlr4-runtime", version.ref = "antlr-base" }
 
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }
 commons-io = { module = "commons-io:commons-io", version.ref = "commons-io" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ guava = "33.1.0-jre"
 java = "11"
 junit = "5.10.2"
 kotlin = "1.9.25"
+kotlineditor = "0.10" # Cannot be called kotlin-editor as it causes `libs.versions.kotlin.get()` to fail
 kotlinx-metadata = "0.9.0"
 moshi = "1.15.1"
 moshix = "0.25.1"
@@ -38,6 +39,8 @@ javax-inject = "javax.inject:javax.inject:1"
 
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
 kotlin-dokka = { module = "org.jetbrains.dokka:kotlin-as-java-plugin", version.ref = "kotlin" }
+kotlin-editor-core = { module = "app.cash.kotlin-editor:core", version.ref = "kotlineditor" }
+kotlin-editor-grammar = { module = "app.cash.kotlin-editor:grammar", version.ref = "kotlineditor" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-stdlib-core = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ junit = "5.10.2"
 kotlin = "1.9.25"
 
 # Cannot be called kotlin-editor as it causes `libs.versions.kotlin.get()` to fail
-kotlineditor = "0.10"
+kotlineditor-core = "0.10"
 kotlineditor-shaded = "0.10.0-SNAPSHOT"
 
 kotlinx-metadata = "0.9.0"
@@ -47,8 +47,8 @@ javax-inject = "javax.inject:javax.inject:1"
 
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
 kotlin-dokka = { module = "org.jetbrains.dokka:kotlin-as-java-plugin", version.ref = "kotlin" }
-kotlin-editor-core = { module = "app.cash.kotlin-editor:core", version.ref = "kotlineditor" }
-kotlin-editor-grammar = { module = "app.cash.kotlin-editor:grammar", version.ref = "kotlineditor" }
+kotlin-editor-core = { module = "app.cash.kotlin-editor:core", version.ref = "kotlineditor-core" }
+kotlin-editor-grammar = { module = "app.cash.kotlin-editor:grammar", version.ref = "kotlineditor-core" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-stdlib-core = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ kotlin = "1.9.25"
 
 # Cannot be called kotlin-editor as it causes `libs.versions.kotlin.get()` to fail
 kotlineditor-core = "0.10"
-kotlineditor-shaded = "0.10.0-SNAPSHOT"
+kotlineditor-relocated = "0.10.0-SNAPSHOT"
 
 kotlinx-metadata = "0.9.0"
 moshi = "1.15.1"
@@ -47,8 +47,11 @@ javax-inject = "javax.inject:javax.inject:1"
 
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
 kotlin-dokka = { module = "org.jetbrains.dokka:kotlin-as-java-plugin", version.ref = "kotlin" }
+
 kotlin-editor-core = { module = "app.cash.kotlin-editor:core", version.ref = "kotlineditor-core" }
 kotlin-editor-grammar = { module = "app.cash.kotlin-editor:grammar", version.ref = "kotlineditor-core" }
+kotlin-editor-relocated = { module = "com.autonomousapps:kotlin-editor-relocated", version.ref = "kotlineditor-relocated" }
+
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-stdlib-core = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -81,6 +81,7 @@ include(":graph-support")
 
 includeShadowed("antlr")
 includeShadowed("asm-relocated")
+includeShadowed("kotlin-editor-relocated")
 
 // https://docs.gradle.org/5.6/userguide/groovy_plugin.html#sec:groovy_compilation_avoidance
 enableFeaturePreview("GROOVY_COMPILATION_AVOIDANCE")

--- a/shadowed/antlr/build.gradle.kts
+++ b/shadowed/antlr/build.gradle.kts
@@ -11,8 +11,7 @@ plugins {
   // This project doesn't need Kotlin, but it is now applied thanks to `convention`. problem?
 }
 
-val antlrVersion = "4.10.1"
-version = "$antlrVersion.6"
+version = "${libs.versions.antlr.base.get()}.6"
 
 val isSnapshot = version.toString().endsWith("SNAPSHOT", true)
 
@@ -50,8 +49,8 @@ configurations.runtimeClasspath {
 }
 
 dependencies {
-  antlr("org.antlr:antlr4:$antlrVersion")
-  runtimeOnly("org.antlr:antlr4-runtime:$antlrVersion")
+  antlr(libs.antlr.core)
+  runtimeOnly(libs.antlr.runtime)
   implementation(libs.grammar)
 
   testImplementation(libs.spock)

--- a/shadowed/kotlin-editor-relocated/CHANGELOG.md
+++ b/shadowed/kotlin-editor-relocated/CHANGELOG.md
@@ -1,0 +1,6 @@
+kotlin-editor-relocated
+
+See https://github.com/cashapp/kotlin-editor
+
+## Version 0.10.0
+* First release.

--- a/shadowed/kotlin-editor-relocated/README.md
+++ b/shadowed/kotlin-editor-relocated/README.md
@@ -1,0 +1,7 @@
+# kotlin-editor-relocated
+
+This shadow module exists only to shade the [KotlinEditor](https://github.com/cashapp/kotlin-editor) project, and only
+because we don't want to permit a non-shaded version of `antlr` to end up in the DAGP runtime. That is a heavily-used 
+tool, and classpath conflicts are common and annoying. This is a heavy workaround, but it does work. We do it as a 
+separate project because it is likely to be a stable artifact, and that will keep the final size of the DAGP jar small,
+which is important in a world of ephemeral CI constantly re-downloading the internet.

--- a/shadowed/kotlin-editor-relocated/RELEASING.md
+++ b/shadowed/kotlin-editor-relocated/RELEASING.md
@@ -7,6 +7,8 @@ Release procedure for kotlin-editor-relocated
 1. `git commit -am "Prepare for kotlin-editor-relocated release x."`.
 1. Publish: `./gradlew :kotlin-editor-relocated:publishToMavenCentral`.
 1. `git tag -a kotlin-editor-relocated-x -m "kotlin-editor-relocated version x."`.
+1. Update version number in `kotlin-editor-relocated/build.gradle.kts` to next snapshot version (x.y.z-SNAPSHOT).
+1. `git commit -am "Prepare next development version."`
 1. `git push && git push --tags`.
 1. (Optional) Follow instructions in console output to release from Maven Central's staging repo.
    This step is now automated via the `:promote` task, and should only be necessary if that task

--- a/shadowed/kotlin-editor-relocated/RELEASING.md
+++ b/shadowed/kotlin-editor-relocated/RELEASING.md
@@ -1,12 +1,13 @@
 Release procedure for kotlin-editor-relocated
 
-1. Update CHANGELOG
-1. Update README if needed
+1. Update CHANGELOG.
+1. Update README if needed.
 1. Verify shadow jar. Run `./gradlew :kotlin-editor-relocated:shadowJar`. Manually inspect contents.
-1. `git commit -am "Prepare for kotlin-editor-relocated release x."`
-1. Publish: `./gradlew :kotlin-editor-relocated:publishToMavenCentral`
-1. `git tag -a kotlin-editor-relocated-x -m "kotlin-editor-relocated version x."`
-1. `git push && git push --tags`
+1. Update version in `kotlin-editor-relocated/build.gradle.kts`.
+1. `git commit -am "Prepare for kotlin-editor-relocated release x."`.
+1. Publish: `./gradlew :kotlin-editor-relocated:publishToMavenCentral`.
+1. `git tag -a kotlin-editor-relocated-x -m "kotlin-editor-relocated version x."`.
+1. `git push && git push --tags`.
 1. (Optional) Follow instructions in console output to release from Maven Central's staging repo.
    This step is now automated via the `:promote` task, and should only be necessary if that task
    fails.

--- a/shadowed/kotlin-editor-relocated/RELEASING.md
+++ b/shadowed/kotlin-editor-relocated/RELEASING.md
@@ -1,0 +1,12 @@
+Release procedure for kotlin-editor-relocated
+
+1. Update CHANGELOG
+1. Update README if needed
+1. Verify shadow jar. Run `./gradlew :kotlin-editor-relocated:shadowJar`. Manually inspect contents.
+1. `git commit -am "Prepare for kotlin-editor-relocated release x."`
+1. Publish: `./gradlew :kotlin-editor-relocated:publishToMavenCentral`
+1. `git tag -a kotlin-editor-relocated-x -m "kotlin-editor-relocated version x."`
+1. `git push && git push --tags`
+1. (Optional) Follow instructions in console output to release from Maven Central's staging repo.
+   This step is now automated via the `:promote` task, and should only be necessary if that task
+   fails.

--- a/shadowed/kotlin-editor-relocated/build.gradle.kts
+++ b/shadowed/kotlin-editor-relocated/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
   id("com.github.johnrengelman.shadow")
 }
 
-version = "0.1-SNAPSHOT"
+version = "${libs.versions.kotlineditor.core.get()}.0-SNAPSHOT"
 
 dagp {
   version(version)

--- a/shadowed/kotlin-editor-relocated/build.gradle.kts
+++ b/shadowed/kotlin-editor-relocated/build.gradle.kts
@@ -1,0 +1,70 @@
+plugins {
+  id("convention")
+  id("com.github.johnrengelman.shadow")
+}
+
+version = "0.1-SNAPSHOT"
+
+dagp {
+  version(version)
+  pom {
+    name.set("KotlinEditor-Shaded")
+    description.set("Shaded version of KotlinEditor")
+    inceptionYear.set("2024")
+  }
+  publishTaskDescription("Publishes to Maven Central and promotes.")
+}
+
+dependencies {
+  implementation(libs.kotlin.editor.core)
+  implementation(libs.kotlin.editor.grammar)
+
+  runtimeOnly(libs.antlr.runtime)
+}
+
+// Excluding icu4j because it bloats artifact size significantly
+configurations.runtimeClasspath {
+  exclude(group = "com.ibm.icu", module = "icu4j")
+}
+
+tasks.jar {
+  // Change the classifier of the original 'jar' task so that it does not overlap with the 'shadowJar' task
+  archiveClassifier.set("plain")
+}
+
+tasks.shadowJar {
+  archiveClassifier.set("")
+
+  relocate("org.antlr", "com.autonomousapps.internal.antlr")
+  relocate("org.glassfish.json", "com.autonomousapps.internal.glassfish.json")
+  relocate("javax.json", "com.autonomousapps.internal.javax.json")
+  relocate("org.abego.treelayout", "com.autonomousapps.internal.abego.treelayout")
+  relocate("org.stringtemplate.v4", "com.autonomousapps.internal.stringtemplate.v4")
+
+  // Directly from KotlinEditor
+  relocate("com.squareup.cash.grammar", "com.autonomousapps.internal.squareup.cash.grammar")
+  relocate("cash.grammar", "com.autonomousapps.internal.cash.grammar")
+
+  dependencies {
+    // Don't bundle Kotlin or other Jetbrains dependencies
+    exclude {
+      it.moduleGroup.startsWith("org.jetbrains")
+    }
+    // Don't bundle in emoji support
+    exclude {
+      it.moduleGroup == "com.ibm.icu"
+    }
+  }
+}
+
+tasks.assemble {
+  dependsOn(tasks.shadowJar)
+}
+
+val javaComponent = components["java"] as AdhocComponentWithVariants
+listOf("apiElements", "runtimeElements").forEach { unpublishable ->
+  // Hide the un-shadowed variants in local consumption
+  configurations[unpublishable].isCanBeConsumed = false
+  // Hide the un-shadowed variants in publishing
+  javaComponent.withVariantsFromConfiguration(configurations[unpublishable]) { skip() }
+}

--- a/shadowed/kotlin-editor-relocated/build.gradle.kts
+++ b/shadowed/kotlin-editor-relocated/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
   id("com.github.johnrengelman.shadow")
 }
 
-version = "${libs.versions.kotlineditor.core.get()}.0-SNAPSHOT"
+version = "${libs.versions.kotlineditor.core.get()}.0"
 
 dagp {
   version(version)

--- a/shadowed/kotlin-editor-relocated/build.gradle.kts
+++ b/shadowed/kotlin-editor-relocated/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
   id("com.github.johnrengelman.shadow")
 }
 
-version = "${libs.versions.kotlineditor.core.get()}.0"
+version = "${libs.versions.kotlineditor.core.get()}.1-SNAPSHOT"
 
 dagp {
   version(version)

--- a/src/main/kotlin/com/autonomousapps/internal/parse/BuildScriptDependenciesRewriter.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/parse/BuildScriptDependenciesRewriter.kt
@@ -1,0 +1,28 @@
+package com.autonomousapps.internal.parse
+
+import com.autonomousapps.internal.advice.AdvicePrinter
+import com.autonomousapps.internal.advice.DslKind
+import com.autonomousapps.model.Advice
+import java.io.File
+
+internal interface BuildScriptDependenciesRewriter {
+  fun rewritten(): String
+
+  companion object {
+    fun of(
+      file: File,
+      advice: Set<Advice>,
+      advicePrinter: AdvicePrinter,
+      reversedDependencyMap: (String) -> String = { it },
+    ): BuildScriptDependenciesRewriter {
+      val dslKind = DslKind.from(file)
+      val filePath = file.toPath()
+
+      return when (dslKind) {
+        DslKind.KOTLIN -> KotlinBuildScriptDependenciesRewriter.of(filePath, advice, advicePrinter, reversedDependencyMap)
+        DslKind.GROOVY -> GroovyBuildScriptDependenciesRewriter.of(filePath, advice, advicePrinter, reversedDependencyMap)
+      }
+    }
+  }
+}
+

--- a/src/main/kotlin/com/autonomousapps/internal/parse/KotlinBuildScriptDependenciesRewriter.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/parse/KotlinBuildScriptDependenciesRewriter.kt
@@ -1,0 +1,177 @@
+package com.autonomousapps.internal.parse
+
+import cash.grammar.kotlindsl.model.DependencyDeclaration
+import cash.grammar.kotlindsl.parse.Parser
+import cash.grammar.kotlindsl.parse.Rewriter
+import cash.grammar.kotlindsl.utils.Blocks.isBuildscript
+import cash.grammar.kotlindsl.utils.Blocks.isDependencies
+import cash.grammar.kotlindsl.utils.CollectingErrorListener
+import cash.grammar.kotlindsl.utils.Context.leafRule
+import cash.grammar.kotlindsl.utils.DependencyExtractor
+import cash.grammar.kotlindsl.utils.Whitespace
+import com.autonomousapps.exception.BuildScriptParseException
+import com.autonomousapps.internal.advice.AdvicePrinter
+import com.autonomousapps.internal.utils.filterToOrderedSet
+import com.autonomousapps.internal.utils.filterToSet
+import com.autonomousapps.internal.utils.ifNotEmpty
+import com.autonomousapps.model.Advice
+import com.squareup.cash.grammar.KotlinParser.NamedBlockContext
+import com.squareup.cash.grammar.KotlinParser.PostfixUnaryExpressionContext
+import com.squareup.cash.grammar.KotlinParser.ScriptContext
+import com.squareup.cash.grammar.KotlinParserBaseListener
+import org.antlr.v4.runtime.CharStream
+import org.antlr.v4.runtime.CommonTokenStream
+import org.antlr.v4.runtime.Token
+import java.nio.file.Path
+
+/**
+ * Rewrites a Kotlin build script based on provided advice, which includes:
+ *
+ * - When entering the `dependencies` block, processing each dependency declaration to either remove or update it according to the advice provided.
+ * - Upon exiting the `dependencies` block, adding any new dependencies.
+ * - At the end of the script, adding a `dependencies` block if new dependencies are present and the block is currently missing.
+ *
+ * Note: Buildscript dependencies are ignored.
+ */
+internal class KotlinBuildScriptDependenciesRewriter(
+  private val input: CharStream,
+  private val tokens: CommonTokenStream,
+  private val errorListener: CollectingErrorListener,
+  private val advice: Set<Advice>,
+  private val printer: AdvicePrinter,
+  /** Reverse map from custom representation to standard. */
+  private val reversedDependencyMap: (String) -> String,
+) : BuildScriptDependenciesRewriter, KotlinParserBaseListener() {
+  private val rewriter = Rewriter(tokens)
+  private val indent = Whitespace.computeIndent(tokens, input)
+
+  private val dependencyExtractor = DependencyExtractor(
+    input = input,
+    tokens = tokens,
+    indent = indent,
+  )
+
+  private var hasDependenciesBlock = false
+  private var inBuildscriptBlock = false
+
+  /**
+   * Returns build script with advice applied.
+   *
+   * Throws [BuildScriptParseException] if the script has some idiosyncrasy that impairs parsing.
+   *
+   */
+  @Throws(BuildScriptParseException::class)
+  override fun rewritten(): String {
+    errorListener.getErrorMessages().ifNotEmpty {
+      throw BuildScriptParseException.withErrors(it)
+    }
+
+    return rewriter.text
+  }
+
+  override fun enterNamedBlock(ctx: NamedBlockContext) {
+    dependencyExtractor.onEnterBlock()
+
+    if (ctx.isBuildscript) {
+      inBuildscriptBlock = true
+    }
+
+    if (ctx.isDependencies) {
+      handleDependencies(ctx)
+    }
+  }
+
+  override fun exitNamedBlock(ctx: NamedBlockContext) {
+    if (ctx.isDependencies && !inBuildscriptBlock) {
+      hasDependenciesBlock = true
+      insertAdvice(advice, ctx.stop, withDependenciesBlock = false)
+    }
+
+    // Must be last
+    if (ctx.isBuildscript) {
+      inBuildscriptBlock = false
+    }
+
+    dependencyExtractor.onExitBlock()
+  }
+
+  override fun exitScript(ctx: ScriptContext) {
+    // Exit early if this build script has a dependencies block. If it doesn't, we may need to add missing dependencies.
+    if (hasDependenciesBlock) return
+
+    insertAdvice(advice, ctx.stop, withDependenciesBlock = true)
+  }
+
+  private fun insertAdvice(advice: Set<Advice>, beforeToken: Token, withDependenciesBlock: Boolean) {
+    val prefix = if (withDependenciesBlock) "\ndependencies {\n" else ""
+    val postfix = if (withDependenciesBlock) "\n}\n" else "\n"
+
+    advice.filterToOrderedSet { it.isAnyAdd() }.ifNotEmpty { addAdvice ->
+      rewriter.insertBefore(
+        beforeToken,
+        addAdvice.joinToString(prefix = prefix, postfix = postfix, separator = "\n") { a ->
+          printer.toDeclaration(a)
+        }
+      )
+    }
+  }
+
+  private fun handleDependencies(ctx: NamedBlockContext) {
+    if (inBuildscriptBlock) return
+
+    val dependencyContainer = dependencyExtractor.collectDependencies(ctx)
+    dependencyContainer.getDependencyDeclarationsWithContext().forEach {
+      if (it.statement.leafRule() !is PostfixUnaryExpressionContext) return@forEach
+
+      val context = it.statement.leafRule() as PostfixUnaryExpressionContext
+      val declaration = it.declaration
+
+      findAdvice(declaration)?.let { a ->
+        if (a.isAnyRemove()) {
+          rewriter.delete(context.start, context.stop)
+          rewriter.deleteWhitespaceToLeft(context.start)
+          rewriter.deleteNewlineToRight(context.stop)
+        } else if (a.isAnyChange()) {
+          rewriter.replace(context.start, context.stop, printer.toDeclaration(a).trim())
+        }
+      }
+    }
+  }
+
+  private fun findAdvice(dependencyDeclaration: DependencyDeclaration): Advice? {
+    val dependency = reversedDependencyMap(dependencyDeclaration.identifier.path.removeSurrounding("\""))
+
+    return advice.find {
+      (it.coordinates.gav() == dependency || it.coordinates.identifier == dependency)
+        && it.fromConfiguration == dependencyDeclaration.configuration
+    }
+  }
+
+  companion object {
+    @JvmStatic
+    fun of(
+      file: Path,
+      advice: Set<Advice>,
+      advicePrinter: AdvicePrinter,
+      reversedDependencyMap: (String) -> String = { it }
+    ): KotlinBuildScriptDependenciesRewriter {
+      val errorListener = CollectingErrorListener()
+
+      return Parser(
+        file = Parser.readOnlyInputStream(file),
+        errorListener = errorListener,
+        startRule = { it.script() },
+        listenerFactory = { input, tokens, _ ->
+          KotlinBuildScriptDependenciesRewriter(
+            input = input,
+            tokens = tokens,
+            errorListener = errorListener,
+            advice = advice,
+            printer = advicePrinter,
+            reversedDependencyMap = reversedDependencyMap
+          )
+        }
+      ).listener()
+    }
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/tasks/RewriteTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/RewriteTask.kt
@@ -7,7 +7,7 @@ import com.autonomousapps.exception.BuildScriptParseException
 import com.autonomousapps.extension.DependenciesHandler.Companion.toLambda
 import com.autonomousapps.internal.advice.AdvicePrinter
 import com.autonomousapps.internal.advice.DslKind
-import com.autonomousapps.internal.parse.GradleBuildScriptDependenciesRewriter
+import com.autonomousapps.internal.parse.BuildScriptDependenciesRewriter
 import com.autonomousapps.internal.utils.filterToSet
 import com.autonomousapps.internal.utils.fromJson
 import com.autonomousapps.internal.utils.reversed
@@ -61,8 +61,8 @@ abstract class RewriteTask : DefaultTask() {
 
     val map = dependencyMap.get()
 
-    val rewriter = GradleBuildScriptDependenciesRewriter.newRewriter(
-      file = buildScript.toPath(),
+    val rewriter = BuildScriptDependenciesRewriter.of(
+      file = buildScript,
       advice = projectAdvice.dependencyAdvice.filtered(isUpgrade),
       advicePrinter = AdvicePrinter(
         dslKind = dslKind,

--- a/src/test/kotlin/com/autonomousapps/internal/parse/GroovyBuildScriptDependenciesRewriterTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/parse/GroovyBuildScriptDependenciesRewriterTest.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Files
 import java.nio.file.Path
 
-internal class GradleBuildScriptDependenciesRewriterTest {
+internal class GroovyBuildScriptDependenciesRewriterTest {
 
   @TempDir
   lateinit var dir: Path
@@ -62,7 +62,7 @@ internal class GradleBuildScriptDependenciesRewriterTest {
     )
 
     // When
-    val parser = GradleBuildScriptDependenciesRewriter.newRewriter(
+    val parser = GroovyBuildScriptDependenciesRewriter.of(
       sourceFile,
       advice,
       AdvicePrinter(DslKind.GROOVY),
@@ -142,7 +142,7 @@ internal class GradleBuildScriptDependenciesRewriterTest {
     )
 
     // When
-    val parser = GradleBuildScriptDependenciesRewriter.newRewriter(
+    val parser = GroovyBuildScriptDependenciesRewriter.of(
       sourceFile,
       advice,
       AdvicePrinter(
@@ -253,7 +253,7 @@ internal class GradleBuildScriptDependenciesRewriterTest {
     )
 
     // When
-    val parser = GradleBuildScriptDependenciesRewriter.newRewriter(
+    val parser = GroovyBuildScriptDependenciesRewriter.of(
       sourceFile,
       advice,
       AdvicePrinter(DslKind.GROOVY),
@@ -319,7 +319,7 @@ internal class GradleBuildScriptDependenciesRewriterTest {
     )
 
     // When
-    val parser = GradleBuildScriptDependenciesRewriter.newRewriter(
+    val parser = GroovyBuildScriptDependenciesRewriter.of(
       sourceFile,
       emptySet(),
       AdvicePrinter(DslKind.GROOVY),
@@ -368,7 +368,7 @@ internal class GradleBuildScriptDependenciesRewriterTest {
     )
 
     // When
-    val parser = GradleBuildScriptDependenciesRewriter.newRewriter(
+    val parser = GroovyBuildScriptDependenciesRewriter.of(
       sourceFile,
       advice,
       AdvicePrinter(DslKind.GROOVY),
@@ -446,7 +446,7 @@ internal class GradleBuildScriptDependenciesRewriterTest {
     )
 
     // When
-    val parser = GradleBuildScriptDependenciesRewriter.newRewriter(
+    val parser = GroovyBuildScriptDependenciesRewriter.of(
       sourceFile,
       advice,
       AdvicePrinter(DslKind.GROOVY),

--- a/src/test/kotlin/com/autonomousapps/internal/parse/KotlinBuildScriptDependenciesRewriterTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/parse/KotlinBuildScriptDependenciesRewriterTest.kt
@@ -1,0 +1,530 @@
+package com.autonomousapps.internal.parse
+
+import com.autonomousapps.internal.advice.AdvicePrinter
+import com.autonomousapps.internal.advice.DslKind
+import com.autonomousapps.model.Advice
+import com.autonomousapps.model.Coordinates
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+internal class KotlinBuildScriptDependenciesRewriterTest {
+  @TempDir
+  lateinit var dir: Path
+
+  @Test fun `can update dependencies`() {
+    // Given
+    val sourceFile = dir.resolve("build.gradle.kts")
+    sourceFile.writeText(
+      """
+        import foo
+        import bar
+
+        plugins {
+          id("foo")
+        }
+
+        repositories {
+          google()
+          mavenCentral()
+        }
+
+        apply(plugin = "bar")
+
+        extra["magic"] = 42
+
+        android {
+          whatever
+        }
+
+        dependencies {
+          implementation("heart:of-gold:1.+")
+          api(project(":marvin"))
+          testImplementation("pan-galactic:gargle-blaster:2.0-SNAPSHOT") {
+              because("life's too short not to")
+          }
+        }
+
+        println("hello, world!")
+      """.trimIndent()
+    )
+    val advice = setOf(
+      Advice.ofChange(Coordinates.of(":marvin"), "api", "compileOnly"),
+      Advice.ofRemove(Coordinates.of("pan-galactic:gargle-blaster:2.0-SNAPSHOT"), "testImplementation"),
+      Advice.ofAdd(Coordinates.of(":sad-robot"), "runtimeOnly"),
+    )
+
+    // When
+    val parser = KotlinBuildScriptDependenciesRewriter.of(sourceFile, advice, AdvicePrinter(DslKind.KOTLIN))
+
+    // Then
+    assertThat(parser.rewritten().trimmedLines()).containsExactlyElementsIn(
+      """
+        import foo
+        import bar
+
+        plugins {
+          id("foo")
+        }
+
+        repositories {
+          google()
+          mavenCentral()
+        }
+
+        apply(plugin = "bar")
+
+        extra["magic"] = 42
+
+        android {
+          whatever
+        }
+
+        dependencies {
+          implementation("heart:of-gold:1.+")
+          compileOnly(project(":marvin"))
+          runtimeOnly(project(":sad-robot"))
+        }
+
+        println("hello, world!")
+      """.trimIndent().trimmedLines()
+    )
+  }
+
+  @Test fun `can update dependencies with dependencyMap`() {
+    // Given
+    val sourceFile = dir.resolve("build.gradle.kts")
+    sourceFile.writeText(
+      """
+        import foo
+        import bar
+
+        plugins {
+          id("foo")
+        }
+
+        repositories {
+          google()
+          mavenCentral()
+        }
+
+        apply(plugin = "bar")
+
+        extra["magic"] = 42
+
+        android {
+          whatever
+        }
+
+        dependencies {
+          implementation("heart:of-gold:1.+")
+          api(project(":marvin"))
+          api(libs.fordPrefect)
+          testImplementation("pan-galactic:gargle-blaster:2.0-SNAPSHOT") {
+              because("life's too short not to")
+          }
+        }
+
+        println("hello, world!")
+      """.trimIndent()
+    )
+
+    val advice = setOf(
+      Advice.ofChange(Coordinates.of(":marvin"), "api", "compileOnly"),
+      Advice.ofChange(Coordinates.of("ford:prefect:1.0"), "api", "implementation"),
+      Advice.ofRemove(Coordinates.of("pan-galactic:gargle-blaster:2.0-SNAPSHOT"), "testImplementation"),
+      Advice.ofAdd(Coordinates.of(":sad-robot"), "runtimeOnly"),
+      Advice.ofAdd(Coordinates.of("magrathea:asleep:1000000"), "implementation"),
+    )
+
+    // When
+    val parser = KotlinBuildScriptDependenciesRewriter.of(
+      sourceFile,
+      advice,
+      AdvicePrinter(
+        dslKind = DslKind.KOTLIN,
+        dependencyMap = {
+          when (it) {
+            ":sad-robot" -> "\":depressed-robot\""
+            "magrathea:asleep:1000000" -> "deps.magrathea"
+            "ford:prefect" -> "libs.fordPrefect"
+            else -> null
+          }
+        }
+      ),
+      reversedDependencyMap = {
+        when (it) {
+          "\":depressed-robot\"" -> ":sad-robot"
+          "deps.magrathea" -> "magrathea:asleep:1000000"
+          "libs.fordPrefect" -> "ford:prefect"
+          else -> it
+        }
+      }
+    )
+
+    // Then
+    assertThat(parser.rewritten().trimmedLines()).containsExactlyElementsIn(
+      """
+        import foo
+        import bar
+
+        plugins {
+          id("foo")
+        }
+
+        repositories {
+          google()
+          mavenCentral()
+        }
+
+        apply(plugin = "bar")
+
+        extra["magic"] = 42
+
+        android {
+          whatever
+        }
+
+        dependencies {
+          implementation("heart:of-gold:1.+")
+          compileOnly(project(":marvin"))
+          implementation(libs.fordPrefect)
+          implementation(deps.magrathea)
+          runtimeOnly(project(":depressed-robot"))
+        }
+
+        println("hello, world!")
+      """.trimIndent().trimmedLines()
+    )
+  }
+
+  @Test fun `ignores buildscript dependencies`() {
+    // Given
+    val sourceFile = dir.resolve("build.gradle.kts")
+    sourceFile.writeText(
+      """
+      import foo
+      import bar
+
+      // see https://github.com/dropbox/dropbox-sdk-java/blob/master/build.gradle
+      buildscript {
+        extra["foo"] = "ba/r"
+        fizzle()
+        repositories {
+          google()
+          maven { url = uri("https://plugins.gradle.org/m2/") }
+        }
+        dependencies {
+          classpath("com.github.ben-manes:gradle-versions-plugin:0.27.0")
+          classpath(files("gradle/dropbox-pem-converter-plugin"))
+        }
+      }
+
+      plugins {
+        id("foo")
+      }
+
+      repositories {
+        google()
+        mavenCentral()
+      }
+
+      apply(plugin = "bar")
+
+      extra["magic"] = 42
+
+      android {
+        whatever
+      }
+
+      dependencies {
+        implementation("heart:of-gold:1.+")
+        api(project(":marvin"))
+        testImplementation("pan-galactic:gargle-blaster:2.0-SNAPSHOT") {
+          because("life's too short not to")
+        }
+      }
+
+      println("hello, world!")
+    """.trimIndent()
+    )
+    val advice = setOf(
+      Advice.ofChange(Coordinates.of(":marvin"), "api", "compileOnly"),
+      Advice.ofRemove(Coordinates.of("pan-galactic:gargle-blaster:2.0-SNAPSHOT"), "testImplementation"),
+      Advice.ofAdd(Coordinates.of(":sad-robot"), "runtimeOnly"),
+    )
+
+    // When
+    val parser = KotlinBuildScriptDependenciesRewriter.of(
+      sourceFile,
+      advice,
+      AdvicePrinter(DslKind.KOTLIN),
+    )
+
+    // Then
+    assertThat(parser.rewritten().trimmedLines()).containsExactlyElementsIn(
+      """
+      import foo
+      import bar
+
+      // see https://github.com/dropbox/dropbox-sdk-java/blob/master/build.gradle
+      buildscript {
+        extra["foo"] = "ba/r"
+        fizzle()
+        repositories {
+          google()
+          maven { url = uri("https://plugins.gradle.org/m2/") }
+        }
+        dependencies {
+          classpath("com.github.ben-manes:gradle-versions-plugin:0.27.0")
+          classpath(files("gradle/dropbox-pem-converter-plugin"))
+        }
+      }
+
+      plugins {
+        id("foo")
+      }
+
+      repositories {
+        google()
+        mavenCentral()
+      }
+
+      apply(plugin = "bar")
+
+      extra["magic"] = 42
+
+      android {
+        whatever
+      }
+
+      dependencies {
+        implementation("heart:of-gold:1.+")
+        compileOnly(project(":marvin"))
+        runtimeOnly(project(":sad-robot"))
+      }
+
+      println("hello, world!")
+      """.trimIndent().trimmedLines()
+    )
+  }
+
+  @Test fun `can handle testFixtures`() {
+    // Given
+    val sourceFile = dir.resolve("build.gradle.kts")
+    sourceFile.writeText(
+      """
+        dependencies {
+          implementation("heart:of-gold:1.+")
+          implementation(testFixtures(project(":foo")))
+        }
+      """.trimIndent()
+    )
+
+    // When
+    val parser = KotlinBuildScriptDependenciesRewriter.of(
+      sourceFile,
+      emptySet(),
+      AdvicePrinter(DslKind.KOTLIN),
+    )
+
+    // Then
+    assertThat(parser.rewritten().trimmedLines()).containsExactlyElementsIn(
+      """
+        dependencies {
+          implementation("heart:of-gold:1.+")
+          implementation(testFixtures(project(":foo")))
+        }
+      """.trimIndent().trimmedLines()
+    ).inOrder()
+  }
+
+  @Test fun `can add dependencies to build script that didn't have a dependencies block`() {
+    // Given
+    val sourceFile = dir.resolve("build.gradle.kts")
+    sourceFile.writeText(
+      """
+        plugins {
+          id("foo")
+        }
+
+        repositories {
+          google()
+          mavenCentral()
+        }
+
+        apply(plugin = "bar")
+
+        extra["magic"] = 42
+
+        android {
+          whatever
+        }
+      """.trimIndent()
+    )
+
+    val advice = setOf(
+      Advice.ofChange(Coordinates.of(":marvin"), "api", "compileOnly"),
+      Advice.ofRemove(Coordinates.of("pan-galactic:gargle-blaster:2.0-SNAPSHOT"), "testImplementation"),
+      Advice.ofAdd(Coordinates.of(":sad-robot"), "runtimeOnly"),
+    )
+
+    // When
+    val parser = KotlinBuildScriptDependenciesRewriter.of(
+      sourceFile,
+      advice,
+      AdvicePrinter(DslKind.KOTLIN),
+    )
+
+    // Then
+    assertThat(parser.rewritten().trimmedLines()).containsExactlyElementsIn(
+      """
+        plugins {
+          id("foo")
+        }
+
+        repositories {
+          google()
+          mavenCentral()
+        }
+
+        apply(plugin = "bar")
+
+        extra["magic"] = 42
+
+        android {
+          whatever
+        }
+
+        dependencies {
+          runtimeOnly(project(":sad-robot"))
+        }
+      """.trimIndent().trimmedLines()
+    )
+  }
+
+  @Test fun `only removes dependencies on expected configuration`() {
+    // Given
+    val sourceFile = dir.resolve("build.gradle.kts")
+    sourceFile.writeText(
+      """
+        plugins {
+          id("foo")
+        }
+
+        repositories {
+          google()
+          mavenCentral()
+        }
+
+        apply(plugin = "bar")
+
+        extra["magic"] = 42
+
+        android {
+          whatever
+        }
+
+        dependencies {
+          implementation("heart:of-gold:1.+")
+          api(project(":marvin"))
+          testImplementation("pan-galactic:gargle-blaster:2.0-SNAPSHOT") {
+              because("life's too short not to")
+          }
+        }
+
+        println("hello, world!")
+      """.trimIndent()
+    )
+
+    val advice = setOf(
+      Advice.ofChange(Coordinates.of(":marvin"), "api", "compileOnly"),
+      Advice.ofRemove(Coordinates.of("pan-galactic:gargle-blaster:2.0-SNAPSHOT"), "implementation"),
+      Advice.ofAdd(Coordinates.of(":sad-robot"), "runtimeOnly"),
+    )
+
+    // When
+    val parser = KotlinBuildScriptDependenciesRewriter.of(
+      sourceFile,
+      advice,
+      AdvicePrinter(DslKind.KOTLIN),
+    )
+
+    // Then
+    assertThat(parser.rewritten().trimmedLines()).containsExactlyElementsIn(
+      """
+        plugins {
+          id("foo")
+        }
+
+        repositories {
+          google()
+          mavenCentral()
+        }
+
+        apply(plugin = "bar")
+
+        extra["magic"] = 42
+
+        android {
+          whatever
+        }
+
+        dependencies {
+          implementation("heart:of-gold:1.+")
+          compileOnly(project(":marvin"))
+          runtimeOnly(project(":sad-robot"))
+          testImplementation("pan-galactic:gargle-blaster:2.0-SNAPSHOT") {
+              because("life's too short not to")
+          }
+        }
+
+        println("hello, world!")
+      """.trimIndent().trimmedLines()
+    )
+  }
+
+  @Test fun `can parse complex dependencies`() {
+    // Given
+    val sourceFile = dir.resolve("build.gradle.kts")
+
+    sourceFile.writeText(
+      """
+      dependencies {
+        if (true) {
+          testImplementation("heart:of-gold:1.+") // stay as is
+        }
+
+        testImplementation("heart:of-gold:1.+")
+        devImplementation(group = "io.netty", name = "netty-transport-native-unix-common", classifier = "osx-aarch_64")
+      }
+      """.trimIndent())
+
+    val advice = setOf(Advice(Coordinates.of("heart:of-gold:1.+"), "testImplementation", "implementation"))
+    // When
+    val parser = KotlinBuildScriptDependenciesRewriter.of(
+      sourceFile,
+      advice,
+      AdvicePrinter(DslKind.KOTLIN),
+    )
+
+    // Then
+    assertThat(parser.rewritten().trimmedLines()).containsExactlyElementsIn(
+      """
+      dependencies {
+        if (true) {
+          testImplementation("heart:of-gold:1.+") // stay as is
+        }
+
+        implementation("heart:of-gold:1.+")
+        devImplementation(group = "io.netty", name = "netty-transport-native-unix-common", classifier = "osx-aarch_64")
+      }
+      """.trimIndent().trimmedLines()
+    ).inOrder()
+  }
+
+  private fun Path.writeText(text: String): Path = Files.writeString(this, text)
+  private fun String.trimmedLines() = lines().map { it.trimEnd() }
+}


### PR DESCRIPTION
## 📝 Description
Updating the `RewritingTask` to use [kotlin-editor](https://github.com/cashapp/kotlin-editor), which contains an updated grammar for more complex Kotlin Gradle build scripts. The grammar used for parsing Groovy build scripts remains unchanged.

Note: this depends on https://github.com/cashapp/kotlin-editor/pull/17