### PR TITLE
revert: feat: check binary compatibility when there are duplicate classes on the classpath.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/AbstractFunctionalSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/AbstractFunctionalSpec.groovy
@@ -39,15 +39,15 @@ abstract class AbstractFunctionalSpec extends Specification {
    */
   private static boolean isCi = System.getenv("CI") == "true"
 
-  def cleanup() {
-    // Delete fixtures on CI to prevent disk space growing out of bounds
-    if (gradleProject != null && isCi) {
-      try {
-        gradleProject.rootDir.deleteDir()
-      } catch (Throwable t) {
-      }
-    }
-  }
+//  def cleanup() {
+//    // Delete fixtures on CI to prevent disk space growing out of bounds
+//    if (gradleProject != null && isCi) {
+//      try {
+//        gradleProject.rootDir.deleteDir()
+//      } catch (Throwable t) {
+//      }
+//    }
+//  }
 
   protected static Boolean quick() {
     return System.getProperty('com.autonomousapps.quick').toBoolean()

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/DuplicateClasspathProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/DuplicateClasspathProject.groovy
@@ -176,6 +176,9 @@ final class DuplicateClasspathProject extends AbstractProject {
 
   private final Set<Advice> consumerAdvice = [
     Advice.ofRemove(projectCoordinates(':unused'), 'implementation'),
+    // This is actually bad advice, but we can't detect it without re-reverting the change to detect binary
+    // incompatibilities.
+    Advice.ofAdd(projectCoordinates(':producer-1'), 'implementation')
   ]
 
   final Set<ProjectAdvice> expectedProjectAdvice = [

--- a/src/main/kotlin/com/autonomousapps/internal/asm.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/asm.kt
@@ -9,7 +9,6 @@ import com.autonomousapps.internal.kotlin.AccessFlags
 import com.autonomousapps.internal.utils.METHOD_DESCRIPTOR_REGEX
 import com.autonomousapps.internal.utils.efficient
 import com.autonomousapps.internal.utils.genericTypes
-import com.autonomousapps.model.internal.intermediates.producer.Member
 import com.autonomousapps.model.internal.intermediates.consumer.MemberAccess
 import kotlinx.metadata.jvm.Metadata
 import org.gradle.api.logging.Logger
@@ -26,13 +25,14 @@ internal class ClassNameAndAnnotationsVisitor(private val logger: Logger) : Clas
   private lateinit var access: Access
   private var outerClassName: String? = null
   private var superClassName: String? = null
-  private var interfaces: Set<String>? = null
+
+  // private var interfaces: Set<String>? = null
   private val retentionPolicyHolder = AtomicReference("")
   private var isAnnotation = false
   private val methods = mutableSetOf<Method>()
   private val innerClasses = mutableSetOf<String>()
-  private val effectivelyPublicFields = mutableSetOf<Member.Field>()
-  private val effectivelyPublicMethods = mutableSetOf<Member.Method>()
+  // private val effectivelyPublicFields = mutableSetOf<Member.Field>()
+  // private val effectivelyPublicMethods = mutableSetOf<Member.Method>()
 
   private var methodCount = 0
   private var fieldCount = 0
@@ -49,7 +49,7 @@ internal class ClassNameAndAnnotationsVisitor(private val logger: Logger) : Clas
       className = className,
       outerClassName = outerClassName,
       superClassName = superClassName!!,
-      interfaces = interfaces.orEmpty(),
+      // interfaces = interfaces.orEmpty(),
       retentionPolicy = retentionPolicyHolder.get(),
       isAnnotation = isAnnotation,
       hasNoMembers = hasNoMembers,
@@ -57,8 +57,8 @@ internal class ClassNameAndAnnotationsVisitor(private val logger: Logger) : Clas
       methods = methods.efficient(),
       innerClasses = innerClasses.efficient(),
       constantClasses = constantClasses.efficient(),
-      effectivelyPublicFields = effectivelyPublicFields,
-      effectivelyPublicMethods = effectivelyPublicMethods,
+      // effectivelyPublicFields = effectivelyPublicFields,
+      // effectivelyPublicMethods = effectivelyPublicMethods,
     )
   }
 
@@ -72,7 +72,7 @@ internal class ClassNameAndAnnotationsVisitor(private val logger: Logger) : Clas
   ) {
     // This _must_ not be canonicalized, unless we also change accesses to be dotty instead of slashy
     this.superClassName = superName
-    this.interfaces = interfaces?.toSortedSet().orEmpty()
+    // this.interfaces = interfaces?.toSortedSet().orEmpty()
 
     className = canonicalize(name)
     if (interfaces?.contains("java/lang/annotation/Annotation") == true) {
@@ -107,15 +107,15 @@ internal class ClassNameAndAnnotationsVisitor(private val logger: Logger) : Clas
       methods.add(Method(descriptor))
     }
 
-    if (isEffectivelyPublic(access)) {
-      effectivelyPublicMethods.add(
-        Member.Method(
-          access = access,
-          name = name,
-          descriptor = descriptor,
-        )
-      )
-    }
+    // if (isEffectivelyPublic(access)) {
+    //   effectivelyPublicMethods.add(
+    //     Member.Method(
+    //       access = access,
+    //       name = name,
+    //       descriptor = descriptor,
+    //     )
+    //   )
+    // }
 
     return null
   }
@@ -131,15 +131,15 @@ internal class ClassNameAndAnnotationsVisitor(private val logger: Logger) : Clas
       constantClasses.add(name)
     }
 
-    if (isEffectivelyPublic(access)) {
-      effectivelyPublicFields.add(
-        Member.Field(
-          access = access,
-          name = name,
-          descriptor = descriptor,
-        )
-      )
-    }
+    // if (isEffectivelyPublic(access)) {
+    //   effectivelyPublicFields.add(
+    //     Member.Field(
+    //       access = access,
+    //       name = name,
+    //       descriptor = descriptor,
+    //     )
+    //   )
+    // }
 
     return null
   }

--- a/src/main/kotlin/com/autonomousapps/internal/models.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/models.kt
@@ -6,8 +6,6 @@ import com.autonomousapps.internal.asm.Opcodes
 import com.autonomousapps.internal.utils.efficient
 import com.autonomousapps.internal.utils.filterNotToSet
 import com.autonomousapps.internal.utils.mapToSet
-import com.autonomousapps.model.internal.intermediates.producer.BinaryClass
-import com.autonomousapps.model.internal.intermediates.producer.Member
 import com.squareup.moshi.JsonClass
 import java.lang.annotation.RetentionPolicy
 import java.util.regex.Pattern
@@ -45,13 +43,13 @@ internal data class AnalyzedClass(
   val methods: Set<Method>,
   val innerClasses: Set<String>,
   val constantFields: Set<String>,
-  val binaryClass: BinaryClass,
+  // val binaryClass: BinaryClass,
 ) : Comparable<AnalyzedClass> {
   constructor(
     className: String,
     outerClassName: String?,
     superClassName: String,
-    interfaces: Set<String>,
+    // interfaces: Set<String>,
     retentionPolicy: String?,
     isAnnotation: Boolean,
     hasNoMembers: Boolean,
@@ -59,8 +57,8 @@ internal data class AnalyzedClass(
     methods: Set<Method>,
     innerClasses: Set<String>,
     constantClasses: Set<String>,
-    effectivelyPublicFields: Set<Member.Field>,
-    effectivelyPublicMethods: Set<Member.Method>,
+    // effectivelyPublicFields: Set<Member.Field>,
+    // effectivelyPublicMethods: Set<Member.Method>,
   ) : this(
     className = className,
     outerClassName = outerClassName,
@@ -71,13 +69,13 @@ internal data class AnalyzedClass(
     methods = methods,
     innerClasses = innerClasses,
     constantFields = constantClasses,
-    binaryClass = BinaryClass(
-      className = className.replace('.', '/'),
-      superClassName = superClassName.replace('.', '/'),
-      interfaces = interfaces,
-      effectivelyPublicFields = effectivelyPublicFields,
-      effectivelyPublicMethods = effectivelyPublicMethods,
-    ),
+    // binaryClass = BinaryClass(
+    //   className = className.replace('.', '/'),
+    //   superClassName = superClassName.replace('.', '/'),
+    //   interfaces = interfaces,
+    //   effectivelyPublicFields = effectivelyPublicFields,
+    //   effectivelyPublicMethods = effectivelyPublicMethods,
+    // ),
   )
 
   companion object {

--- a/src/main/kotlin/com/autonomousapps/model/internal/Capability.kt
+++ b/src/main/kotlin/com/autonomousapps/model/internal/Capability.kt
@@ -102,131 +102,131 @@ internal data class AnnotationProcessorCapability(
   }
 }
 
-@TypeLabel("binaryClass")
-@JsonClass(generateAdapter = false)
-internal data class BinaryClassCapability(
-  val binaryClasses: Set<BinaryClass>,
-) : Capability() {
-
-  internal data class PartitionResult(
-    val matchingClasses: Set<BinaryClass>,
-    val nonMatchingClasses: Set<BinaryClass>,
-  ) {
-
-    companion object {
-      fun empty(): PartitionResult = PartitionResult(emptySet(), emptySet())
-    }
-
-    class Builder {
-      val matchingClasses = sortedSetOf<BinaryClass>()
-      val nonMatchingClasses = sortedSetOf<BinaryClass>()
-
-      fun build(): PartitionResult {
-        return PartitionResult(
-          matchingClasses = matchingClasses,
-          nonMatchingClasses = nonMatchingClasses,
-        )
-      }
-    }
-  }
-
-  override fun merge(other: Capability): Capability {
-    return BinaryClassCapability(
-      binaryClasses = binaryClasses + (other as BinaryClassCapability).binaryClasses,
-    )
-  }
-
-  internal fun findMatchingClasses(memberAccess: MemberAccess): PartitionResult {
-    val relevant = findRelevantBinaryClasses(memberAccess)
-
-    // lenient
-    if (relevant.isEmpty()) return PartitionResult.empty()
-
-    return relevant
-      .map { bin -> bin.partition(memberAccess) }
-      .fold(PartitionResult.Builder()) { acc, (match, nonMatch) ->
-        acc.apply {
-          match?.let { matchingClasses.add(it) }
-          nonMatch?.let { nonMatchingClasses.add(it) }
-        }
-      }
-      .build()
-  }
-
-  /**
-   * Example:
-   * 1. [memberAccess] is for `groovy/lang/MetaClass#getProperty`.
-   * 2. That method is actually provided by `groovy/lang/MetaObjectProtocol`, which `groovy/lang/MetaClass` implements.
-   *
-   * All of the above ("this" class, its super class, and its interfaces) are relevant for search purposes. Note we
-   * don't inspect the member names for this check.
-   */
-  private fun findRelevantBinaryClasses(memberAccess: MemberAccess): Set<BinaryClass> {
-    // direct references
-    val relevant = binaryClasses.filterTo(mutableSetOf()) { bin ->
-      bin.className == memberAccess.owner
-    }
-
-    // Walk up the class hierarchy
-    fun walkUp(): Int {
-      binaryClasses.filterTo(relevant) { bin ->
-        bin.className in relevant.map { it.superClassName }
-          || bin.className in relevant.flatMap { it.interfaces }
-      }
-      return relevant.size
-    }
-
-    // TODO(tsr): this could be more performant
-    do {
-      val size = relevant.size
-      val newSize = walkUp()
-    } while (newSize > size)
-
-    return relevant
-  }
-
-  /**
-   * Partitions and returns artificial pair of [BinaryClasses][BinaryClass]. Non-null elements indicate relevant (to
-   * [memberAccess] matching and non-matching members of this `BinaryClass`. Matching members are binary-compatible; and
-   * non-matching members have the same [name][com.autonomousapps.model.intermediates.producer.Member.name] but
-   * incompatible [descriptors][com.autonomousapps.model.intermediates.producer.Member.descriptor], and are therefore
-   * binary-incompatible.
-   *
-   * nb: We don't want this as a method directly in BinaryClass because it can't safely assert the prerequisite that
-   * it's only called on "relevant" classes. THIS class, however, can, via findRelevantBinaryClasses.
-   */
-  private fun BinaryClass.partition(memberAccess: MemberAccess): Pair<BinaryClass?, BinaryClass?> {
-    // There can be only one match
-    val matchingFields = effectivelyPublicFields.firstOrNull { it.matches(memberAccess) }
-    val matchingMethods = effectivelyPublicMethods.firstOrNull { it.matches(memberAccess) }
-
-    // There can be many non-matches
-    val nonMatchingFields = effectivelyPublicFields.filterToOrderedSet { it.doesNotMatch(memberAccess) }
-    val nonMatchingMethods = effectivelyPublicMethods.filterToOrderedSet { it.doesNotMatch(memberAccess) }
-
-    // Create a view of the binary class containing only the matching members.
-    val match = if (matchingFields != null || matchingMethods != null) {
-      copy(
-        effectivelyPublicFields = matchingFields?.let { setOf(it) }.orEmpty(),
-        effectivelyPublicMethods = matchingMethods?.let { setOf(it) }.orEmpty()
-      )
-    } else {
-      null
-    }
-
-    // Create a view of the binary class containing only the non-matching members.
-    val nonMatch = if (nonMatchingFields.isNotEmpty() || nonMatchingMethods.isNotEmpty()) {
-      copy(
-        effectivelyPublicFields = nonMatchingFields,
-        effectivelyPublicMethods = nonMatchingMethods,
-      )
-    } else {
-      null
-    }
-
-    return match to nonMatch
-  }
-}
+// @TypeLabel("binaryClass")
+// @JsonClass(generateAdapter = false)
+// internal data class BinaryClassCapability(
+//   val binaryClasses: Set<BinaryClass>,
+// ) : Capability() {
+//
+//   internal data class PartitionResult(
+//     val matchingClasses: Set<BinaryClass>,
+//     val nonMatchingClasses: Set<BinaryClass>,
+//   ) {
+//
+//     companion object {
+//       fun empty(): PartitionResult = PartitionResult(emptySet(), emptySet())
+//     }
+//
+//     class Builder {
+//       val matchingClasses = sortedSetOf<BinaryClass>()
+//       val nonMatchingClasses = sortedSetOf<BinaryClass>()
+//
+//       fun build(): PartitionResult {
+//         return PartitionResult(
+//           matchingClasses = matchingClasses,
+//           nonMatchingClasses = nonMatchingClasses,
+//         )
+//       }
+//     }
+//   }
+//
+//   override fun merge(other: Capability): Capability {
+//     return BinaryClassCapability(
+//       binaryClasses = binaryClasses + (other as BinaryClassCapability).binaryClasses,
+//     )
+//   }
+//
+//   internal fun findMatchingClasses(memberAccess: MemberAccess): PartitionResult {
+//     val relevant = findRelevantBinaryClasses(memberAccess)
+//
+//     // lenient
+//     if (relevant.isEmpty()) return PartitionResult.empty()
+//
+//     return relevant
+//       .map { bin -> bin.partition(memberAccess) }
+//       .fold(PartitionResult.Builder()) { acc, (match, nonMatch) ->
+//         acc.apply {
+//           match?.let { matchingClasses.add(it) }
+//           nonMatch?.let { nonMatchingClasses.add(it) }
+//         }
+//       }
+//       .build()
+//   }
+//
+//   /**
+//    * Example:
+//    * 1. [memberAccess] is for `groovy/lang/MetaClass#getProperty`.
+//    * 2. That method is actually provided by `groovy/lang/MetaObjectProtocol`, which `groovy/lang/MetaClass` implements.
+//    *
+//    * All of the above ("this" class, its super class, and its interfaces) are relevant for search purposes. Note we
+//    * don't inspect the member names for this check.
+//    */
+//   private fun findRelevantBinaryClasses(memberAccess: MemberAccess): Set<BinaryClass> {
+//     // direct references
+//     val relevant = binaryClasses.filterTo(mutableSetOf()) { bin ->
+//       bin.className == memberAccess.owner
+//     }
+//
+//     // Walk up the class hierarchy
+//     fun walkUp(): Int {
+//       binaryClasses.filterTo(relevant) { bin ->
+//         bin.className in relevant.map { it.superClassName }
+//           || bin.className in relevant.flatMap { it.interfaces }
+//       }
+//       return relevant.size
+//     }
+//
+//     // TODO(tsr): this could be more performant
+//     do {
+//       val size = relevant.size
+//       val newSize = walkUp()
+//     } while (newSize > size)
+//
+//     return relevant
+//   }
+//
+//   /**
+//    * Partitions and returns artificial pair of [BinaryClasses][BinaryClass]. Non-null elements indicate relevant (to
+//    * [memberAccess] matching and non-matching members of this `BinaryClass`. Matching members are binary-compatible; and
+//    * non-matching members have the same [name][com.autonomousapps.model.intermediates.producer.Member.name] but
+//    * incompatible [descriptors][com.autonomousapps.model.intermediates.producer.Member.descriptor], and are therefore
+//    * binary-incompatible.
+//    *
+//    * nb: We don't want this as a method directly in BinaryClass because it can't safely assert the prerequisite that
+//    * it's only called on "relevant" classes. THIS class, however, can, via findRelevantBinaryClasses.
+//    */
+//   private fun BinaryClass.partition(memberAccess: MemberAccess): Pair<BinaryClass?, BinaryClass?> {
+//     // There can be only one match
+//     val matchingFields = effectivelyPublicFields.firstOrNull { it.matches(memberAccess) }
+//     val matchingMethods = effectivelyPublicMethods.firstOrNull { it.matches(memberAccess) }
+//
+//     // There can be many non-matches
+//     val nonMatchingFields = effectivelyPublicFields.filterToOrderedSet { it.doesNotMatch(memberAccess) }
+//     val nonMatchingMethods = effectivelyPublicMethods.filterToOrderedSet { it.doesNotMatch(memberAccess) }
+//
+//     // Create a view of the binary class containing only the matching members.
+//     val match = if (matchingFields != null || matchingMethods != null) {
+//       copy(
+//         effectivelyPublicFields = matchingFields?.let { setOf(it) }.orEmpty(),
+//         effectivelyPublicMethods = matchingMethods?.let { setOf(it) }.orEmpty()
+//       )
+//     } else {
+//       null
+//     }
+//
+//     // Create a view of the binary class containing only the non-matching members.
+//     val nonMatch = if (nonMatchingFields.isNotEmpty() || nonMatchingMethods.isNotEmpty()) {
+//       copy(
+//         effectivelyPublicFields = nonMatchingFields,
+//         effectivelyPublicMethods = nonMatchingMethods,
+//       )
+//     } else {
+//       null
+//     }
+//
+//     return match to nonMatch
+//   }
+// }
 
 @TypeLabel("class")
 @JsonClass(generateAdapter = false)

--- a/src/main/kotlin/com/autonomousapps/model/internal/ProjectVariant.kt
+++ b/src/main/kotlin/com/autonomousapps/model/internal/ProjectVariant.kt
@@ -98,15 +98,15 @@ internal data class ProjectVariant(
     codeSource.flatMapToOrderedSet { it.imports }
   }
 
-  /**
-   * Every member access from this project to classes in another module. cf [usedClasses], which is a flat set of
-   * referenced class names.
-   */
-  val memberAccesses: Set<MemberAccess> by unsafeLazy {
-    codeSource.flatMapToOrderedSet { src ->
-      src.binaryClassAccesses.entries.flatMap { entry -> entry.value }
-    }
-  }
+  // /**
+  //  * Every member access from this project to classes in another module. cf [usedClasses], which is a flat set of
+  //  * referenced class names.
+  //  */
+  // val memberAccesses: Set<MemberAccess> by unsafeLazy {
+  //   codeSource.flatMapToOrderedSet { src ->
+  //     src.binaryClassAccesses.entries.flatMap { entry -> entry.value }
+  //   }
+  // }
 
   val javaImports: Set<String> by unsafeLazy {
     codeSource.filter { it.kind == Kind.JAVA }

--- a/src/main/kotlin/com/autonomousapps/model/internal/Source.kt
+++ b/src/main/kotlin/com/autonomousapps/model/internal/Source.kt
@@ -68,8 +68,8 @@ internal data class CodeSource(
   /** Every import in this source file. */
   val imports: Set<String>,
 
-  /** Every [MemberAccess] to another class from [this class][className]. */
-  val binaryClassAccesses: Map<String, Set<MemberAccess>>,
+  // /** Every [MemberAccess] to another class from [this class][className]. */
+  // val binaryClassAccesses: Map<String, Set<MemberAccess>>,
 ) : Source(relativePath) {
 
   enum class Kind {

--- a/src/main/kotlin/com/autonomousapps/model/internal/intermediates/ExplodingJar.kt
+++ b/src/main/kotlin/com/autonomousapps/model/internal/intermediates/ExplodingJar.kt
@@ -8,7 +8,6 @@ import com.autonomousapps.internal.ClassNames
 import com.autonomousapps.internal.utils.mapToOrderedSet
 import com.autonomousapps.internal.utils.reallyAll
 import com.autonomousapps.model.internal.KtFile
-import com.autonomousapps.model.internal.intermediates.producer.BinaryClass
 import java.lang.annotation.RetentionPolicy
 
 /**
@@ -39,11 +38,11 @@ internal class ExplodingJar(
   val androidLintRegistry: String?
 ) {
 
-  /**
-   * The set of classes provided by this jar, including information about their superclass, interfaces, and public
-   * members. May be empty. cf [classNames].
-   */
-  val binaryClasses: Set<BinaryClass> = analyzedClasses.mapToOrderedSet { it.binaryClass }
+  // /**
+  //  * The set of classes provided by this jar, including information about their superclass, interfaces, and public
+  //  * members. May be empty. cf [classNames].
+  //  */
+  // val binaryClasses: Set<BinaryClass> = analyzedClasses.mapToOrderedSet { it.binaryClass }
 
   /** The set of classes provided by this jar. May be empty. cf [binaryClasses]. */
   val classNames: Set<String> = analyzedClasses.mapToOrderedSet { it.className }

--- a/src/main/kotlin/com/autonomousapps/model/internal/intermediates/producer/ExplodedJar.kt
+++ b/src/main/kotlin/com/autonomousapps/model/internal/intermediates/producer/ExplodedJar.kt
@@ -3,16 +3,9 @@
 package com.autonomousapps.model.internal.intermediates.producer
 
 import com.autonomousapps.internal.utils.ifNotEmpty
-import com.autonomousapps.model.internal.AndroidLinterCapability
-import com.autonomousapps.model.internal.BinaryClassCapability
-import com.autonomousapps.model.internal.Capability
-import com.autonomousapps.model.internal.ClassCapability
-import com.autonomousapps.model.internal.ConstantCapability
 import com.autonomousapps.model.Coordinates
-import com.autonomousapps.model.internal.InferredCapability
-import com.autonomousapps.model.internal.KtFile
+import com.autonomousapps.model.internal.*
 import com.autonomousapps.model.internal.PhysicalArtifact
-import com.autonomousapps.model.internal.SecurityProviderCapability
 import com.autonomousapps.model.internal.intermediates.DependencyView
 import com.autonomousapps.model.internal.intermediates.ExplodingJar
 import com.squareup.moshi.JsonClass
@@ -47,10 +40,10 @@ internal data class ExplodedJar(
    * [androidLintRegistry] must be non-null.
    */
   val isLintJar: Boolean = false,
-  /**
-   * The classes (with binary member signatures) provided by this library.
-   */
-  val binaryClasses: Set<BinaryClass>,
+  // /**
+  //  * The classes (with binary member signatures) provided by this library.
+  //  */
+  // val binaryClasses: Set<BinaryClass>,
   /**
    * The classes declared by this library.
    */
@@ -76,7 +69,7 @@ internal data class ExplodedJar(
     securityProviders = exploding.securityProviders,
     androidLintRegistry = exploding.androidLintRegistry,
     isLintJar = exploding.isLintJar,
-    binaryClasses = exploding.binaryClasses,
+    // binaryClasses = exploding.binaryClasses,
     classes = exploding.classNames,
     constantFields = exploding.constants,
     ktFiles = exploding.ktFiles
@@ -97,7 +90,7 @@ internal data class ExplodedJar(
   override fun toCapabilities(): List<Capability> {
     val capabilities = mutableListOf<Capability>()
     capabilities += InferredCapability(isCompileOnlyAnnotations)
-    binaryClasses.ifNotEmpty { capabilities += BinaryClassCapability(it) }
+    // binaryClasses.ifNotEmpty { capabilities += BinaryClassCapability(it) }
     classes.ifNotEmpty { capabilities += ClassCapability(it) }
     constantFields.ifNotEmpty { capabilities += ConstantCapability(it, ktFiles) }
     securityProviders.ifNotEmpty { capabilities += SecurityProviderCapability(it) }

--- a/src/main/kotlin/com/autonomousapps/tasks/SynthesizeProjectViewTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/SynthesizeProjectViewTask.kt
@@ -62,7 +62,7 @@ abstract class SynthesizeProjectViewTask @Inject constructor(
   @get:InputFile
   abstract val graph: RegularFileProperty
 
-  /** [`Set<AnnotationProcessorDependency>`][com.autonomousapps.model.intermediates.AnnotationProcessorDependency] */
+  /** [`Set<AnnotationProcessorDependency>`][com.autonomousapps.model.internal.intermediates.AnnotationProcessorDependency] */
   @get:PathSensitive(PathSensitivity.NONE)
   @get:InputFile
   abstract val annotationProcessors: RegularFileProperty
@@ -180,14 +180,13 @@ abstract class SynthesizeProjectViewTask @Inject constructor(
             nonAnnotationClasses.addAll(bytecode.nonAnnotationClasses)
             annotationClasses.addAll(bytecode.annotationClasses)
             invisibleAnnotationClasses.addAll(bytecode.invisibleAnnotationClasses)
-
-            // TODO(tsr): flatten into a single set? Do we need the map?
-            // Merge the two maps
-            bytecode.binaryClassAccesses.forEach { (className, memberAccesses) ->
-              binaryClassAccesses.merge(className, memberAccesses.toMutableSet()) { acc, inc ->
-                acc.apply { addAll(inc) }
-              }
-            }
+            // // TODO(tsr): flatten into a single set? Do we need the map?
+            // // Merge the two maps
+            // bytecode.binaryClassAccesses.forEach { (className, memberAccesses) ->
+            //   binaryClassAccesses.merge(className, memberAccesses.toMutableSet()) { acc, inc ->
+            //     acc.apply { addAll(inc) }
+            //   }
+            // }
           },
           CodeSourceBuilder::concat
         )
@@ -275,7 +274,7 @@ private class CodeSourceBuilder(val className: String) {
   val invisibleAnnotationClasses = mutableSetOf<String>()
   val exposedClasses = mutableSetOf<String>()
   val imports = mutableSetOf<String>()
-  val binaryClassAccesses = mutableMapOf<String, MutableSet<MemberAccess>>()
+  // val binaryClassAccesses = mutableMapOf<String, MutableSet<MemberAccess>>()
 
   fun concat(other: CodeSourceBuilder): CodeSourceBuilder {
     nonAnnotationClasses.addAll(other.nonAnnotationClasses)
@@ -299,7 +298,7 @@ private class CodeSourceBuilder(val className: String) {
       usedInvisibleAnnotationClasses = invisibleAnnotationClasses,
       exposedClasses = exposedClasses,
       imports = imports,
-      binaryClassAccesses = binaryClassAccesses,
+      // binaryClassAccesses = binaryClassAccesses,
     )
   }
 }


### PR DESCRIPTION
This dramatically increased size (more than 2x) of this plugin's outputs on disk, and was leading to additional follow-up changes that felt increasingly risky for a marginal use-case. For now, users will have to just rely on the existing `Warning` feature for notification about the duplicate classes issue.

https://github.com/autonomousapps/dependency-analysis-gradle-plugin/pull/1306
https://github.com/autonomousapps/dependency-analysis-gradle-plugin/pull/1310