### PR TITLE
fix: fixes issue 1346

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/android/AndroidTransformSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AndroidTransformSpec.groovy
@@ -1,0 +1,32 @@
+// Copyright (c) 2024. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.android
+
+
+import com.autonomousapps.android.projects.AndroidTransformProject
+import org.gradle.util.GradleVersion
+
+import static com.autonomousapps.advice.truth.BuildHealthSubject.buildHealth
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertAbout
+
+/** See https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1346. */
+final class AndroidTransformSpec extends AbstractAndroidSpec {
+
+  def "does not recommend replace api with implementation (#gradleVersion AGP #agpVersion)"() {
+    given:
+    def project = new AndroidTransformProject(agpVersion as String)
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion as GradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertAbout(buildHealth())
+      .that(project.actualBuildHealth())
+      .containsExactlyDependencyAdviceIn(project.expectedBuildHealth)
+
+    where:
+    [gradleVersion, agpVersion] << gradleAgpMatrix()
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidTransformProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidTransformProject.groovy
@@ -1,0 +1,185 @@
+// Copyright (c) 2024. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.android.projects
+
+
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.gradle.dependencies.Plugins
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.actualProjectAdvice
+import static com.autonomousapps.AdviceHelper.emptyProjectAdviceFor
+import static com.autonomousapps.kit.gradle.Dependency.project
+
+/**
+ * https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1346.
+ */
+final class AndroidTransformProject extends AbstractAndroidProject {
+
+  final GradleProject gradleProject
+  private final String agpVersion
+
+  AndroidTransformProject(String agpVersion) {
+    super(agpVersion)
+
+    this.agpVersion = agpVersion
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newAndroidGradleProjectBuilder(agpVersion)
+      .withAndroidLibProject('consumer', 'com.example.consumer') { consumer ->
+        consumer.manifest = libraryManifest('com.example.consumer')
+        consumer.sources = consumerSources
+        consumer.withBuildScript { bs ->
+          bs.plugins = [Plugins.androidLib, Plugins.kotlinAndroidNoVersion, Plugins.dependencyAnalysisNoVersion]
+          bs.android = defaultAndroidLibBlock(true, 'com.example.consumer')
+
+          bs.dependencies(
+            project('api', ':producer'),
+          )
+          bs.withGroovy(TRANSFORM_TASK)
+        }
+      }
+      .withSubproject('producer') { producer ->
+        producer.sources = producerSources
+        producer.withBuildScript { bs ->
+          bs.plugins = [Plugins.kotlinJvmNoVersion, Plugins.dependencyAnalysisNoVersion]
+        }
+      }
+      .write()
+  }
+
+  private static TRANSFORM_TASK =
+    """\
+    import com.android.build.api.artifact.ScopedArtifact
+    import com.android.build.api.variant.ScopedArtifacts
+    import java.io.FileInputStream
+    import java.io.FileOutputStream
+    import java.nio.file.Files
+    import java.nio.file.Paths
+    import java.util.zip.ZipEntry
+    import java.util.zip.ZipFile
+    import java.util.zip.ZipOutputStream
+    
+    abstract class TransformTask extends DefaultTask {
+      @PathSensitive(PathSensitivity.RELATIVE)
+      @InputFiles
+      abstract ListProperty<RegularFile> getAllJars();
+    
+      @PathSensitive(PathSensitivity.RELATIVE)
+      @InputFiles
+      abstract ListProperty<Directory> getAllDirs();
+    
+      @OutputFile
+      abstract RegularFileProperty getOutput();
+    
+      @TaskAction
+      void transform() {
+        def outputFile = output.get().asFile
+        def outputStream = new ZipOutputStream(new FileOutputStream(outputFile))
+        try {
+          allJars.get().forEach { jar ->
+            addJarToZip(jar.asFile, outputStream)
+          }
+          allDirs.get().forEach { dir ->
+            addDirectoryToZip(dir.asFile, outputStream, dir.asFile.path)
+          }
+        } finally {
+          outputStream.close()
+        }
+    
+        println("Copying \${allJars.get()} and \${allDirs.get()} into \${output.get()}")
+        println("Resulting jar file contents:")
+        def zipFile = new ZipFile(outputFile)
+        try {
+          zipFile.entries().each {
+            println(it.name)
+          }
+        } finally {
+          zipFile.close()
+        }
+      }
+    
+      void addJarToZip(File file, ZipOutputStream zipOut) {
+        def zipFile = new ZipFile(file)
+        zipFile.entries().each {
+          def zipEntry = new ZipEntry(it.name)
+          zipOut.putNextEntry(zipEntry)
+          def inputStream = zipFile.getInputStream(it)
+          try {
+            inputStream.transferTo(zipOut)
+          } finally {
+            inputStream.close()
+          }
+        }
+      }
+    
+      void addDirectoryToZip(File directory, ZipOutputStream zipOut, String basePath) {
+        Files.walk(directory.toPath()).forEach {
+          def file = it.toFile()
+          if (file.isFile()) {
+            def fileInputStream = new FileInputStream(file)
+            try {
+              def zipEntry = new ZipEntry(Paths.get(basePath).relativize(file.toPath()).toString())
+              zipOut.putNextEntry(zipEntry)
+              fileInputStream.transferTo(zipOut)
+              zipOut.closeEntry()
+            } finally {
+              fileInputStream.close()
+            }
+          }
+        }
+      }
+    }
+    
+    androidComponents {
+      onVariants(selector().all()) { variant ->
+        variant.artifacts
+          .forScope(ScopedArtifacts.Scope.PROJECT)
+          .use(tasks.register("transformTask\${variant.name.capitalize()}", TransformTask.class))
+          .toTransform(ScopedArtifact.CLASSES.INSTANCE,  { it.getAllJars() }, { it.getAllDirs() }, { it.getOutput() })
+      }
+    }
+    """.stripIndent()
+
+  private List<Source> consumerSources = [
+    Source.kotlin(
+      """
+      package com.example.consumer
+      
+      import com.example.producer.Producer
+      
+      class Consumer : Producer() {
+        override fun produce(): String {
+          return "Hello, world!"
+        }
+      }
+      """.stripIndent()
+    )
+      .withPath('com.example.consumer', 'Consumer')
+      .build()
+  ]
+
+  private List<Source> producerSources = [
+    Source.kotlin(
+      """
+      package com.example.producer
+      
+      abstract class Producer {
+        abstract fun produce(): String
+      }
+      """.stripIndent()
+    )
+      .withPath('com.example.producer', 'Producer')
+      .build()
+  ]
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  final Set<ProjectAdvice> expectedBuildHealth =
+    emptyProjectAdviceFor(':consumer', ':producer')
+}

--- a/src/main/kotlin/com/autonomousapps/internal/kotlin/PublicApiDump.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/kotlin/PublicApiDump.kt
@@ -38,9 +38,15 @@ internal fun getBinaryAPI(jar: JarFile, visibilityFilter: (String) -> Boolean = 
 
 internal fun getBinaryAPI(
   classes: Set<File>,
+  jarFiles: Set<JarFile>,
   visibilityFilter: (String) -> Boolean = { true }
-): List<ClassBinarySignature> =
-  getBinaryAPI(classes.asSequence().map { it.inputStream() }, visibilityFilter)
+): List<ClassBinarySignature> {
+  val classesBinaryAPI = getBinaryAPI(classes.asSequence().map { it.inputStream() }, visibilityFilter)
+  val jarsBinaryAPI = jarFiles.flatMap { getBinaryAPI(it, visibilityFilter) }
+
+  return classesBinaryAPI + jarsBinaryAPI
+}
+
 
 internal fun getBinaryAPI(
   classStreams: Sequence<InputStream>,

--- a/src/main/kotlin/com/autonomousapps/internal/kotlin/abiDependencies.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/kotlin/abiDependencies.kt
@@ -9,12 +9,14 @@ import com.autonomousapps.internal.utils.allItems
 import com.autonomousapps.internal.utils.flatMapToSet
 import com.autonomousapps.model.internal.intermediates.consumer.ExplodingAbi
 import java.io.File
+import java.util.jar.JarFile
 
 internal fun computeAbi(
   classFiles: Set<File>,
+  jarFiles: Set<JarFile>,
   exclusions: AbiExclusions,
   abiDumpFile: File? = null
-): Set<ExplodingAbi> = getBinaryAPI(classFiles).explodedAbi(exclusions, abiDumpFile)
+): Set<ExplodingAbi> = getBinaryAPI(classFiles, jarFiles).explodedAbi(exclusions, abiDumpFile)
 
 private fun List<ClassBinarySignature>.explodedAbi(
   exclusions: AbiExclusions,

--- a/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
@@ -64,6 +64,10 @@ internal fun Iterable<File>.filterToClassFiles(): List<File> {
   return filter { it.extension == "class" && !it.name.endsWith("module-info.class") }
 }
 
+internal fun Iterable<File>.filterToJarFiles(): List<File> {
+  return filter { it.extension == "jar" }
+}
+
 /** Filters a [FileCollection] to contain only class files. */
 internal fun FileCollection.filterToClassFiles(): FileCollection {
   return filter {

--- a/src/main/kotlin/com/autonomousapps/tasks/AndroidClassesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/AndroidClassesTask.kt
@@ -3,6 +3,7 @@
 package com.autonomousapps.tasks
 
 import com.autonomousapps.internal.utils.filterToClassFiles
+import com.autonomousapps.internal.utils.filterToJarFiles
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.Directory
 import org.gradle.api.file.RegularFile
@@ -20,7 +21,7 @@ import java.io.File
  */
 abstract class AndroidClassesTask : DefaultTask() {
 
-  /** Will be empty for this task. */
+  /** May be empty. */
   @get:PathSensitive(PathSensitivity.RELATIVE)
   @get:InputFiles
   abstract val jars: ListProperty<RegularFile>
@@ -33,5 +34,10 @@ abstract class AndroidClassesTask : DefaultTask() {
   /** Must be called during the execution phase. */
   protected fun androidClassFiles(): List<File> {
     return dirs.getOrElse(emptyList()).flatMap { it.asFileTree.files }.filterToClassFiles()
+  }
+
+  /** Must be called during the execution phase. */
+  protected fun androidJarFiles(): List<File> {
+    return jars.getOrElse(emptyList()).map { it.asFile }.filterToJarFiles()
   }
 }

--- a/src/main/kotlin/com/autonomousapps/tasks/ClassListExploderTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ClassListExploderTask.kt
@@ -40,6 +40,7 @@ abstract class ClassListExploderTask @Inject constructor(
       classFiles.setFrom(classes.asFileTree.filterToClassFiles().files)
       // Android projects
       classFiles.from(androidClassFiles())
+      jarFiles.from(androidJarFiles())
 
       buildDir.set(layout.buildDirectory)
       output.set(this@ClassListExploderTask.output)
@@ -48,6 +49,7 @@ abstract class ClassListExploderTask @Inject constructor(
 
   interface ClassListExploderParameters : WorkParameters {
     val classFiles: ConfigurableFileCollection
+    val jarFiles: ConfigurableFileCollection
     val buildDir: DirectoryProperty
     val output: RegularFileProperty
   }
@@ -59,6 +61,7 @@ abstract class ClassListExploderTask @Inject constructor(
 
       val usedClasses = ClassFilesParser(
         classes = parameters.classFiles.asFileTree.files,
+        jarFiles = parameters.jarFiles.files,
         buildDir = parameters.buildDir.get().asFile,
       ).analyze()
 


### PR DESCRIPTION
Fixes the issue #1346.

`ClassReferenceParser` and `getBinaryAPI` extension functions now handle `jar` files as an input alongside with class files. There is a bit of duplication with regard to to reading jar files, maybe it would be better to hide two sources of class files inside `AndroidClassesTask` by unpacking jars into intermediate directory. I've also added a test that fails without aforementioned fixes, it is a bit verbose because of the actual implementation of the transform task.