### PR TITLE
Fix issues in testkit readme

### DIFF
--- a/testkit/README.asciidoc
+++ b/testkit/README.asciidoc
@@ -91,25 +91,11 @@ class Test {
   }
 }
 
-class MyFixture : AbstractGradleProject {
+class MyFixture : AbstractGradleProject() {
 
   // Injected into functionalTest JVM by the plugin
   // Also available via AbstractGradleProject.PLUGIN_UNDER_TEST_VERSION
   private val pluginVersion = System.getProperty("com.autonomousapps.plugin-under-test.version")
-
-  val gradleProject: GradleProject = build()
-
-  private fun build(): GradleProject {
-    return newGradleProjectBuilder()
-      .withSubproject("project") {
-        sources = source
-        withBuildScript {
-          plugins(Plugin.javaLibrary, Plugin("my-cool-plugin", pluginVersion))
-          dependencies(implementation("com.company:library:1.0"))
-        }
-      }
-      .write()
-  }
 
   private val source = listOf(
     Source.java(
@@ -124,5 +110,19 @@ class MyFixture : AbstractGradleProject {
       .withPath(/* packagePath = */ "com.example.project", /* className = */ "Project")
       .build()
   )
+
+  val gradleProject: GradleProject = build()
+
+  private fun build(): GradleProject {
+    return newGradleProjectBuilder()
+      .withSubproject("project") {
+        sources += source
+        withBuildScript {
+          plugins(Plugin.javaLibrary, Plugin("my-cool-plugin", pluginVersion))
+          dependencies(implementation("com.company:library:1.0"))
+        }
+      }
+      .write()
+  }
 }
 ----


### PR DESCRIPTION
This fixes a few issues in the README

- Invoke the base class constructor
- Add a list as the `sources` property is a List, not assignable to a single value
- Move the source used to _above_ the `gradleProject` init, as otherwise it isn't initialized yet and will be (a sneaky) null at init