### PR TITLE
fix: use projectPath, not identityPath, for included build coordinates.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/utils/gradleStrings.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/gradleStrings.kt
@@ -43,7 +43,7 @@ private fun ResolvedDependencyResult.compositeRequest(): IncludedBuildCoordinate
     gradleVariantIdentification = gradleVariantIdentification
   )
   val resolved = ProjectCoordinates(
-    identifier = (selected.id as ProjectComponentIdentifier).identityPath(),
+    identifier = (selected.id as ProjectComponentIdentifier).projectPath(),
     gradleVariantIdentification = gradleVariantIdentification,
     buildPath = (selected.id as ProjectComponentIdentifier).build.let {
       if (GradleVersions.isAtLeastGradle82) it.buildPath else @Suppress("DEPRECATION") it.name
@@ -53,8 +53,8 @@ private fun ResolvedDependencyResult.compositeRequest(): IncludedBuildCoordinate
   return IncludedBuildCoordinates.of(requested, resolved)
 }
 
-private fun ProjectComponentIdentifier.identityPath(): String {
-  return (this as? DefaultProjectComponentIdentifier)?.identityPath?.toString()
+private fun ProjectComponentIdentifier.projectPath(): String {
+  return (this as? DefaultProjectComponentIdentifier)?.projectPath?.toString()
     ?: error("${toCoordinates(GradleVariantIdentification.EMPTY)} is not a DefaultProjectComponentIdentifier")
 }
 


### PR DESCRIPTION
This has been a longstanding issue and will probably have multiple knock-on effects. The immediate reason I saw this was that SuperGraph was trying to find nodes built with one version of a graph using nodes from another version of a graph, and failing. This change should sync the two, which ought to also mean fewer outputs in the dependencies directory (no duplication for included build dependencies). I think lots of other code was working around this problem too without realizing it.