### PR TITLE
chore: simplify KotlinCompile configuration

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -1,6 +1,5 @@
 // Copyright (c) 2024. Tony Robalik.
 // SPDX-License-Identifier: Apache-2.0
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -16,7 +15,6 @@ java {
 
 tasks.withType<KotlinCompile>().configureEach {
   compilerOptions {
-    jvmTarget = JvmTarget.fromTarget(libs.versions.java.get())
     freeCompilerArgs = listOf("-Xinline-classes", "-opt-in=kotlin.RequiresOptIn", "-Xsam-conversions=class")
   }
 }


### PR DESCRIPTION
Reason: the kotlin-gradle-plugin respects JvmToolchains, see [here](https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support).

In case you wanted to be explicit about it, feel free to just close this PR :)