### PR TITLE
Add ProviderConvertible support

### DIFF
--- a/src/main/kotlin/com/autonomousapps/extension/BundleHandler.kt
+++ b/src/main/kotlin/com/autonomousapps/extension/BundleHandler.kt
@@ -7,6 +7,7 @@ import org.gradle.api.artifacts.MinimalExternalModuleDependency
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderConvertible
 import org.gradle.api.provider.SetProperty
 import org.gradle.kotlin.dsl.setProperty
 import org.intellij.lang.annotations.Language
@@ -68,6 +69,13 @@ abstract class BundleHandler @Inject constructor(
   }
 
   /**
+   * (Optional): Specify the primary entry point that the user is "supposed" to declare.
+   */
+  fun primary(module: ProviderConvertible<MinimalExternalModuleDependency>) {
+    primary(module.asProvider())
+  }
+
+  /**
    * Include all in group as a single logical dependency.
    */
   fun includeGroup(group: String) {
@@ -79,6 +87,13 @@ abstract class BundleHandler @Inject constructor(
    */
   fun includeGroup(module: Provider<MinimalExternalModuleDependency>) {
     includeGroup(module.group())
+  }
+
+  /**
+   * Include all in group as a single logical dependency.
+   */
+  fun includeGroup(module: ProviderConvertible<MinimalExternalModuleDependency>) {
+    includeGroup(module.asProvider())
   }
 
   /**
@@ -102,6 +117,13 @@ abstract class BundleHandler @Inject constructor(
    */
   fun includeDependency(module: Provider<MinimalExternalModuleDependency>) {
     includeDependency(module.identifier())
+  }
+
+  /**
+   * Include all supplied dependencies as a single logical dependency.
+   */
+  fun includeDependency(module: ProviderConvertible<MinimalExternalModuleDependency>) {
+    includeDependency(module.asProvider())
   }
 
   /**

--- a/src/main/kotlin/com/autonomousapps/extension/Issue.kt
+++ b/src/main/kotlin/com/autonomousapps/extension/Issue.kt
@@ -8,6 +8,7 @@ import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.MinimalExternalModuleDependency
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderConvertible
 import org.gradle.kotlin.dsl.property
 import org.gradle.kotlin.dsl.setProperty
 import javax.inject.Inject
@@ -66,6 +67,17 @@ open class Issue @Inject constructor(
    */
   fun exclude(vararg ignore: Provider<MinimalExternalModuleDependency>) {
     exclude(*ignore.map { it.get().module.toString() }.toTypedArray())
+  }
+
+  /**
+   * All provided elements will be filtered out of the final advice. For example:
+   * ```
+   * exclude(libs.example, libs.some.thing)
+   * ```
+   * tells the plugin to exclude those dependencies in the final advice.
+   */
+  fun exclude(vararg ignore: ProviderConvertible<MinimalExternalModuleDependency>) {
+    exclude(*ignore.map { it.asProvider() }.toTypedArray())
   }
 
   /**


### PR DESCRIPTION
Allows using version catalogs like the following:

```toml
com-example = {}
com-example-support = {}
```

Where you must use `asProvider()` to pass `libs.com.example` to DAGP DSL

Closes #1281