### PR TITLE
test: only run functionalTest against latest combination of AGP and Gradle.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,11 +74,11 @@ jobs:
 
       - name: Execute JVM functional tests
         id: gradle-jvm-check
-        run: './gradlew :functionalTest -DfuncTest.package=jvm'
+        run: './gradlew :functionalTest -DfuncTest.package=jvm -DfuncTest.quick'
 
       - name: Execute Android functional tests
         id: gradle-android-check
-        run: './gradlew :functionalTest -DfuncTest.package=android'
+        run: './gradlew :functionalTest -DfuncTest.package=android -DfuncTest.quick'
 
       - name: 'Maybe add Build Scan URLs as PR comment'
         uses: actions/github-script@v7


### PR DESCRIPTION
Attempting to appease Github's CI runner, which has lately started killing itself instead of finishing the test suite.

If this works, I'll work on a refactor of the test suites. Would like some way to run at least a smoke test against earliest-supported versions in addition to latest.