### PR TITLE
chore: align gradle toolchain resolver syntax with project convention

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,7 +36,7 @@ pluginManagement {
 
 plugins {
   id("com.gradle.develocity")
-  id("org.gradle.toolchains.foojay-resolver-convention") version("0.8.0")
+  id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
 }
 
 // Yes, this is also in pluginManagement above. This is required for normal dependencies.


### PR DESCRIPTION
As discussed [here](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/pull/1339#discussion_r1885497306)