### PR TITLE
Fix NestedProjectsSpec on Windows environments

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/NestedProjectsSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/NestedProjectsSpec.groovy
@@ -41,7 +41,7 @@ final class NestedProjectsSpec extends AbstractJvmSpec {
     result.output.contains '''
       Circular dependency between the following tasks:
       :featureC:public:compileJava
-      \\--- :featureC:public:compileJava (*)'''.stripIndent()
+      \\--- :featureC:public:compileJava (*)'''.stripIndent().join(System.lineSeparator())
 
     where:
     gradleVersion << gradleVersions()


### PR DESCRIPTION
Build Scan: https://scans.gradle.com/s/uwlpzccsbxhuy/tests/overview

This time, the issue comes from the fact that:
- `Circular dependency between the following tasks` log message is being printed by Gradle itself, and therfore following the `System.lineSeparator()`
- Groovy strings are using `\n` by default