### PR TITLE
fix: module advice must be 'actionable' to be 'not empty'.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/advice/ProjectHealthConsoleReportBuilder.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/advice/ProjectHealthConsoleReportBuilder.kt
@@ -199,7 +199,7 @@ internal class ProjectHealthConsoleReportBuilder(
   }
 
   private fun Set<ModuleAdvice>.hasPrintableAdvice(): Boolean {
-    return isNotEmpty() && filterIsInstance<AndroidScore>().any { it.couldBeJvm() }
+    return ModuleAdvice.isNotEmpty(this)
   }
 
   private fun AndroidScore.text() = buildString {

--- a/src/main/kotlin/com/autonomousapps/model/ProjectAdvice.kt
+++ b/src/main/kotlin/com/autonomousapps/model/ProjectAdvice.kt
@@ -20,7 +20,7 @@ data class ProjectAdvice(
   /** Returns true if this has no advice, nor any warnings. */
   fun isEmpty(): Boolean = dependencyAdvice.isEmpty()
     && pluginAdvice.isEmpty()
-    && moduleAdvice.isEmpty()
+    && ModuleAdvice.isEmpty(moduleAdvice)
     && warning.isEmpty()
 
   /**


### PR DESCRIPTION
Resolves https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1381.