### PR TITLE
Update AGP 8.9.0 stable

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
@@ -16,22 +16,22 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
 
   protected static final AGP_8_0 = AgpVersion.version('8.0.2')
   protected static final AGP_8_1 = AgpVersion.version('8.1.4')
-  protected static final AGP_8_2 = AgpVersion.version('8.2.0')
+  protected static final AGP_8_2 = AgpVersion.version('8.2.2')
   protected static final AGP_8_3 = AgpVersion.version('8.3.2')
   protected static final AGP_8_4 = AgpVersion.version('8.4.2')
   protected static final AGP_8_5 = AgpVersion.version('8.5.2')
   protected static final AGP_8_6 = AgpVersion.version('8.6.1')
   protected static final AGP_8_7 = AgpVersion.version('8.7.3')
-  protected static final AGP_8_8 = AgpVersion.version('8.8.0')
-  protected static final AGP_8_9 = AgpVersion.version('8.9.0-rc01')
-  protected static final AGP_8_10 = AgpVersion.version('8.10.0-alpha04')
+  protected static final AGP_8_8 = AgpVersion.version('8.8.2')
+  protected static final AGP_8_9 = AgpVersion.version('8.9.0')
+  protected static final AGP_8_10 = AgpVersion.version('8.10.0-alpha07')
 
   protected static final AGP_LATEST = AGP_8_10
 
   /**
    * TODO(tsr): this doc is perpetually out of date.
    *
-   * {@code AGP_8_0} represents the minimum stable _tested_ version. {@code AGP_8_8} represents the maximum stable
+   * {@code AGP_8_0} represents the minimum stable _tested_ version. {@code AGP_8_9} represents the maximum stable
    * _tested_ version. We also test against the latest alpha, {@code AGP_8_10} at time of writing. DAGP may work with
    * other versions of AGP, but they aren't tested, primarily for CI performance reasons.
    *
@@ -39,7 +39,7 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
    */
   protected static final SUPPORTED_AGP_VERSIONS = [
     AGP_8_0,
-    AGP_8_8,
+    AGP_8_9,
     AGP_8_10,
   ]
 

--- a/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
@@ -15,7 +15,7 @@ internal class AgpVersion private constructor(val version: String) : Comparable<
   companion object {
 
     @JvmStatic val AGP_MIN = version("8.0.0")
-    @JvmStatic val AGP_MAX = version("8.8.0")
+    @JvmStatic val AGP_MAX = version("8.9.0")
 
     @JvmStatic fun current(): AgpVersion = AgpVersion(agpVersion())
     @JvmStatic fun version(version: String): AgpVersion = AgpVersion(version)


### PR DESCRIPTION
This commit updates the project to the latest stable version of AGP: 8.9.0.
It also updates to the latest bugfix version of older versions (8.2.2, 8.8.2) and the latest alpha of the next version (8.10.0-alpha07).