### PR TITLE
chore: update to Kotlin 2.0.21.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,7 +105,6 @@ gradleTestKitSupport {
 }
 
 dependencies {
-  implementation(platform(libs.kotlin.bom))
   implementation(platform(libs.okio.bom))
 
   api(libs.javax.inject)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,9 +11,7 @@ grammar = "0.5"
 guava = "33.3.1-jre"
 java = "11"
 junit = "5.10.2"
-# TODO: sync these two:
-kotlin = "1.9.25"
-kotlinMetadata = "2.0.21"
+kotlin = "2.0.21"
 
 # Cannot be called kotlin-editor as it causes `libs.versions.kotlin.get()` to fail
 kotlineditor-core = "0.18"
@@ -57,7 +55,7 @@ kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-stdlib-core = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
-kotlin-metadata-jvm = { module = "org.jetbrains.kotlin:kotlin-metadata-jvm", version.ref = "kotlinMetadata" }
+kotlin-metadata-jvm = { module = "org.jetbrains.kotlin:kotlin-metadata-jvm", version.ref = "kotlin" }
 
 moshi-core = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/Kotlin2MigrationSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/Kotlin2MigrationSpec.groovy
@@ -8,36 +8,6 @@ import static com.google.common.truth.Truth.assertThat
 
 final class Kotlin2MigrationSpec extends AbstractJvmSpec {
 
-  def "buildHealth passes without testFixtures dependencies with Kotlin 1.9 (#gradleVersion)"() {
-    given:
-    def project = new Kotlin2Migration.CompilesWithoutTestFixturesDependencies()
-    gradleProject = project.gradleProject
-
-    when:
-    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
-
-    then:
-    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
-
-    where:
-    gradleVersion << gradleVersions()
-  }
-
-  def "buildHealth fails without testFixtures dependencies with Kotlin 1.9 (#gradleVersion)"() {
-    given:
-    def project = new Kotlin2Migration.BuildHealthFailsWithoutTestFixturesDependencies()
-    gradleProject = project.gradleProject
-
-    when:
-    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
-
-    then:
-    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
-
-    where:
-    gradleVersion << gradleVersions()
-  }
-
   def "buildHealth passes with testFixtures dependency with Kotlin 2.0 (#gradleVersion)"() {
     given:
     def project = new Kotlin2Migration.CompilesWithTestFixturesDependency()

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/Kotlin2Migration.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/Kotlin2Migration.groovy
@@ -3,17 +3,15 @@ package com.autonomousapps.jvm.projects
 import com.autonomousapps.AbstractProject
 import com.autonomousapps.kit.GradleProject
 import com.autonomousapps.kit.Source
-import com.autonomousapps.model.Advice
 import com.autonomousapps.model.ProjectAdvice
 
-import static com.autonomousapps.AdviceHelper.*
+import static com.autonomousapps.AdviceHelper.actualProjectAdvice
+import static com.autonomousapps.AdviceHelper.emptyProjectAdviceFor
 import static com.autonomousapps.kit.gradle.Dependency.implementation
 import static com.autonomousapps.kit.gradle.Dependency.testFixturesImplementation
 
 abstract class Kotlin2Migration extends AbstractProject {
 
-  // the embeddedKotlinVersion in Gradle 8.10.2
-  protected static final String KOTLIN_1 = '1.9.23'
   // latest stable Kotlin 2.0.x at time of writing
   protected static final String KOTLIN_2 = '2.0.21'
 
@@ -74,107 +72,7 @@ abstract class Kotlin2Migration extends AbstractProject {
       .withSourceSet('testFixtures')
       .build(),
   ]
-
-  static final class CompilesWithoutTestFixturesDependencies extends Kotlin2Migration {
-
-    final GradleProject gradleProject
-
-    CompilesWithoutTestFixturesDependencies() {
-      super(KOTLIN_1)
-      gradleProject = build()
-    }
-
-    private GradleProject build() {
-      return newGradleProjectBuilder()
-        .withSubproject('consumer') { s ->
-          s.sources = sourcesConsumer
-          s.withBuildScript { bs ->
-            bs.plugins = kotlin + plugins.javaTestFixtures
-            bs.dependencies(
-              implementation(':producer'),
-              implementation(':producer').onTestFixtures(),
-            )
-          }
-        }
-        .withSubproject('producer') { s ->
-          s.sources = sourcesProducer
-          s.withBuildScript { bs ->
-            bs.plugins = kotlin + plugins.javaTestFixtures
-          }
-        }
-        .write()
-    }
-
-    Set<ProjectAdvice> actualBuildHealth() {
-      return actualProjectAdvice(gradleProject)
-    }
-
-    final Set<ProjectAdvice> expectedBuildHealth = [
-      emptyProjectAdviceFor(':consumer'),
-      emptyProjectAdviceFor(':producer'),
-    ]
-  }
-
-  static final class BuildHealthFailsWithoutTestFixturesDependencies extends Kotlin2Migration {
-
-    final GradleProject gradleProject
-
-    BuildHealthFailsWithoutTestFixturesDependencies() {
-      super(KOTLIN_1)
-      gradleProject = build()
-    }
-
-    private GradleProject build() {
-      return newGradleProjectBuilder()
-        .withRootProject { r ->
-          r.withBuildScript { bs ->
-            bs.withGroovy(
-              '''\
-                dependencyAnalysis {
-                  structure {
-                    explicitSourceSets()
-                  }
-                }
-              '''
-            )
-          }
-        }
-        .withSubproject('consumer') { s ->
-          s.sources = sourcesConsumer
-          s.withBuildScript { bs ->
-            bs.plugins = kotlin + plugins.javaTestFixtures
-            bs.dependencies(
-              implementation(':producer'),
-              implementation(':producer').onTestFixtures(),
-            )
-          }
-        }
-        .withSubproject('producer') { s ->
-          s.sources = sourcesProducer
-          s.withBuildScript { bs ->
-            bs.plugins = kotlin + plugins.javaTestFixtures
-          }
-        }
-        .write()
-    }
-
-    Set<ProjectAdvice> actualBuildHealth() {
-      return actualProjectAdvice(gradleProject)
-    }
-
-    private final Set<Advice> consumerAdvice = [
-      Advice.ofAdd(
-        projectCoordinates(':producer'),
-        'testFixturesImplementation',
-      )
-    ]
-
-    final Set<ProjectAdvice> expectedBuildHealth = [
-      projectAdviceForDependencies(':consumer', consumerAdvice),
-      emptyProjectAdviceFor(':producer'),
-    ]
-  }
-
+  
   static final class CompilesWithTestFixturesDependency extends Kotlin2Migration {
 
     final GradleProject gradleProject

--- a/testkit/gradle-testkit-truth/build.gradle.kts
+++ b/testkit/gradle-testkit-truth/build.gradle.kts
@@ -46,7 +46,6 @@ dependencies {
   api(gradleTestKit())
   api(libs.truth)
 
-  implementation(platform(libs.kotlin.bom))
   implementation(libs.errorProne) {
     because("Uses @CanIgnoreReturnValue")
   }


### PR DESCRIPTION
Replaces https://github.com/autonomousapps/dependency-analysis-gradle-plugin/pull/1371.