### PR TITLE
fix: use stable kotlin-metadata 2.0.21.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -119,12 +119,8 @@ dependencies {
   implementation(libs.moshi.kotlin)
   implementation(libs.moshix.sealed.reflect)
   implementation(libs.okio)
-
-  implementation(libs.kotlinx.metadata.jvm) {
-    because("For Kotlin ABI analysis")
-    // Depends on Kotlin 1.6, which I don't want. We also don't want to set a strict constraint, because
-    // I think that is exposed to consumers, and which would invariably break their projects. In the end,
-    // this is merely aesthetic.
+  implementation(libs.kotlin.metadata.jvm) {
+    // Depends on Kotlin 2.x, which I don't want. This is fragile, though. Will eventually have to update to Kotlin 2.
     isTransitive = false
   }
   implementation(libs.caffeine) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,9 @@ grammar = "0.3"
 guava = "33.3.1-jre"
 java = "11"
 junit = "5.10.2"
+# TODO: sync these two:
 kotlin = "1.9.25"
+kotlinMetadata = "2.0.21"
 
 # Cannot be called kotlin-editor as it causes `libs.versions.kotlin.get()` to fail
 kotlineditor-core = "0.10"
@@ -56,7 +58,7 @@ kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-stdlib-core = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
-kotlinx-metadata-jvm = { module = "org.jetbrains.kotlinx:kotlinx-metadata-jvm", version.ref = "kotlinx-metadata" }
+kotlin-metadata-jvm = { module = "org.jetbrains.kotlin:kotlin-metadata-jvm", version.ref = "kotlinMetadata" }
 
 moshi-core = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }

--- a/src/main/kotlin/com/autonomousapps/internal/JarExploder.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/JarExploder.kt
@@ -9,8 +9,8 @@ import com.autonomousapps.model.internal.KtFile
 import com.autonomousapps.model.internal.PhysicalArtifact
 import com.autonomousapps.model.internal.PhysicalArtifact.Mode
 import com.autonomousapps.model.internal.intermediates.AndroidLinterDependency
-import com.autonomousapps.model.internal.intermediates.producer.ExplodedJar
 import com.autonomousapps.model.internal.intermediates.ExplodingJar
+import com.autonomousapps.model.internal.intermediates.producer.ExplodedJar
 import com.autonomousapps.services.InMemoryCache
 import com.autonomousapps.tasks.ExplodeJarTask
 import java.util.zip.ZipFile

--- a/src/main/kotlin/com/autonomousapps/internal/asm.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/asm.kt
@@ -10,10 +10,10 @@ import com.autonomousapps.internal.utils.METHOD_DESCRIPTOR_REGEX
 import com.autonomousapps.internal.utils.efficient
 import com.autonomousapps.internal.utils.genericTypes
 import com.autonomousapps.model.internal.intermediates.consumer.MemberAccess
-import kotlinx.metadata.jvm.Metadata
 import org.gradle.api.logging.Logger
 import java.util.SortedSet
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.metadata.jvm.Metadata
 
 private val logDebug: Boolean get() = Flags.logBytecodeDebug()
 private const val ASM_VERSION = Opcodes.ASM9

--- a/src/main/kotlin/com/autonomousapps/internal/kotlin/asmUtils.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/kotlin/asmUtils.kt
@@ -11,10 +11,10 @@ import com.autonomousapps.internal.ClassNames.canonicalize
 import com.autonomousapps.internal.asm.Opcodes
 import com.autonomousapps.internal.asm.tree.*
 import com.autonomousapps.internal.utils.appendReproducibleNewLine
-import kotlinx.metadata.jvm.JvmFieldSignature
-import kotlinx.metadata.jvm.JvmMemberSignature
-import kotlinx.metadata.jvm.JvmMethodSignature
-import kotlinx.metadata.jvm.KotlinClassMetadata
+import kotlin.metadata.jvm.JvmFieldSignature
+import kotlin.metadata.jvm.JvmMemberSignature
+import kotlin.metadata.jvm.JvmMethodSignature
+import kotlin.metadata.jvm.KotlinClassMetadata
 
 internal val ACCESS_NAMES = mapOf(
   Opcodes.ACC_PUBLIC to "public",
@@ -113,7 +113,8 @@ internal data class MethodBinarySignature(
     "\$annotations"
   ))
 
-  private fun isDummyDefaultConstructor() = access.isSynthetic && name == "<init>" && desc == "(Lkotlin/jvm/internal/DefaultConstructorMarker;)V"
+  private fun isDummyDefaultConstructor() =
+    access.isSynthetic && name == "<init>" && desc == "(Lkotlin/jvm/internal/DefaultConstructorMarker;)V"
 
   /**
    * Calculates the signature of this method without default parameters

--- a/src/main/kotlin/com/autonomousapps/internal/kotlin/kotlinMetadataVisibilities.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/kotlin/kotlinMetadataVisibilities.kt
@@ -8,8 +8,8 @@
 package com.autonomousapps.internal.kotlin
 
 import com.autonomousapps.internal.asm.tree.ClassNode
-import kotlinx.metadata.*
-import kotlinx.metadata.jvm.*
+import kotlin.metadata.*
+import kotlin.metadata.jvm.*
 
 internal val ClassNode.kotlinMetadata: KotlinClassMetadata?
   get() {

--- a/src/main/kotlin/com/autonomousapps/internal/kotlin/kotlinVisibilities.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/kotlin/kotlinVisibilities.kt
@@ -7,8 +7,8 @@
 
 package com.autonomousapps.internal.kotlin
 
-import kotlinx.metadata.Visibility
-import kotlinx.metadata.jvm.JvmMemberSignature
+import kotlin.metadata.Visibility
+import kotlin.metadata.jvm.JvmMemberSignature
 
 internal class ClassVisibility(
   val name: String,

--- a/src/main/kotlin/com/autonomousapps/model/internal/KtFile.kt
+++ b/src/main/kotlin/com/autonomousapps/model/internal/KtFile.kt
@@ -3,11 +3,11 @@
 package com.autonomousapps.model.internal
 
 import com.squareup.moshi.JsonClass
-import kotlinx.metadata.jvm.KotlinModuleMetadata
-import kotlinx.metadata.jvm.UnstableMetadataApi
 import java.io.File
 import java.io.InputStream
 import java.util.zip.ZipFile
+import kotlin.metadata.jvm.KotlinModuleMetadata
+import kotlin.metadata.jvm.UnstableMetadataApi
 
 /**
  * A "KT File" is one that has top-level declarations, and so the class file is something like

--- a/src/main/kotlin/com/autonomousapps/tasks/FindKotlinMagicTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindKotlinMagicTask.kt
@@ -15,8 +15,8 @@ import com.autonomousapps.model.internal.TypealiasCapability
 import com.autonomousapps.model.internal.intermediates.InlineMemberDependency
 import com.autonomousapps.model.internal.intermediates.TypealiasDependency
 import com.autonomousapps.services.InMemoryCache
-import kotlinx.metadata.*
-import kotlinx.metadata.jvm.KotlinClassMetadata
+import kotlin.metadata.*
+import kotlin.metadata.jvm.KotlinClassMetadata
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty


### PR DESCRIPTION
Can't use latest, because I'm still compiling against Kotlin 1.9.

Based on [internal work thread](https://cash.slack.com/archives/C01LTRS23B9/p1732616786960369).