### PR TITLE
fix: detect usages of SAM interfaces.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/SamInterfacesSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/SamInterfacesSpec.groovy
@@ -1,0 +1,24 @@
+package com.autonomousapps.jvm
+
+import com.autonomousapps.jvm.projects.SamInterfacesProject
+
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertThat
+
+final class SamInterfacesSpec extends AbstractJvmSpec {
+
+  def "detects SAM interfaces (#gradleVersion)"() {
+    given:
+    def project = new SamInterfacesProject()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualProjectAdvice()).containsExactlyElementsIn(project.expectedProjectAdvice)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/SamInterfacesProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/SamInterfacesProject.groovy
@@ -1,0 +1,104 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.actualProjectAdvice
+import static com.autonomousapps.AdviceHelper.emptyProjectAdviceFor
+import static com.autonomousapps.kit.gradle.Dependency.project
+
+final class SamInterfacesProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  SamInterfacesProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newGradleProjectBuilder()
+      .withSubproject('kotlin-consumer') { c ->
+        c.sources = kotlinConsumerSources
+        c.withBuildScript { bs ->
+          bs.plugins = kotlin
+          bs.dependencies = [
+            project('implementation', ':sam-interface-consumer'),
+            project('implementation', ':sam-interface-producer'),
+          ]
+        }
+      }
+      .withSubproject('sam-interface-consumer') { c ->
+        c.sources = samInterfaceConsumerSources
+        c.withBuildScript { bs ->
+          bs.plugins = javaLibrary
+        }
+      }
+      .withSubproject('sam-interface-producer') { c ->
+        c.sources = samInterfaceProducerSources
+        c.withBuildScript { bs ->
+          bs.plugins = javaLibrary
+        }
+      }
+      .write()
+  }
+
+  private kotlinConsumerSources = [
+    Source.kotlin(
+      """\
+      package com.example.consumer
+            
+      import com.example.consumer.java.SamInterfaceConsumer
+            
+      class Consumer {
+        fun usesJavaProducer() {
+          val consumer = SamInterfaceConsumer()
+          consumer.setWhatever(com.example.producer.java.SamInterface { "magic!" })
+        }
+      }
+      """
+    )
+      .withPath('com.example.consumer', 'Consumer')
+      .build(),
+  ]
+
+  private samInterfaceConsumerSources = [
+    Source.java(
+      """\
+      package com.example.consumer.java;
+            
+      public class SamInterfaceConsumer {
+        public void setWhatever(Object whatever) {}
+      }
+      """
+    )
+      .withPath('com.example.consumer.java', 'SamInterfaceConsumer')
+      .build(),
+  ]
+
+  private samInterfaceProducerSources = [
+    Source.java(
+      """\
+      package com.example.producer.java;
+      
+      public interface SamInterface {
+        String produce();
+      }
+      """
+    )
+      .withPath('com.example.producer.java', 'SamInterface')
+      .build()
+  ]
+
+  Set<ProjectAdvice> actualProjectAdvice() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+
+  final Set<ProjectAdvice> expectedProjectAdvice = [
+    emptyProjectAdviceFor(':kotlin-consumer'),
+    emptyProjectAdviceFor(':sam-interface-consumer'),
+    emptyProjectAdviceFor(':sam-interface-producer'),
+  ]
+}

--- a/src/main/kotlin/com/autonomousapps/internal/asm.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/asm.kt
@@ -230,7 +230,7 @@ internal class ClassAnalyzer(private val logger: Logger) : ClassVisitor(ASM_VERS
   val interfaces = sortedSetOf<String>()
 
   val classes = mutableSetOf<ClassRef>()
-  private val binaryClasses = mutableMapOf<String, SortedSet<MemberAccess>>()
+  private val binaryClasses = sortedMapOf<String, SortedSet<MemberAccess>>()
 
   private val methodAnalyzer = MethodAnalyzer(logger, classes, binaryClasses)
   private val fieldAnalyzer = FieldAnalyzer(logger, classes)

--- a/src/main/kotlin/com/autonomousapps/internal/asm.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/asm.kt
@@ -6,6 +6,7 @@ import com.autonomousapps.Flags
 import com.autonomousapps.internal.ClassNames.canonicalize
 import com.autonomousapps.internal.asm.*
 import com.autonomousapps.internal.kotlin.AccessFlags
+import com.autonomousapps.internal.utils.JAVA_FQCN_REGEX_ASM
 import com.autonomousapps.internal.utils.METHOD_DESCRIPTOR_REGEX
 import com.autonomousapps.internal.utils.efficient
 import com.autonomousapps.internal.utils.genericTypes
@@ -587,14 +588,11 @@ private class FieldAnalyzer(
 }
 
 private fun MutableSet<ClassRef>.addClass(classRef: String?, kind: ClassRef.Kind) {
-  classRef?.let {
-    // Strip array indicators
-    it.replace("[", "")
-    // Only add class types (not primitives)
-    if (it.startsWith("L")) {
-      add(ClassRef(it.substring(1, it.length - 1), kind))
-    }
-  }
+  classRef ?: return
+
+  JAVA_FQCN_REGEX_ASM.findAll(classRef)
+    .map { it.value }
+    .forEach { add(ClassRef(it.substring(1, it.length - 1), kind)) }
 }
 
 /* ===================================================================================================

--- a/src/main/kotlin/com/autonomousapps/internal/utils/regex.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/regex.kt
@@ -47,4 +47,22 @@ internal val JAVA_FQCN_REGEX_DOTTY =
 internal val JAVA_FQCN_REGEX_SLASHY =
   "(\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*/)+\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*".toRegex()
 
+/**
+ * Matches Java fully-qualified class names as found in descriptors that are seen when analyzing bytecode with asm.
+ * E.g.,
+ *
+ * ```
+ * ()Lcom/example/producer/java/SamInterface;
+ * ```
+ *
+ * The way this works is `\p{javaJavaIdentifierStart}` (etc) will map to a method in the `Character` class such as
+ * `Character.isJavaIdentifierStart()`. So, drop the first `java`, and add the prefix `is`. I don't know why this isn't
+ * clearly documented in the `Pattern` docs directly.
+ *
+ * @see <a href="https://docs.oracle.com/en/java/javase/24/docs/api/java.base/java/lang/Character.html">java.lang.Character</a>
+ * @see <a href="https://docs.oracle.com/en/java/javase/24/docs/api/java.base/java/util/regex/Pattern.html#java">java.util.regex.Pattern</a>
+ */
+internal val JAVA_FQCN_REGEX_ASM =
+  "L(\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*/)+\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*;".toRegex()
+
 internal const val JAVA_SUB_PACKAGE = "(\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)+"

--- a/src/test/kotlin/com/autonomousapps/internal/utils/AnnotationNodeExtensionTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/utils/AnnotationNodeExtensionTest.kt
@@ -4,12 +4,10 @@ package com.autonomousapps.internal.utils
 
 import com.autonomousapps.internal.asm.Type
 import com.autonomousapps.internal.asm.tree.AnnotationNode
-import com.google.common.truth.Truth
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
 
-
-class AnnotationNodeExtensionTest {
+internal class AnnotationNodeExtensionTest {
 
   @Test fun `should correctly parse an annotation node that references a list of Types`() {
     val annotationNode = AnnotationNode("Lcom/test/AnnotationWithMultipleReferences;")
@@ -52,4 +50,3 @@ class AnnotationNodeExtensionTest {
     )
   }
 }
-

--- a/src/test/kotlin/com/autonomousapps/internal/utils/RegexTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/utils/RegexTest.kt
@@ -1,0 +1,21 @@
+package com.autonomousapps.internal.utils
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+internal class RegexTest {
+
+  /** See asm.kt, `visitInvokeDynamicInsn(..., descriptor: String?, ...)` */
+  @ParameterizedTest(name = "{0} => {1}")
+  @CsvSource(
+    value = [
+      "()Lcom/example/producer/java/SamInterface;, Lcom/example/producer/java/SamInterface;",
+      "(Lcom/example/Magic;)Lcom/example/producer/java/SamInterface;, 'Lcom/example/Magic;, Lcom/example/producer/java/SamInterface;'",
+    ]
+  )
+  fun `should parse types from invoke dynamics`(descriptor: String, expectedMatches: String) {
+    assertThat(JAVA_FQCN_REGEX_ASM.findAll(descriptor).map { it.value }.toList())
+      .containsExactlyElementsIn(expectedMatches.split(", "))
+  }
+}


### PR DESCRIPTION
* fix: binaryClassAccesses uses sorted keys.
    * Previously only had sorted values. This should improve cacheability.
* fix: detect usages of SAM interfaces.
    * Instead of doing simply string matching, use regex to find all valid Java class descriptors.