### PR TITLE
fix: cache SuperClassGraph. No need to recompute. Intern more strings.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/ClassNames.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/ClassNames.kt
@@ -4,7 +4,7 @@ package com.autonomousapps.internal
 
 internal object ClassNames {
 
-  fun canonicalize(className: String): String = className.replace('/', '.')
+  fun canonicalize(className: String): String = className.replace('/', '.').intern()
 
   // TODO(tsr): I think I can delete the slashy version but I'm not sure
   fun isEnum(superClassName: String?): Boolean = superClassName == "java.lang.Enum" || superClassName == "java/lang/Enum"

--- a/src/main/kotlin/com/autonomousapps/internal/asm.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/asm.kt
@@ -47,9 +47,9 @@ internal class ClassNameAndAnnotationsVisitor(private val logger: Logger) : Clas
     val hasNoMembers = fieldCount == 0 && methodCount == 0
 
     return AnalyzedClass(
-      className = className,
-      outerClassName = outerClassName,
-      superClassName = superClassName,
+      className = className.intern(),
+      outerClassName = outerClassName?.intern(),
+      superClassName = superClassName?.intern(),
       interfaces = interfaces.orEmpty().efficient(),
       retentionPolicy = retentionPolicyHolder.get(),
       isAnnotation = isAnnotation,

--- a/src/main/kotlin/com/autonomousapps/internal/graph/supers/SuperClassGraphHolder.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/graph/supers/SuperClassGraphHolder.kt
@@ -1,0 +1,36 @@
+package com.autonomousapps.internal.graph.supers
+
+import com.autonomousapps.internal.unsafeLazy
+import com.autonomousapps.internal.utils.flatMapToOrderedSet
+import com.autonomousapps.internal.utils.mapNotNullToOrderedSet
+import com.autonomousapps.internal.utils.mapToOrderedSet
+import com.autonomousapps.visitor.GraphViewVisitor
+import com.google.common.graph.Graph
+
+/**
+ * This calculation is very expensive, so we cache it.
+ *
+ * @see <a href="https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1358">Issue 1358</a>
+ */
+@Suppress("UnstableApiUsage") // Guava graphs
+internal class SuperClassGraphHolder(private val context: GraphViewVisitor.Context) {
+
+  /** Graph from child classes up through super classes and interfaces, up to `java/lang/Object`. */
+  val superGraph: Graph<SuperNode> by unsafeLazy { SuperClassGraphBuilder.of(context) }
+
+  /** The set of super classes and interfaces not available from [context] (therefore "external" to "this" module). */
+  val externals: Set<String> by unsafeLazy { computeExternalSupers() }
+
+  private fun computeExternalSupers(): Set<String> {
+    val supers = context.project.codeSource.mapNotNullToOrderedSet { src -> src.superClass }
+    val interfaces = context.project.codeSource.flatMapToOrderedSet { src -> src.interfaces }
+    // These are all the super classes and interfaces in "this" module
+    val localClasses = context.project.codeSource.mapToOrderedSet { src -> src.className }
+    // These super classes and interfaces are not available from "this" module, so must come from dependencies.
+    val externalSupers = supers - localClasses
+    val externalInterfaces = interfaces - localClasses
+    val externals = externalSupers + externalInterfaces
+
+    return externals
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/model/internal/intermediates/producer/Member.kt
+++ b/src/main/kotlin/com/autonomousapps/model/internal/intermediates/producer/Member.kt
@@ -11,7 +11,7 @@ import dev.zacsweers.moshix.sealed.annotations.TypeLabel
  * Represents a member of a [class][BinaryClass].
  *
  * nb: Borrowing heavily from `asmUtils.kt` and similar but substantially different from
- * [MemberAccess][com.autonomousapps.model.intermediates.consumer.MemberAccess] on the consumer side.
+ * [MemberAccess][com.autonomousapps.model.internal.intermediates.consumer.MemberAccess] on the consumer side.
  */
 @JsonClass(generateAdapter = false, generator = "sealed:type")
 internal sealed class Member(


### PR DESCRIPTION
https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1358