### PR TITLE
Fix JvmSpec functionalTest on Windows environments

### DIFF
--- a/testkit/gradle-testkit-plugin/src/main/kotlin/com/autonomousapps/GradleTestKitPlugin.kt
+++ b/testkit/gradle-testkit-plugin/src/main/kotlin/com/autonomousapps/GradleTestKitPlugin.kt
@@ -55,7 +55,7 @@ public class GradleTestKitPlugin : Plugin<Project> {
           // Gradle tests generally require more metaspace
           jvmArgs("-XX:+HeapDumpOnOutOfMemoryError", "-XX:MaxMetaspaceSize=1g")
 
-          systemProperty("com.autonomousapps.plugin-under-test.repo", extension.funcTestRepo.absolutePath)
+          systemProperty("com.autonomousapps.plugin-under-test.repo", extension.funcTestRepo.invariantSeparatorsPath)
           systemProperty("com.autonomousapps.plugin-under-test.version", version.toString())
         }
       }


### PR DESCRIPTION
Here is a Build Scan of the errors: https://scans.gradle.com/s/3plpnsp5mibti/tests/overview?outcome=FAILED

This comes from the injected string in the generated settings.gradle not respecting Java syntax: `maven { url = 'E:\IdeaProjects\dependency-analysis-gradle-plugin\build\functionalTestRepo' }`

This is almost identical to this PR:
- https://github.com/autonomousapps/dependency-analysis-gradle-plugin/pull/1045

That being said, I chose to not try to "escape" the String like it was achieved in the PR because:
- I could not re-use the function directly
- escaping characters to respect Java's [specification](https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.6) is a bit more involving, and only escaping backslash feels wrong.

This will result in:

`maven { url = 'E:/IdeaProjects/dependency-analysis-gradle-plugin/build/functionalTestRepo' }` which is compatible, regardless of the environement.

Another solution could be to use `toPath().toUri().toString()` with this result (but I find it more convoluted)

`maven { url = 'file:///E:/IdeaProjects/dependency-analysis-gradle-plugin/build/functionalTestRepo/' }`

Let me know if you prefer one over the other.

(more Windows related fixes are coming up)