### PR TITLE
Bump Kotlin to 2.0.21

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,9 +11,7 @@ grammar = "0.5"
 guava = "33.3.1-jre"
 java = "11"
 junit = "5.10.2"
-# TODO: sync these two:
-kotlin = "1.9.25"
-kotlinMetadata = "2.0.21"
+kotlin = "2.0.21"
 
 # Cannot be called kotlin-editor as it causes `libs.versions.kotlin.get()` to fail
 kotlineditor-core = "0.18"
@@ -57,7 +55,7 @@ kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-stdlib-core = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
-kotlin-metadata-jvm = { module = "org.jetbrains.kotlin:kotlin-metadata-jvm", version.ref = "kotlinMetadata" }
+kotlin-metadata-jvm = { module = "org.jetbrains.kotlin:kotlin-metadata-jvm", version.ref = "kotlin" }
 
 moshi-core = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/Kotlin2MigrationSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/Kotlin2MigrationSpec.groovy
@@ -8,36 +8,6 @@ import static com.google.common.truth.Truth.assertThat
 
 final class Kotlin2MigrationSpec extends AbstractJvmSpec {
 
-  def "buildHealth passes without testFixtures dependencies with Kotlin 1.9 (#gradleVersion)"() {
-    given:
-    def project = new Kotlin2Migration.CompilesWithoutTestFixturesDependencies()
-    gradleProject = project.gradleProject
-
-    when:
-    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
-
-    then:
-    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
-
-    where:
-    gradleVersion << gradleVersions()
-  }
-
-  def "buildHealth fails without testFixtures dependencies with Kotlin 1.9 (#gradleVersion)"() {
-    given:
-    def project = new Kotlin2Migration.BuildHealthFailsWithoutTestFixturesDependencies()
-    gradleProject = project.gradleProject
-
-    when:
-    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
-
-    then:
-    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
-
-    where:
-    gradleVersion << gradleVersions()
-  }
-
   def "buildHealth passes with testFixtures dependency with Kotlin 2.0 (#gradleVersion)"() {
     given:
     def project = new Kotlin2Migration.CompilesWithTestFixturesDependency()


### PR DESCRIPTION
Release Notes:
- [Kotlin 2.0](https://kotlinlang.org/docs/whatsnew20.html)
- [Kotlin 2.0.20](https://kotlinlang.org/docs/whatsnew2020.html)