### PR TITLE
chore: adjust shadow plugin coordinates

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,7 +28,7 @@ pluginManagement {
     }
   }
   plugins {
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    id("com.gradleup.shadow") version "8.3.0"
     id("com.gradle.develocity") version "3.18.2"
     id("com.gradle.plugin-publish") version "1.1.0"
   }

--- a/shadowed/antlr/build.gradle.kts
+++ b/shadowed/antlr/build.gradle.kts
@@ -5,7 +5,7 @@
 plugins {
   `java-library`
   antlr
-  id("com.github.johnrengelman.shadow")
+  id("com.gradleup.shadow")
   groovy
   id("convention")
   // This project doesn't need Kotlin, but it is now applied thanks to `convention`. problem?

--- a/shadowed/asm-relocated/build.gradle.kts
+++ b/shadowed/asm-relocated/build.gradle.kts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 plugins {
   `java-library`
-  id("com.github.johnrengelman.shadow")
+  id("com.gradleup.shadow")
   id("convention")
   // This project doesn't need Kotlin, but it is now applied thanks to `convention`. problem?
 }

--- a/shadowed/kotlin-editor-relocated/build.gradle.kts
+++ b/shadowed/kotlin-editor-relocated/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("convention")
-  id("com.github.johnrengelman.shadow")
+  id("com.gradleup.shadow")
 }
 
 version = "${libs.versions.kotlineditor.core.get()}.1-SNAPSHOT"

--- a/testkit/settings.gradle.kts
+++ b/testkit/settings.gradle.kts
@@ -24,7 +24,7 @@ pluginManagement {
   }
   plugins {
     id("com.autonomousapps.testkit") version "0.8"
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    id("com.gradleup.shadow") version "8.3.0"
     id("com.gradle.develocity") version "3.18.2"
     id("com.gradle.plugin-publish") version "1.1.0"
     id("org.jetbrains.dokka") version "1.9.20"


### PR DESCRIPTION
The plugin was relocated see [here](https://github.com/GradleUp/shadow/releases/tag/8.3.0).
Version 8.3.0 is very similar to 8.1.1, the gradle requirement was bumped to 8.3 which shouldn't be an issue since you are using 8.11 as far as I can tell.