### PR TITLE
Allow adding custom content to android blocks

### DIFF
--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/android/AndroidBlock.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/android/AndroidBlock.kt
@@ -5,6 +5,7 @@ package com.autonomousapps.kit.gradle.android
 import com.autonomousapps.kit.GradleProject.DslKind
 import com.autonomousapps.kit.render.Element
 import com.autonomousapps.kit.render.Scribe
+import org.intellij.lang.annotations.Language
 
 /**
  * The `android` block, for use by projects build with the Android Gradle Plugin.
@@ -21,6 +22,9 @@ public class AndroidBlock @JvmOverloads constructor(
   public var defaultConfig: DefaultConfig = DefaultConfig.DEFAULT_APP,
   public var compileOptions: CompileOptions = CompileOptions.DEFAULT,
   public var kotlinOptions: KotlinOptions? = null,
+  public var additions: String = "",
+  private val usesGroovy: Boolean = false,
+  private val usesKotlin: Boolean = false,
 ) : Element.Block {
 
   override val name: String = "android"
@@ -45,6 +49,13 @@ public class AndroidBlock @JvmOverloads constructor(
     defaultConfig.render(s)
     compileOptions.render(s)
     kotlinOptions?.render(s)
+    
+    if (additions.isNotBlank()) {
+      if (usesKotlin) {
+        error("You called withGroovy() but you're using Kotlin DSL")
+      }
+      s.line { it.append(additions) }
+    }
   }
 
   private fun renderKotlin(scribe: Scribe): String = scribe.block(this) { s ->
@@ -62,6 +73,13 @@ public class AndroidBlock @JvmOverloads constructor(
     defaultConfig.render(s)
     compileOptions.render(s)
     kotlinOptions?.render(s)
+
+    if (additions.isNotBlank()) {
+      if (usesGroovy) {
+        error("You called withKotlin() but you're using Groovy DSL")
+      }
+      s.line { it.append(additions) }
+    }
   }
 
   public class Builder {
@@ -71,6 +89,20 @@ public class AndroidBlock @JvmOverloads constructor(
     public var compileOptions: CompileOptions = CompileOptions.DEFAULT
     public var kotlinOptions: KotlinOptions? = null
 
+    public var additions: String = ""
+    private var usesGroovy = false
+    private var usesKotlin = false
+
+    public fun withGroovy(@Language("Groovy") script: String) {
+      additions = script.trimIndent()
+      usesGroovy = true
+    }
+
+    public fun withKotlin(@Language("kt") script: String) {
+      additions = script.trimIndent()
+      usesKotlin = true
+    }
+
     public fun build(): AndroidBlock {
       return AndroidBlock(
         namespace = namespace,
@@ -78,6 +110,7 @@ public class AndroidBlock @JvmOverloads constructor(
         defaultConfig = defaultConfig,
         compileOptions = compileOptions,
         kotlinOptions = kotlinOptions,
+        additions = additions,
       )
     }
   }

--- a/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestGroovy.kt
+++ b/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestGroovy.kt
@@ -546,6 +546,41 @@ internal class ScribeTestGroovy {
         """.trimIndent()
       )
     }
+
+    @Test fun `can render custom android content`() {
+      // Given
+      val buildScript = BuildScript(
+        android = AndroidBlock.Builder().apply {
+           withGroovy("custom { config = true }")
+        }.build(),
+      )
+
+      // When
+      val text = buildScript.render(scribe)
+
+      // Then
+      assertThat(text).isEqualTo(
+        """
+          android {
+            compileSdkVersion 34
+            defaultConfig {
+              applicationId 'com.example'
+              minSdkVersion 21
+              targetSdkVersion 29
+              versionCode 1
+              versionName '1.0'
+            }
+            compileOptions {
+              sourceCompatibility JavaVersion.VERSION_1_8
+              targetCompatibility JavaVersion.VERSION_1_8
+            }
+            custom { config = true }
+          }
+        
+        
+        """.trimIndent()
+      )
+    }
   }
 
   @Nested inner class PluginsTest {

--- a/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestKotlin.kt
+++ b/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestKotlin.kt
@@ -547,6 +547,42 @@ internal class ScribeTestKotlin {
         """.trimIndent()
       )
     }
+
+    @Test fun `can render custom android content`() {
+      // Given
+      val buildScript = BuildScript(
+        android = AndroidBlock.Builder().apply {
+          withKotlin("custom { config = true }")
+        }.build(),
+        usesKotlin = true,
+      )
+
+      // When
+      val text = buildScript.render(scribe)
+
+      // Then
+      assertThat(text).isEqualTo(
+        """
+          android {
+            compileSdk = 34
+            defaultConfig {
+              applicationId = "com.example"
+              minSdk = 21
+              targetSdk = 29
+              versionCode = 1
+              versionName = "1.0"
+            }
+            compileOptions {
+              sourceCompatibility = JavaVersion.VERSION_1_8
+              targetCompatibility = JavaVersion.VERSION_1_8
+            }
+            custom { config = true }
+          }
+        
+        
+        """.trimIndent()
+      )
+    }
   }
 
   @Nested inner class PluginsTest {


### PR DESCRIPTION
This is so you can test android dsl extensions.
https://developer.android.com/reference/tools/gradle-api/8.7/com/android/build/api/variant/AndroidComponentsExtension#registerExtension(com.android.build.api.variant.DslExtension,kotlin.Function1)