### PR TITLE
Fix ProjectHealthSpec on Windows environments

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/ProjectHealthSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/ProjectHealthSpec.groovy
@@ -20,11 +20,11 @@ final class ProjectHealthSpec extends AbstractJvmSpec {
 
     then:
     assertThat(result.output).contains(
-      """${gradleProject.rootDir.getPath()}/proj/build.gradle
-        |Existing dependencies which should be modified to be as indicated:
-        |  api project(':genericsBar') (was implementation)
-        |  api project(':genericsFoo') (was implementation)
-        |""".stripMargin())
+      """\
+        ${new File(gradleProject.rootDir, "proj/build.gradle").getPath()}
+        Existing dependencies which should be modified to be as indicated:
+          api project(':genericsBar') (was implementation)
+          api project(':genericsFoo') (was implementation)""".stripIndent())
 
     where:
     gradleVersion << gradleVersions()


### PR DESCRIPTION
Build Scan: https://scans.gradle.com/s/csbapb2cecxwo/tests/overview

Gstrings are surprising... The last line would not be correctly handled...

Besides this issue, multiple solutions are available for the file path:
- remove the manual string path concatenation with proper file resolving
- replace `ProjectHealthTask`'s `buildFilePath` input with `invariantSeparatorsPath`

I chose the first to avoid changing production code.