### PR TITLE
fix: kotlin-reflect must be on the compile classpath.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/KotlinReflectSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/KotlinReflectSpec.groovy
@@ -1,0 +1,24 @@
+package com.autonomousapps.jvm
+
+import com.autonomousapps.jvm.projects.KotlinReflectProject
+
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertThat
+
+final class KotlinReflectSpec extends AbstractJvmSpec {
+
+  def "kotlin-reflect must be present at compile-time (#gradleVersion)"() {
+    given:
+    def project = new KotlinReflectProject()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/KotlinReflectProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/KotlinReflectProject.groovy
@@ -1,0 +1,60 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.actualProjectAdvice
+import static com.autonomousapps.AdviceHelper.emptyProjectAdviceFor
+import static com.autonomousapps.kit.gradle.dependencies.Dependencies.kotlinReflect
+
+final class KotlinReflectProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  KotlinReflectProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newGradleProjectBuilder()
+      .withSubproject('proj') { s ->
+        s.sources = sources
+        s.withBuildScript { bs ->
+          bs.plugins = kotlin
+          bs.dependencies = [
+            // Must not be advised to move to runtimeOnly
+            kotlinReflect('implementation')
+          ]
+        }
+      }
+      .write()
+  }
+
+  private sources = [
+    Source.kotlin(
+      '''\
+        package com.example
+        
+        sealed class SealedClass {
+          class SubClass : SealedClass() {
+            fun usesKotlinReflect(): String {
+              return SealedClass::class.sealedSubclasses.joinToString()
+            }
+          }
+        }
+      '''
+    )
+      .withPath('com.example', 'SealedClass')
+      .build(),
+  ]
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  final Set<ProjectAdvice> expectedBuildHealth = [
+    emptyProjectAdviceFor(':proj')
+  ]
+}

--- a/src/functionalTest/kotlin/com/autonomousapps/kit/gradle/dependencies/Dependencies.kt
+++ b/src/functionalTest/kotlin/com/autonomousapps/kit/gradle/dependencies/Dependencies.kt
@@ -22,6 +22,11 @@ object Dependencies {
   }
 
   @JvmStatic
+  fun kotlinReflect(configuration: String): Dependency {
+    return provider.kotlinReflect(configuration)
+  }
+
+  @JvmStatic
   fun kotlinStdLib(configuration: String): Dependency {
     return provider.kotlinStdLib(configuration)
   }

--- a/src/functionalTest/kotlin/com/autonomousapps/kit/gradle/dependencies/DependencyProvider.kt
+++ b/src/functionalTest/kotlin/com/autonomousapps/kit/gradle/dependencies/DependencyProvider.kt
@@ -28,6 +28,10 @@ class DependencyProvider(
     return Dependency(configurationName, "org.codehaus.groovy:groovy-all:2.4.15")
   }
 
+  fun kotlinReflect(configuration: String): Dependency {
+    return Dependency(configuration, "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
+  }
+
   fun kotlinStdLib(configuration: String): Dependency {
     return Dependency(configuration, "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
   }

--- a/src/main/kotlin/com/autonomousapps/internal/utils/resolvedDependencies.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/resolvedDependencies.kt
@@ -9,10 +9,11 @@ import org.gradle.api.file.ConfigurableFileCollection
  * Must only be called in a task action.
  */
 internal fun ConfigurableFileCollection.dependencyCoordinates(): Set<ModuleCoordinates> =
-  this.files
+  files.asSequence()
     .flatMap { it.readLines() }
     .map {
       val external = Coordinates.of(it)
       check(external is ModuleCoordinates) { "ModuleCoordinates expected. Was $it." }
       external
-    }.toSet()
+    }
+    .toSet()

--- a/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
@@ -174,12 +174,20 @@ internal class ProjectPlugin(private val project: Project) {
         onAny {
           exclude("org.jetbrains.kotlin:kotlin-stdlib")
         }
+        onRuntimeOnly {
+          // kotlin-reflect must be on the compile classpath: https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1384
+          exclude("org.jetbrains.kotlin:kotlin-reflect")
+        }
       }
     }
     pluginManager.withPlugin(KOTLIN_ANDROID_PLUGIN) {
       dagpExtension.issueHandler.project(path) {
         onAny {
           exclude("org.jetbrains.kotlin:kotlin-stdlib")
+        }
+        onRuntimeOnly {
+          // kotlin-reflect must be on the compile classpath: https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1384
+          exclude("org.jetbrains.kotlin:kotlin-reflect")
         }
       }
     }

--- a/src/main/kotlin/com/autonomousapps/subplugin/RootPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/RootPlugin.kt
@@ -162,7 +162,7 @@ internal class RootPlugin(private val project: Project) {
   }
 
   private fun Resolver<DagpArtifacts>.artifactFilesProvider(): Provider<FileCollection> =
-    this.internal.map { c ->
+    internal.map { c ->
       c.incoming.artifactView {
         // Not all projects in the build will have DAGP applied, meaning they won't have any artifact to consume.
         // Setting `lenient(true)` means we can still have a dependency on those projects, and not fail this task when

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeAllDependenciesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeAllDependenciesTask.kt
@@ -5,6 +5,7 @@ package com.autonomousapps.tasks
 import com.autonomousapps.TASK_GROUP_DEP
 import com.autonomousapps.internal.utils.getAndDelete
 import com.autonomousapps.internal.utils.dependencyCoordinates
+import com.autonomousapps.internal.utils.mapToOrderedSet
 import com.autonomousapps.model.ModuleCoordinates
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
@@ -37,8 +38,7 @@ abstract class ComputeAllDependenciesTask : DefaultTask() {
 
     val libs: Set<String> = resolvedDependenciesReports
       .dependencyCoordinates()
-      .map { "${it.toVersionCatalogAlias()} = { module = \"${it.identifier}\", version = \"${it.resolvedVersion}\" }" }
-      .toSortedSet()
+      .mapToOrderedSet { "${it.toVersionCatalogAlias()} = { module = \"${it.identifier}\", version = \"${it.resolvedVersion}\" }" }
 
     val tomlContent = buildString {
       appendLine("[libraries]")
@@ -51,7 +51,7 @@ abstract class ComputeAllDependenciesTask : DefaultTask() {
   }
 
   private fun ModuleCoordinates.toVersionCatalogAlias(): String {
-    return "${this.identifier}-${this.resolvedVersion}"
+    return "${identifier}-${resolvedVersion}"
       .split(':', '.')
       // replace reserved keywords with safe alternatives
       .joinToString(separator = "-") { tomlReservedKeywordMappings.getOrDefault(it, it) }


### PR DESCRIPTION
Don't suggest moving to runtimeOnly.

Resolves https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1384