### PR TITLE
feat: experimenting with compressing intermediates.

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/autonomousapps/convention/tasks/GunzipTask.kt
+++ b/build-logic/convention/src/main/kotlin/com/autonomousapps/convention/tasks/GunzipTask.kt
@@ -1,0 +1,88 @@
+package com.autonomousapps.convention.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.*
+import org.gradle.api.tasks.options.Option
+import org.gradle.process.ExecOperations
+import java.io.File
+import javax.inject.Inject
+
+/**
+ * This is just a fancy way of running
+ * ```
+ * # -d decompression
+ * # -c stdout
+ * $ gzip -cd path/to/file.json.gz
+ * ```
+ */
+@CacheableTask
+abstract class GunzipTask @Inject constructor(
+  private val execOperations: ExecOperations
+) : DefaultTask() {
+
+  init {
+    description = "Gunzips a gzipped Dependency Analysis output file"
+  }
+
+  @get:Internal
+  abstract val projectDir: DirectoryProperty
+
+  @get:Classpath
+  abstract val runtimeClasspath: ConfigurableFileCollection
+
+  @get:Option(option = "file", description = "The file to gunzip")
+  @get:Internal
+  abstract val filePath: Property<String>
+
+  @PathSensitive(PathSensitivity.RELATIVE)
+  @InputFile
+  fun getFile(): File = fileToRead()
+
+  @get:OutputDirectory
+  abstract val outputDir: DirectoryProperty
+
+  @TaskAction fun action() {
+    val fileToRead = fileToRead()
+    val outputFile = outputFile(fileToRead)
+
+    execOperations.javaexec { spec ->
+      spec.classpath = runtimeClasspath
+      spec.mainClass.set("com.autonomousapps.tools.gzip.GunzipTaskOutput")
+      spec.args(fileToRead.absolutePath, outputFile.absolutePath)
+    }
+  }
+
+  private fun fileToRead(): File {
+    val input = filePath.get()
+
+    val inputFile = if (input.startsWith('/')) {
+      // absolute
+      File(input)
+    } else {
+      // interpret as relative to the project directory
+      projectDir.file(input).get().asFile
+    }
+
+    return inputFile.absoluteFile.normalize().also {
+      require(it.exists()) {
+        "${it.absolutePath} does not exist!"
+      }
+      require(it.isFile) {
+        "${it.absolutePath} is not a file!"
+      }
+    }
+  }
+
+  private fun outputFile(fileToRead: File): File {
+    // Filename will be like `foo.json.gz` or `foo.txt.gz`. Remove the `.gz`, since the output will NOT be gzipped.
+    val fileName = fileToRead.name.removeSuffix(".gz")
+
+    val outputFile = outputDir.file(fileName).get().asFile
+    outputFile.delete()
+
+    return outputFile
+  }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -115,6 +115,7 @@ dependencies {
   implementation(libs.guava)
   implementation(libs.kotlin.stdlib.jdk8)
   implementation(libs.kotlin.editor.relocated)
+  // implementation(libs.kryo5)
   implementation(libs.moshi.kotlin)
   implementation(libs.moshix.sealed.reflect)
   implementation(libs.okio)
@@ -307,6 +308,17 @@ tasks.register("publishEverywhere") {
 
 tasks.withType<GroovyCompile>().configureEach {
   options.isIncremental = true
+}
+
+// TODO(tsr): gzip. also register this task in ProjectPlugin
+// To run:
+// ```
+// ./gradlew :readFile --input path/to/gzipped-file
+// ```
+tasks.register<com.autonomousapps.convention.tasks.GunzipTask>("gunzip") {
+  runtimeClasspath.setFrom(sourceSets.main.map { it.runtimeClasspath })
+  projectDir.set(layout.projectDirectory)
+  outputDir.set(layout.buildDirectory.dir("gzip"))
 }
 
 dependencyAnalysis {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,8 @@ guava = "33.3.1-jre"
 java = "11"
 junit = "5.10.2"
 kotlin = "2.0.21"
+# TODO(tsr): gzip. Delete
+kryo = "5.6.2"
 
 # Cannot be called kotlin-editor as it causes `libs.versions.kotlin.get()` to fail
 kotlineditor-core = "0.18"
@@ -56,6 +58,10 @@ kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref =
 kotlin-stdlib-core = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlin-metadata-jvm = { module = "org.jetbrains.kotlin:kotlin-metadata-jvm", version.ref = "kotlin" }
+
+# TODO(tsr): gzip. Delete
+kryo = { module = "com.esotericsoftware:kryo", version.ref = "kryo" }
+kryo5 = { module = "com.esotericsoftware.kryo:kryo5", version.ref = "kryo" }
 
 moshi-core = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }

--- a/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
@@ -27,7 +27,9 @@ internal class OutputPaths(
   val externalDependenciesPath = file("${intermediatesDir}/external-dependencies.txt")
   val duplicateCompileClasspathPath = file("${intermediatesDir}/duplicate-classes-compile.json")
   val duplicateCompileRuntimePath = file("${intermediatesDir}/duplicate-classes-runtime.json")
-  val explodedJarsPath = file("${intermediatesDir}/exploded-jars.json")
+  // TODO(tsr): gzip
+  // val explodedJarsPath = file("${intermediatesDir}/exploded-jars.json")
+  val explodedJarsPath = file("${intermediatesDir}/exploded-jars.json.gz")
   val inlineUsagePath = file("${intermediatesDir}/inline-usage.json")
   val typealiasUsagePath = file("${intermediatesDir}/typealias-usage.json")
   val inlineUsageErrorsPath = file("${intermediatesDir}/inline-usage-errors.txt")

--- a/src/main/kotlin/com/autonomousapps/internal/utils/moshi.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/moshi.kt
@@ -19,7 +19,6 @@ import java.io.File
 import kotlin.io.use
 
 const val noJsonIndent = ""
-const val prettyJsonIndent = "  "
 
 val MOSHI: Moshi by lazy {
   Moshi.Builder()
@@ -32,7 +31,7 @@ val MOSHI: Moshi by lazy {
 
 inline fun <reified T> JsonAdapter<T>.withNulls(withNulls: Boolean): JsonAdapter<T> {
   return if (withNulls) {
-    this.serializeNulls()
+    serializeNulls()
   } else {
     this
   }
@@ -97,14 +96,6 @@ inline fun <reified K, reified V> BufferedSource.fromJsonMapSet(): Map<K, Set<V>
   return getJsonMapSetAdapter<K, V>().fromJson(this)!!
 }
 
-inline fun <reified T> T.toPrettyString(withNulls: Boolean = false): String {
-  return getJsonAdapter<T>(withNulls).indent(prettyJsonIndent).toJson(this)
-}
-
-inline fun <reified K, reified V> Map<K, V>.toPrettyString(withNulls: Boolean = false): String {
-  return getJsonMapAdapter<K, V>(withNulls).indent(prettyJsonIndent).toJson(this)
-}
-
 /**
  * Buffers writes of the set to disk, using the indent to make the output human-readable.
  * By default, the output is compacted.
@@ -136,16 +127,6 @@ inline fun <reified K, reified V> File.bufferWriteJsonMapSet(set: Map<K, Set<V>>
 }
 
 /**
- * Buffers pretty writes of the set to disk, using the indent to make the output human-readable.
- * By default, the output is compacted.
- *
- * @param set The set to write to file
- */
-inline fun <reified T> File.bufferPrettyWriteJsonList(set: List<T>) {
-  bufferWriteJsonList(set, prettyJsonIndent)
-}
-
-/**
  * Buffers writes of the set to disk, using the indent to make the output human-readable.
  * By default, the output is compacted.
  *
@@ -156,16 +137,6 @@ inline fun <reified T> File.bufferWriteJsonList(set: List<T>, indent: String = n
   JsonWriter.of(sink().buffer()).use { writer ->
     getJsonListAdapter<T>().indent(indent).toJson(writer, set)
   }
-}
-
-/**
- * Buffers pretty writes of the set to disk, using the indent to make the output human-readable.
- * By default, the output is compacted.
- *
- * @param set The set to write to file
- */
-inline fun <reified T> File.bufferPrettyWriteJsonSet(set: Set<T>) {
-  bufferWriteJsonSet(set, prettyJsonIndent)
 }
 
 /**

--- a/src/main/kotlin/com/autonomousapps/internal/utils/moshi.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/moshi.kt
@@ -13,10 +13,10 @@ import com.squareup.moshi.*
 import com.squareup.moshi.Types.newParameterizedType
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dev.zacsweers.moshix.sealed.reflect.MoshiSealedJsonAdapterFactory
-import okio.BufferedSource
-import okio.buffer
-import okio.sink
+import okio.*
+import org.gradle.api.file.RegularFileProperty
 import java.io.File
+import kotlin.io.use
 
 const val noJsonIndent = ""
 const val prettyJsonIndent = "  "
@@ -178,6 +178,20 @@ inline fun <reified T> File.bufferPrettyWriteJsonSet(set: Set<T>) {
 inline fun <reified T> File.bufferWriteJsonSet(set: Set<T>, indent: String = noJsonIndent) {
   JsonWriter.of(sink().buffer()).use { writer ->
     getJsonSetAdapter<T>().indent(indent).toJson(writer, set)
+  }
+}
+
+// TODO(tsr): gzip. centralize, update docs
+inline fun <reified T> File.gzipCompress(set: Set<T>, indent: String = noJsonIndent) {
+  JsonWriter.of(GzipSink(sink()).buffer()).use { writer ->
+    getJsonSetAdapter<T>().indent(indent).toJson(writer, set)
+  }
+}
+
+// TODO(tsr): gzip. centralize, update docs
+inline fun <reified T> RegularFileProperty.gzipDecompress(): Set<T> {
+  return GzipSource(get().asFile.source()).buffer().use { source ->
+    getJsonSetAdapter<T>().fromJson(source)!!
   }
 }
 

--- a/src/main/kotlin/com/autonomousapps/internal/utils/utils.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/utils.kt
@@ -49,8 +49,8 @@ internal inline fun <reified T> RegularFileProperty.fromJsonSet(): Set<T> = get(
  * Buffers reads of the RegularFile from disk to the set.
  */
 internal inline fun <reified T> RegularFile.fromJsonSet(): Set<T> {
-  asFile.bufferRead().use { reader ->
-    return getJsonSetAdapter<T>().fromJson(reader)!!
+  return asFile.bufferRead().use { source ->
+    getJsonSetAdapter<T>().fromJson(source)!!
   }
 }
 
@@ -63,8 +63,8 @@ internal inline fun <reified T> RegularFileProperty.fromJsonList(): List<T> = ge
  * Buffers reads of the RegularFile from disk to the set.
  */
 internal inline fun <reified T> RegularFile.fromJsonList(): List<T> {
-  asFile.bufferRead().use { reader ->
-    return getJsonListAdapter<T>().fromJson(reader)!!
+  return asFile.bufferRead().use { reader ->
+    getJsonListAdapter<T>().fromJson(reader)!!
   }
 }
 
@@ -106,8 +106,8 @@ internal inline fun <reified K, reified V> RegularFile.fromJsonMap(): Map<K, V> 
  * Buffers reads of the File from disk to the set.
  */
 internal inline fun <reified K, reified V> File.fromJsonMap(): Map<K, V> {
-  bufferRead().use { reader ->
-    return getJsonMapAdapter<K, V>().fromJson(reader)!!
+  return bufferRead().use { reader ->
+    getJsonMapAdapter<K, V>().fromJson(reader)!!
   }
 }
 
@@ -125,8 +125,8 @@ internal inline fun <reified T> RegularFile.fromJson(): T = asFile.fromJson()
  * Buffer reads of the File from disk to the set.
  */
 internal inline fun <reified T> File.fromJson(): T {
-  bufferRead().use { reader ->
-    return getJsonAdapter<T>().fromJson(reader)!!
+  return bufferRead().use { reader ->
+    getJsonAdapter<T>().fromJson(reader)!!
   }
 }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/ExplodeJarTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ExplodeJarTask.kt
@@ -5,7 +5,7 @@
 package com.autonomousapps.tasks
 
 import com.autonomousapps.internal.JarExploder
-import com.autonomousapps.internal.utils.bufferWriteJsonSet
+import com.autonomousapps.internal.utils.*
 import com.autonomousapps.internal.utils.fromJsonList
 import com.autonomousapps.internal.utils.fromNullableJsonSet
 import com.autonomousapps.internal.utils.getAndDelete
@@ -86,7 +86,8 @@ abstract class ExplodeJarTask @Inject constructor(
       ).explodedJars()
 
       // Write output to disk
-      outputFile.bufferWriteJsonSet(explodedJars)
+      // outputFile.bufferWriteJsonSet(explodedJars) // TODO(tsr): gzip
+      outputFile.gzipCompress(explodedJars)
     }
   }
 }

--- a/src/main/kotlin/com/autonomousapps/tasks/SynthesizeDependenciesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/SynthesizeDependenciesTask.kt
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.tasks
 
-import com.autonomousapps.internal.utils.bufferWriteJson
+import com.autonomousapps.internal.utils.*
 import com.autonomousapps.internal.utils.fromJson
 import com.autonomousapps.internal.utils.fromJsonSet
 import com.autonomousapps.internal.utils.fromNullableJsonSet
@@ -152,7 +152,8 @@ abstract class SynthesizeDependenciesTask @Inject constructor(
 
       val dependencies = parameters.compileDependencies.fromJson<CoordinatesContainer>().coordinates
       val physicalArtifacts = parameters.physicalArtifacts.fromJsonSet<PhysicalArtifact>()
-      val explodedJars = parameters.explodedJars.fromJsonSet<ExplodedJar>()
+      // val explodedJars = parameters.explodedJars.fromJsonSet<ExplodedJar>() // TODO(tsr): gzip
+      val explodedJars = parameters.explodedJars.gzipDecompress<ExplodedJar>() // TODO(tsr): gzip
       val inlineMembers = parameters.inlineMembers.fromJsonSet<InlineMemberDependency>()
       val typealiases = parameters.typealiases.fromJsonSet<TypealiasDependency>()
       val serviceLoaders = parameters.serviceLoaders.fromJsonSet<ServiceLoaderDependency>()

--- a/src/main/kotlin/com/autonomousapps/tools/gzip/GunzipTaskOutput.kt
+++ b/src/main/kotlin/com/autonomousapps/tools/gzip/GunzipTaskOutput.kt
@@ -1,0 +1,43 @@
+package com.autonomousapps.tools.gzip
+
+import okio.GzipSource
+import okio.buffer
+import okio.source
+import java.nio.file.FileSystem
+import java.nio.file.FileSystems
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.exists
+import kotlin.io.path.writeText
+
+/** Decompresses a gzipped [input] and writes the result to [output]. */
+class GunzipTaskOutput(
+  private val fs: FileSystem,
+  private val input: String,
+  private val output: String,
+) {
+
+  internal fun run() {
+    val input = fs.getPath(input)
+    val output = fs.getPath(output)
+
+    require(input.exists()) { "Input file does not exist. Expected ${input.absolutePathString()}" }
+
+    println("Processing file input '$input'")
+    println("Writing output to '$output'")
+
+    val decompressed = GzipSource(input.source()).buffer().use { source ->
+      source.readUtf8()
+    }
+
+    output.writeText(decompressed)
+  }
+
+  companion object {
+    @JvmStatic
+    fun main(vararg args: String) {
+      require(args.size == 2) { "Expected two arguments. Was ${args.joinToString()}" }
+
+      GunzipTaskOutput(fs = FileSystems.getDefault(), input = args[0], output = args[1]).run()
+    }
+  }
+}

--- a/src/test/kotlin/com/autonomousapps/model/AdviceTest.kt
+++ b/src/test/kotlin/com/autonomousapps/model/AdviceTest.kt
@@ -10,12 +10,13 @@ import org.junit.jupiter.api.Test
 class AdviceTest {
 
   /**
-   * This test exists due to the discovery of a subtle bug in [Advice.compareTo] and how that
-   * interacts with [java.util.TreeSet].
+   * This test exists due to the discovery of a subtle bug in [Advice.compareTo] and how that interacts with
+   * [java.util.TreeSet].
    */
   @Test fun `an ordered set of advice contains no duplicates`() {
     // Given
-    val androidxLifecycle = ModuleCoordinates("androidx.lifecycle:lifecycle-common8", "n/a", GradleVariantIdentification.EMPTY)
+    val androidxLifecycle =
+      ModuleCoordinates("androidx.lifecycle:lifecycle-common8", "n/a", GradleVariantIdentification.EMPTY)
     val adviceSet1 = setOf(Advice.ofRemove(androidxLifecycle, "foo"))
     val adviceSet2 = setOf(Advice.ofRemove(androidxLifecycle, "foo"))
     val list = listOf(adviceSet1, adviceSet2)
@@ -26,4 +27,222 @@ class AdviceTest {
     // Then
     assertThat(orderedSet.size).isEqualTo(1)
   }
+
+  // TODO(tsr): gzip. Delete.
+  // @Nested inner class Compression {
+  //
+  //   @TempDir lateinit var tempDir: Path
+  //
+  //   private val kryoFile by unsafeLazy { tempDir.resolve("file.bin") }
+  //   private val jsonFile by unsafeLazy { tempDir.resolve("file.json") }
+  //   private val okioFile by unsafeLazy { tempDir.resolve("file.okio") }
+  //
+  //   private val projectVariantString = """
+  //     {
+  //       "coordinates": {
+  //         "identifier": ":annos",
+  //         "gradleVariantIdentification": {
+  //           "capabilities": [],
+  //           "attributes": {}
+  //         }
+  //       },
+  //       "variant": {
+  //         "variant": "main",
+  //         "kind": "MAIN"
+  //       },
+  //       "sources": [
+  //         {
+  //           "type": "code",
+  //           "relativePath": "src/main/java/com/example/TypeAnno.java",
+  //           "kind": "JAVA",
+  //           "className": "com.example.TypeAnno",
+  //           "superClass": "java.lang.Object",
+  //           "interfaces": [],
+  //           "usedNonAnnotationClasses": [],
+  //           "usedAnnotationClasses": [],
+  //           "usedInvisibleAnnotationClasses": [],
+  //           "exposedClasses": [],
+  //           "imports": [
+  //             "java.lang.annotation.*"
+  //           ],
+  //           "binaryClassAccesses": {}
+  //         },
+  //         {
+  //           "type": "code",
+  //           "relativePath": "src/main/kotlin/com/example/Anno.kt",
+  //           "kind": "KOTLIN",
+  //           "className": "com.example.Anno",
+  //           "superClass": "java.lang.Object",
+  //           "interfaces": [],
+  //           "usedNonAnnotationClasses": [
+  //             "kotlin.annotation.AnnotationRetention",
+  //             "kotlin.annotation.AnnotationTarget"
+  //           ],
+  //           "usedAnnotationClasses": [
+  //             "kotlin.annotation.MustBeDocumented",
+  //             "kotlin.annotation.Target",
+  //             "kotlin.annotation.Retention",
+  //             "kotlin.Metadata"
+  //           ],
+  //           "usedInvisibleAnnotationClasses": [],
+  //           "exposedClasses": [
+  //             "kotlin.Metadata",
+  //             "kotlin.annotation.MustBeDocumented",
+  //             "kotlin.annotation.Retention",
+  //             "kotlin.annotation.Target"
+  //           ],
+  //           "imports": [],
+  //           "binaryClassAccesses": {}
+  //         },
+  //         {
+  //           "type": "code",
+  //           "relativePath": "src/main/kotlin/com/example/WithProperty.kt",
+  //           "kind": "KOTLIN",
+  //           "className": "com.example.WithProperty",
+  //           "superClass": "java.lang.Object",
+  //           "interfaces": [],
+  //           "usedNonAnnotationClasses": [
+  //             "kotlin.annotation.AnnotationRetention",
+  //             "kotlin.annotation.AnnotationTarget"
+  //           ],
+  //           "usedAnnotationClasses": [
+  //             "kotlin.annotation.MustBeDocumented",
+  //             "kotlin.annotation.Target",
+  //             "kotlin.reflect.KClass",
+  //             "kotlin.annotation.Retention",
+  //             "kotlin.Metadata"
+  //           ],
+  //           "usedInvisibleAnnotationClasses": [],
+  //           "exposedClasses": [
+  //             "kotlin.Metadata",
+  //             "kotlin.annotation.MustBeDocumented",
+  //             "kotlin.annotation.Retention",
+  //             "kotlin.annotation.Target"
+  //           ],
+  //           "imports": [
+  //             "kotlin.reflect.KClass"
+  //           ],
+  //           "binaryClassAccesses": {}
+  //         }
+  //       ],
+  //       "classpath": [
+  //         {
+  //           "type": "module",
+  //           "identifier": "org.jetbrains.kotlin:kotlin-stdlib",
+  //           "resolvedVersion": "1.9.25",
+  //           "gradleVariantIdentification": {
+  //             "capabilities": [
+  //               "org.jetbrains.kotlin:kotlin-stdlib"
+  //             ],
+  //             "attributes": {}
+  //           }
+  //         },
+  //         {
+  //           "type": "module",
+  //           "identifier": "org.jetbrains:annotations",
+  //           "resolvedVersion": "13.0",
+  //           "gradleVariantIdentification": {
+  //             "capabilities": [
+  //               "org.jetbrains:annotations"
+  //             ],
+  //             "attributes": {}
+  //           }
+  //         },
+  //         {
+  //           "type": "project",
+  //           "identifier": ":annos",
+  //           "gradleVariantIdentification": {
+  //             "capabilities": [
+  //               "ROOT"
+  //             ],
+  //             "attributes": {}
+  //           },
+  //           "buildPath": ":"
+  //         }
+  //       ],
+  //       "annotationProcessors": []
+  //     }
+  //   """.trimIndent()
+  //
+  //   private val kryo = Kryo().apply {
+  //     setRegistrationRequired(false)
+  //     register(Advice::class.java)
+  //     register(ModuleCoordinates::class.java)
+  //     register(GradleVariantIdentification::class.java)
+  //     // register(kotlin.collections.EmptyMap::class.java)
+  //     // register(Advice::class.java, object : FieldSerializer<Advice>(kryo, Advice::class.java) {
+  //     //   override fun create(kryo: Kryo, input: Input, type: Class<out Advice>): Advice {
+  //     //     return super.create(kryo, input, type)
+  //     //   }
+  //     // })
+  //     instantiatorStrategy = DefaultInstantiatorStrategy(StdInstantiatorStrategy())
+  //   }
+  //
+  //   @Test fun `can (de)serialize advice with kryo`() {
+  //     // model object
+  //     val androidxLifecycle = ModuleCoordinates(
+  //       "androidx.lifecycle:lifecycle-common8",
+  //       "n/a", GradleVariantIdentification.EMPTY,
+  //     )
+  //     val advice = Advice.ofChange(androidxLifecycle, "foo", "bar")
+  //
+  //     val syntheticProject = projectVariantString.fromJson<ProjectVariant>()
+  //
+  //     // Doing each twice to ensure the code paths are warm. Makes a very measurable difference
+  //     assertThat(kryo(syntheticProject)).isEqualTo(syntheticProject)
+  //     val kryoDuration = measureNanoTime { assertThat(kryo(syntheticProject)).isEqualTo(syntheticProject) }
+  //     measureNanoTime { assertThat(okio(syntheticProject)).isEqualTo(syntheticProject) }
+  //     val okioDuration = measureNanoTime { assertThat(okio(syntheticProject)).isEqualTo(syntheticProject) }
+  //     measureNanoTime { assertThat(moshi(syntheticProject)).isEqualTo(syntheticProject) }
+  //     val moshiDuration = measureNanoTime { assertThat(moshi(syntheticProject)).isEqualTo(syntheticProject) }
+  //
+  //     val jsonSize = jsonFile.toFile().length()
+  //     val binSize = kryoFile.toFile().length()
+  //     val okioSize = okioFile.toFile().length()
+  //     val binRatio = binSize.toDouble() / jsonSize
+  //     val okioRatio = okioSize.toDouble() / jsonSize
+  //
+  //     println("SIZES (smaller is better):")
+  //     println("file.json size = $jsonSize")
+  //     println("file.bin size = $binSize")
+  //     println("file.okio size = $okioSize")
+  //     println("compression ratio for bin = $binRatio")
+  //     println("compression ratio for okio = $okioRatio")
+  //
+  //     println("\nDURATIONS (smaller is better):")
+  //     println("moshiDuration = $moshiDuration")
+  //     println("kryoDuration = $kryoDuration")
+  //     println("okioDuration = $okioDuration")
+  //     println("duration ratio for bin = ${kryoDuration.toDouble() / moshiDuration}")
+  //     println("duration ratio for okio = ${okioDuration.toDouble() / moshiDuration}")
+  //   }
+  //
+  //   private inline fun <reified T> kryo(obj: T): T {
+  //     val output = Output(DeflaterOutputStream(kryoFile.outputStream()))
+  //     kryo.writeObject(output, obj)
+  //     output.close()
+  //     val input = Input(InflaterInputStream(kryoFile.inputStream()))
+  //     val a = kryo.readObject(input, T::class.java)
+  //     input.close()
+  //
+  //     return a as T
+  //   }
+  //
+  //   private inline fun <reified T> moshi(advice: T): T {
+  //     jsonFile.writeText(advice.toJson())
+  //     return jsonFile.toFile().fromJson<T>()
+  //   }
+  //
+  //   private inline fun <reified T> okio(advice: T): T {
+  //     okioFile.sink().use { fileSink ->
+  //       GzipSink(fileSink).buffer().use { bufferedSink ->
+  //         bufferedSink.writeUtf8(advice.toJson())
+  //       }
+  //     }
+  //     // Decompress the file and read its contents
+  //     return GzipSource(okioFile.source()).use { fileSource ->
+  //       fileSource.buffer().use { bufferedSource -> bufferedSource.readUtf8() }
+  //     }.fromJson<T>()
+  //   }
+  // }
 }


### PR DESCRIPTION
Using gzip, since it is fast, effective, and an easy drop-in alongside Moshi and Okio.
Starting with exploded-jars.json, which is one of the larger outputs.

Working towards a resolution of https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1395. This gzips one of the largest files we see in DAGP outputs. Let's use this as a test to see if there are any issues with consumers.