### PR TITLE
fix: issue 1360. Include check for java/main in ArtifactsReportTask

### DIFF
--- a/src/main/kotlin/com/autonomousapps/tasks/ArtifactsReportTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ArtifactsReportTask.kt
@@ -74,7 +74,7 @@ abstract class ArtifactsReportTask : DefaultTask() {
       .mapNotNull {
         try {
           // https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/948#issuecomment-1711177139
-          val file = if (it.file.path.endsWith("kotlin/main")) {
+          val file = if (it.file.path.endsWith("kotlin/main") || it.file.path.endsWith("java/main")) {
             it.file.parentFile!!.parentFile!!
           } else {
             it.file


### PR DESCRIPTION
This PR fixes #1360. 

After updating to Kotlin 2.0.21 in our large Android project, the artifact path is sometimes incorrect. This PR applies that same workaround to find the grandparent folder that was previously added for `kotlin/main`.