### PR TITLE
Add toolchain plugin everywhere and unify plugin style

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -7,6 +7,13 @@ pluginManagement {
     gradlePluginPortal()
     mavenCentral()
   }
+  plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+  }
+}
+
+plugins {
+  id("org.gradle.toolchains.foojay-resolver-convention")
 }
 
 dependencyResolutionManagement {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,12 +31,13 @@ pluginManagement {
     id("com.gradleup.shadow") version "8.3.0"
     id("com.gradle.develocity") version "3.18.2"
     id("com.gradle.plugin-publish") version "1.1.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
   }
 }
 
 plugins {
   id("com.gradle.develocity")
-  id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+  id("org.gradle.toolchains.foojay-resolver-convention")
 }
 
 // Yes, this is also in pluginManagement above. This is required for normal dependencies.

--- a/testkit/settings.gradle.kts
+++ b/testkit/settings.gradle.kts
@@ -28,11 +28,13 @@ pluginManagement {
     id("com.gradle.develocity") version "3.18.2"
     id("com.gradle.plugin-publish") version "1.1.0"
     id("org.jetbrains.dokka") version "1.9.20"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
   }
 }
 
 plugins {
   id("com.gradle.develocity")
+  id("org.gradle.toolchains.foojay-resolver-convention")
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
> Configure project :testkit:gradle-testkit-plugin
Using a toolchain installed via auto-provisioning, but having no toolchain repositories configured. This behavior is deprecated. Consider defining toolchain download repositories, otherwise the build might fail in clean environments; see https://docs.gradle.org/8.11-rc-3/userguide/toolchains.html#sub:download_repositoriesed artifacts.

It's needed in all projects where there's a settings.gradle AND toolchains are used, which happens to be all 3.