### PR TITLE
fix: support colorizing multiline strings. feat: new dependencyAnalysis.reporting.printBuildHealth DSL option.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/DuplicateClasspathProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/DuplicateClasspathProject.groovy
@@ -208,7 +208,8 @@ final class DuplicateClasspathProject extends AbstractProject {
       builder.append('dependencyAnalysis {\n')
       builder.append('  reporting {\n')
       builder.append('    onlyOnFailure(true)\n')
-      builder.append('    postscript("ERRORS-ONLY POSTSCRIPT")\n')
+      // multiline for a "manual test" of colorized support for multiline strings
+      builder.append('    postscript("""MULTILINE\nERRORS-ONLY POSTSCRIPT""")\n')
       builder.append('  }\n')
 
       builder.append('  issues {\n')

--- a/src/main/kotlin/com/autonomousapps/Flags.kt
+++ b/src/main/kotlin/com/autonomousapps/Flags.kt
@@ -35,7 +35,13 @@ object Flags {
 
   internal fun Project.shouldAnalyzeTests() = getGradleOrSysProp(FLAG_TEST_ANALYSIS, true)
 
+  /**
+   * Whether to print the buildHealth report to console.
+   *
+   * @see [com.autonomousapps.extension.ReportingHandler.printBuildHealth]
+   */
   internal fun Project.printBuildHealth() = getGradlePropForConfiguration(FLAG_PRINT_BUILD_HEALTH, false)
+
   internal fun Project.androidIgnoredVariants() = getGradlePropForConfiguration(
     FLAG_ANDROID_IGNORED_VARIANTS, ""
   ).split(",")

--- a/src/main/kotlin/com/autonomousapps/extension/ReportingHandler.kt
+++ b/src/main/kotlin/com/autonomousapps/extension/ReportingHandler.kt
@@ -14,7 +14,10 @@ import javax.inject.Inject
  * dependencyAnalysis {
  *   reporting {
  *     onlyOnFailure(false) // when true, only prints postscript when there are failure-level issues.
+ *
  *     postscript(/* Some text to help out end users who may not be build engineers. */)
+ *
+ *     printBuildHealth(false) // when true, prints buildHealth report to console
  *   }
  * }
  * ```
@@ -23,6 +26,10 @@ abstract class ReportingHandler @Inject constructor(private val objects: ObjectF
 
   internal val onlyOnFailure: Property<Boolean> = objects.property<Boolean>().convention(false)
   internal val postscript: Property<String> = objects.property<String>().convention("")
+
+  // nb: this intentionally does not have a convention set. If the user does not supply a value, we then check the
+  // value of the Gradle property, which itself supplies a default value.
+  internal val printBuildHealth: Property<Boolean> = objects.property<Boolean>()
 
   /**
    * Whether to always include the postscript, or only when the report includes failure-level issues.
@@ -38,6 +45,16 @@ abstract class ReportingHandler @Inject constructor(private val objects: ObjectF
   fun postscript(postscript: String) {
     this.postscript.set(postscript)
     this.postscript.disallowChanges()
+  }
+
+  /**
+   * Whether to print the buildHealth report to console.
+   *
+   * @see [com.autonomousapps.Flags.FLAG_PRINT_BUILD_HEALTH]
+   */
+  fun printBuildHealth(printBuildHealth: Boolean) {
+    this.printBuildHealth.set(printBuildHealth)
+    this.printBuildHealth.disallowChanges()
   }
 
   internal fun config(): Config {

--- a/src/main/kotlin/com/autonomousapps/internal/utils/Colors.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/Colors.kt
@@ -17,11 +17,31 @@ internal object Colors {
   /**
    * Colorizes string for console output. Default is [GREEN_BOLD].
    *
-   * See also
-   * 1. [https://jakewharton.com/peeking-at-colorful-command-line-output/]
-   * 2. [https://en.wikipedia.org/wiki/ANSI_escape_code]
+   * @see <a href="https://jakewharton.com/peeking-at-colorful-command-line-output/">Peeking at command-line ANSI escape sequences</a>
+   * @see <a href="https://en.wikipedia.org/wiki/ANSI_escape_code">ANSI escape code</a>
    */
   internal fun String.colorize(style: String = GREEN_BOLD): String {
-    return "$style$this$NORMAL"
+    // The complexity of this implementation is due to the fact that ANSI escape codes don't persist across newline
+    // boundaries. So we need to wrap each line in the codes. We make a best effort to ensure the final, colorized
+    // string retains the newline (or not) at the end of the original string.
+
+    val lines = lines()
+    val appendNewlineAtEnd = endsWith(System.lineSeparator())
+    val lineCount = lines.size
+
+    return buildString {
+      lines.forEachIndexed { i, line ->
+        append(style)
+        append(line)
+        if (i < lineCount - 1) {
+          appendLine()
+        }
+        append(NORMAL)
+      }
+
+      if (appendNewlineAtEnd) {
+        appendLine()
+      }
+    }
   }
 }

--- a/src/main/kotlin/com/autonomousapps/subplugin/RootPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/RootPlugin.kt
@@ -127,7 +127,7 @@ internal class RootPlugin(private val project: Project) {
       shouldFail.set(generateBuildHealthTask.flatMap { it.outputFail })
       buildHealth.set(generateBuildHealthTask.flatMap { it.output })
       consoleReport.set(generateBuildHealthTask.flatMap { it.consoleOutput })
-      printBuildHealth.set(printBuildHealth())
+      printBuildHealth.set(dagpExtension.reportingHandler.printBuildHealth.orElse(printBuildHealth()))
       postscript.set(dagpExtension.reportingHandler.postscript)
     }
 


### PR DESCRIPTION
Maybe should just find a library for this...