### PR TITLE
Update latest stable AGP to 8.10.0

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/AbstractFunctionalSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/AbstractFunctionalSpec.groovy
@@ -22,8 +22,10 @@ abstract class AbstractFunctionalSpec extends Specification {
   protected static final GRADLE_8_10 = GradleVersion.version('8.10.2')
   protected static final GRADLE_8_11 = GradleVersion.version('8.11.1')
   protected static final GRADLE_8_12 = GradleVersion.version('8.12.1')
+  protected static final GRADLE_8_13 = GradleVersion.version('8.13')
+  protected static final GRADLE_8_14 = GradleVersion.version('8.14')
 
-  protected static final GRADLE_LATEST = GRADLE_8_12
+  protected static final GRADLE_LATEST = GRADLE_8_14
 
   // For faster CI times, we only test min + max. Testing all would be preferable, but we don't have till the heat death
   // of the universe.

--- a/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
@@ -23,24 +23,25 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
   protected static final AGP_8_6 = AgpVersion.version('8.6.1')
   protected static final AGP_8_7 = AgpVersion.version('8.7.3')
   protected static final AGP_8_8 = AgpVersion.version('8.8.2')
-  protected static final AGP_8_9 = AgpVersion.version('8.9.0')
-  protected static final AGP_8_10 = AgpVersion.version('8.10.0-alpha07')
+  protected static final AGP_8_9 = AgpVersion.version('8.9.2')
+  protected static final AGP_8_10 = AgpVersion.version('8.10.0')
+  protected static final AGP_8_11 = AgpVersion.version('8.11.0-alpha09')
 
-  protected static final AGP_LATEST = AGP_8_10
+  protected static final AGP_LATEST = AGP_8_11
 
   /**
    * TODO(tsr): this doc is perpetually out of date.
    *
-   * {@code AGP_8_0} represents the minimum stable _tested_ version. {@code AGP_8_9} represents the maximum stable
-   * _tested_ version. We also test against the latest alpha, {@code AGP_8_10} at time of writing. DAGP may work with
+   * {@code AGP_8_0} represents the minimum stable _tested_ version. {@code AGP_8_10} represents the maximum stable
+   * _tested_ version. We also test against the latest alpha, {@code AGP_8_11} at time of writing. DAGP may work with
    * other versions of AGP, but they aren't tested, primarily for CI performance reasons.
    *
    * @see <a href="https://maven.google.com/web/index.html?#com.android.tools.build:gradle">AGP releases</a>
    */
   protected static final SUPPORTED_AGP_VERSIONS = [
     AGP_8_0,
-    AGP_8_9,
     AGP_8_10,
+    AGP_8_11,
   ]
 
   protected static List<AgpVersion> agpVersions(AgpVersion minAgpVersion = AgpVersion.AGP_MIN) {

--- a/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
@@ -15,7 +15,7 @@ internal class AgpVersion private constructor(val version: String) : Comparable<
   companion object {
 
     @JvmStatic val AGP_MIN = version("8.0.0")
-    @JvmStatic val AGP_MAX = version("8.9.0")
+    @JvmStatic val AGP_MAX = version("8.10.0")
 
     @JvmStatic fun current(): AgpVersion = AgpVersion(agpVersion())
     @JvmStatic fun version(version: String): AgpVersion = AgpVersion(version)


### PR DESCRIPTION
This PR:
- Bumps the latest stable AGP version to 8.10.0.
- Updates AGP 8.9 to use the latest bug fix version (8.9.2).
- Starts testing against the latest alpha (8.11.0-alpha09).
- Include Gradle 8.13 and 8.14.
- Tests against Gradle 8.14 instead of 8.12 (AGP 8.11 seems to require Gradle 8.13+).