### PR TITLE
Take indentation into consideration when adding dependencies

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/advice/AdvicePrinter.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/advice/AdvicePrinter.kt
@@ -15,8 +15,8 @@ internal class AdvicePrinter(
   fun line(configuration: String, printableIdentifier: String, was: String = ""): String =
     "  $configuration$printableIdentifier$was"
 
-  fun toDeclaration(advice: Advice): String =
-    "  ${advice.toConfiguration}${gav(advice.coordinates)}"
+  fun toDeclaration(advice: Advice, prefix: String = "  "): String =
+    "$prefix${advice.toConfiguration}${gav(advice.coordinates)}"
 
   fun gav(coordinates: Coordinates): String {
     val quotedDep = coordinates.mapped()

--- a/src/main/kotlin/com/autonomousapps/internal/parse/KotlinBuildScriptDependenciesRewriter.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/parse/KotlinBuildScriptDependenciesRewriter.kt
@@ -106,7 +106,7 @@ internal class KotlinBuildScriptDependenciesRewriter(
       rewriter.insertBefore(
         beforeToken,
         addAdvice.joinToString(prefix = prefix, postfix = postfix, separator = "\n") { a ->
-          printer.toDeclaration(a)
+          printer.toDeclaration(advice = a, prefix = indent)
         }
       )
     }

--- a/src/test/kotlin/com/autonomousapps/internal/parse/KotlinBuildScriptDependenciesRewriterTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/parse/KotlinBuildScriptDependenciesRewriterTest.kt
@@ -200,6 +200,85 @@ internal class KotlinBuildScriptDependenciesRewriterTest {
     )
   }
 
+  @Test fun `can update dependencies with custom indent level`() {
+    // Given
+    val sourceFile = dir.resolve("build.gradle.kts")
+    sourceFile.writeText(
+      """
+        import foo
+        import bar
+
+        plugins {
+            id("foo")
+        }
+
+        repositories {
+            google()
+            mavenCentral()
+        }
+
+        apply(plugin = "bar")
+
+        extra["magic"] = 42
+
+        android {
+            whatever
+        }
+
+        dependencies {
+            implementation("heart:of-gold:1.+")
+            api(project(":marvin"))
+            testImplementation("pan-galactic:gargle-blaster:2.0-SNAPSHOT") {
+                because("life's too short not to")
+          }
+        }
+
+        println("hello, world!")
+      """.trimIndent()
+    )
+    val advice = setOf(
+      Advice.ofChange(Coordinates.of(":marvin"), "api", "compileOnly"),
+      Advice.ofRemove(Coordinates.of("pan-galactic:gargle-blaster:2.0-SNAPSHOT"), "testImplementation"),
+      Advice.ofAdd(Coordinates.of(":sad-robot"), "runtimeOnly"),
+    )
+
+    // When
+    val parser = KotlinBuildScriptDependenciesRewriter.of(sourceFile, advice, AdvicePrinter(DslKind.KOTLIN))
+
+    // Then
+    assertThat(parser.rewritten().trimmedLines()).containsExactlyElementsIn(
+      """
+        import foo
+        import bar
+
+        plugins {
+            id("foo")
+        }
+
+        repositories {
+            google()
+            mavenCentral()
+        }
+
+        apply(plugin = "bar")
+
+        extra["magic"] = 42
+
+        android {
+            whatever
+        }
+
+        dependencies {
+            implementation("heart:of-gold:1.+")
+            compileOnly(project(":marvin"))
+            runtimeOnly(project(":sad-robot"))
+        }
+
+        println("hello, world!")
+      """.trimIndent().trimmedLines()
+    )
+  }
+
   @Test fun `ignores buildscript dependencies`() {
     // Given
     val sourceFile = dir.resolve("build.gradle.kts")


### PR DESCRIPTION
This is applied only for kts, since we don't have an equivalent to the `Whitespace` class for groovy files.