### PR TITLE
Fix issue #1323: Incorrect advice for testFixtures configuration in Android project

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/android/TestFixturesSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/TestFixturesSpec.groovy
@@ -1,0 +1,87 @@
+// Copyright (c) 2024. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.android
+
+import com.autonomousapps.android.projects.TestFixturesAddTransitiveProject
+import com.autonomousapps.android.projects.TestFixturesUnusedDependencyProject
+import com.autonomousapps.android.projects.TestFixturesWithAbiProject
+import com.autonomousapps.android.projects.TestFixturesDuplicatedWithMainProject
+import com.autonomousapps.internal.android.AgpVersion
+import org.gradle.util.GradleVersion
+
+import static com.autonomousapps.advice.truth.BuildHealthSubject.buildHealth
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertAbout
+
+final class TestFixturesSpec extends AbstractAndroidSpec {
+  static AgpVersion MINIMAL_AGP_SUPPORTING_TEST_FIXTURES = AgpVersion.version("8.5.0")
+
+  def "should not falsely report duplicated dependencies with main source set(#gradleVersion AGP #agpVersion)"() {
+    given:
+    def project = new TestFixturesDuplicatedWithMainProject(agpVersion as String)
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion as GradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertAbout(buildHealth())
+      .that(project.actualBuildHealth())
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth())
+
+    where:
+    [gradleVersion, agpVersion] << gradleAgpMatrix(MINIMAL_AGP_SUPPORTING_TEST_FIXTURES)
+  }
+
+  def "should advice removing unused dependency even if it is duplicated in main source set"() {
+    given:
+    def project = new TestFixturesUnusedDependencyProject(agpVersion as String)
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion as GradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertAbout(buildHealth())
+            .that(project.actualBuildHealth())
+            .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth())
+
+    where:
+    [gradleVersion, agpVersion] << gradleAgpMatrix(MINIMAL_AGP_SUPPORTING_TEST_FIXTURES)
+  }
+
+  def "should advice to include an ABI dependency as testFixturesApi"() {
+    given:
+    def project = new TestFixturesWithAbiProject(agpVersion as String)
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion as GradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertAbout(buildHealth())
+      .that(project.actualBuildHealth())
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth())
+
+    where:
+    [gradleVersion, agpVersion] << gradleAgpMatrix(MINIMAL_AGP_SUPPORTING_TEST_FIXTURES)
+  }
+
+
+  def "should advice to replace an unused mockito-kotlin with a used transitive mockito-core"() {
+    given:
+    def project = new TestFixturesAddTransitiveProject(agpVersion as String)
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion as GradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertAbout(buildHealth())
+      .that(project.actualBuildHealth())
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth())
+
+    where:
+    [gradleVersion, agpVersion] << gradleAgpMatrix(MINIMAL_AGP_SUPPORTING_TEST_FIXTURES)
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/TestFixturesAddTransitiveProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/TestFixturesAddTransitiveProject.groovy
@@ -1,0 +1,83 @@
+// Copyright (c) 2024. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.android.projects
+
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.kit.gradle.GradleProperties
+import com.autonomousapps.kit.gradle.android.TestFixturesOptions
+import com.autonomousapps.model.Advice
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.*
+import static com.autonomousapps.kit.gradle.dependencies.Dependencies.mockitoKotlin
+
+final class TestFixturesAddTransitiveProject extends AbstractAndroidProject {
+
+  final GradleProject gradleProject
+
+  private final String agpVersion
+
+  TestFixturesAddTransitiveProject(String agpVersion) {
+    super(agpVersion)
+    this.agpVersion = agpVersion
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newAndroidGradleProjectBuilder(agpVersion)
+      .withRootProject { r ->
+        r.gradleProperties = GradleProperties.minimalAndroidProperties() +
+          "android.experimental.enableTestFixturesKotlinSupport=true"
+      }
+      .withAndroidSubproject('lib') { s ->
+        s.sources = libWithFixturesSources
+        s.manifest = libraryManifest('lib.with.fixtures')
+        s.withBuildScript { bs ->
+          bs.plugins = androidLibWithKotlin
+          bs.android = defaultAndroidLibBlock(true).tap {
+            testFixturesOptions = new TestFixturesOptions(true)
+          }
+          bs.dependencies = [
+            mockitoKotlin('testFixturesImplementation'),
+          ]
+        }
+      }
+      .write()
+  }
+
+  private List<Source> libWithFixturesSources = [
+    new Source(
+      SourceType.KOTLIN, 'ClassInFixtures', 'com/example/lib',
+      """\
+      package com.example.fixtures
+
+      import org.mockito.Mockito.verify
+      import org.mockito.ArgumentMatchers.eq
+      
+      object ClassInFixtures {
+          fun someAssert(obj: Any) = verify(obj).equals(eq("anything"))
+      }
+      """.stripIndent(),
+      'testFixtures'
+    )
+  ]
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  private static Set<Advice> changeMockitoKotlinToMockitoCore() {
+    return [
+      Advice.ofRemove(moduleCoordinates('org.mockito.kotlin:mockito-kotlin:4.0.0'), 'testFixturesImplementation'),
+      Advice.ofAdd(moduleCoordinates('org.mockito:mockito-core:4.0.0'), 'testFixturesImplementation'),
+    ]
+  }
+
+  Set<ProjectAdvice> expectedBuildHealth() {
+    [
+      projectAdviceForDependencies(':lib', changeMockitoKotlinToMockitoCore())
+    ]
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/TestFixturesDuplicatedWithMainProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/TestFixturesDuplicatedWithMainProject.groovy
@@ -1,0 +1,107 @@
+// Copyright (c) 2024. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.android.projects
+
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.kit.gradle.GradleProperties
+import com.autonomousapps.kit.gradle.android.TestFixturesOptions
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.*
+import static com.autonomousapps.kit.gradle.Dependency.project
+
+final class TestFixturesDuplicatedWithMainProject extends AbstractAndroidProject {
+
+  final GradleProject gradleProject
+
+  private final String agpVersion
+
+  TestFixturesDuplicatedWithMainProject(String agpVersion) {
+    super(agpVersion)
+    this.agpVersion = agpVersion
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newAndroidGradleProjectBuilder(agpVersion)
+      .withRootProject { r ->
+        r.gradleProperties = GradleProperties.minimalAndroidProperties() +
+          "android.experimental.enableTestFixturesKotlinSupport=true"
+      }
+      .withSubproject('lib-test-utils') { s ->
+        s.sources = libTestUtilsSources
+        s.withBuildScript { bs ->
+          bs.plugins = kotlin
+        }
+      }
+      .withAndroidSubproject('lib') { s ->
+        s.sources = libWithFixturesSources
+        s.manifest = libraryManifest('lib.with.fixtures')
+        s.withBuildScript { bs ->
+          bs.plugins = androidLibWithKotlin
+          bs.android = defaultAndroidLibBlock(true).tap {
+            testFixturesOptions = new TestFixturesOptions(true)
+          }
+          bs.dependencies = [
+            project("implementation", ":lib-test-utils"),
+            project("testFixturesImplementation", ":lib-test-utils")
+          ]
+        }
+      }
+      .write()
+  }
+
+  private List<Source> libTestUtilsSources = [
+    new Source(
+      SourceType.KOTLIN, 'SomeUtil', 'com/example/utils',
+      """\
+      package com.example.utils
+      
+      object SomeUtils {
+          fun utilFun() = Unit
+      }
+      """.stripIndent()
+    ),
+  ]
+
+  private List<Source> libWithFixturesSources = [
+    new Source(
+      SourceType.KOTLIN, 'ClassInImpl', 'com/example/fixtures',
+      """\
+      package com.example.fixtures
+
+      import com.example.utils.SomeUtils
+      
+      object ClassInImpl {
+          fun impl() = SomeUtils.utilFun()
+      }
+      """.stripIndent()
+    ),
+    new Source(
+      SourceType.KOTLIN, 'ClassInFixtures', 'com/example/lib',
+      """\
+      package com.example.fixtures
+
+      import com.example.utils.SomeUtils
+      
+      object ClassInFixtures {
+          fun impl() = SomeUtils.utilFun()
+      }
+      """.stripIndent(),
+      'testFixtures'
+    )
+  ]
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  Set<ProjectAdvice> expectedBuildHealth() {
+    [
+      emptyProjectAdviceFor(':lib'),
+      emptyProjectAdviceFor(':lib-test-utils')
+    ]
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/TestFixturesUnusedDependencyProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/TestFixturesUnusedDependencyProject.groovy
@@ -1,0 +1,102 @@
+// Copyright (c) 2024. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.android.projects
+
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.kit.gradle.GradleProperties
+import com.autonomousapps.kit.gradle.android.TestFixturesOptions
+import com.autonomousapps.model.Advice
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.*
+import static com.autonomousapps.kit.gradle.Dependency.project
+
+final class TestFixturesUnusedDependencyProject extends AbstractAndroidProject {
+
+  final GradleProject gradleProject
+
+  private final String agpVersion
+
+  TestFixturesUnusedDependencyProject(String agpVersion) {
+    super(agpVersion)
+    this.agpVersion = agpVersion
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newAndroidGradleProjectBuilder(agpVersion)
+      .withRootProject { r ->
+        r.gradleProperties = GradleProperties.minimalAndroidProperties() +
+          "android.experimental.enableTestFixturesKotlinSupport=true"
+      }
+      .withSubproject('lib-test-utils') { s ->
+        s.sources = libTestUtilsSources
+        s.withBuildScript { bs ->
+          bs.plugins = kotlin
+        }
+      }
+      .withAndroidSubproject('lib') { s ->
+        s.sources = libWithFixturesSources
+        s.manifest = libraryManifest('lib.with.fixtures')
+        s.withBuildScript { bs ->
+          bs.plugins = androidLibWithKotlin
+          bs.android = defaultAndroidLibBlock(true).tap {
+            testFixturesOptions = new TestFixturesOptions(true)
+          }
+          bs.dependencies = [
+            project("implementation", ":lib-test-utils"),
+            project("testFixturesImplementation", ":lib-test-utils")
+          ]
+        }
+      }
+      .write()
+  }
+
+  private List<Source> libTestUtilsSources = [
+    new Source(
+      SourceType.KOTLIN, 'SomeUtil', 'com/example/utils',
+      """\
+      package com.example.utils
+      
+      object SomeUtils {
+          fun utilFun() = Unit
+      }
+      """.stripIndent()
+    ),
+  ]
+
+  private List<Source> libWithFixturesSources = [
+    new Source(
+      SourceType.KOTLIN, 'ClassInImpl', 'com/example/fixtures',
+      """\
+      package com.example.fixtures
+
+      import com.example.utils.SomeUtils
+      
+      object ClassInImpl {
+          fun impl() = SomeUtils.utilFun()
+      }
+      """.stripIndent()
+    ),
+    // no files in testFixtures
+  ]
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  private static Set<Advice> removeUnusedTestFixturesImplementation() {
+    return [
+      Advice.ofRemove(projectCoordinates(':lib-test-utils'), 'testFixturesImplementation'),
+    ]
+  }
+
+  static Set<ProjectAdvice> expectedBuildHealth() {
+    [
+      emptyProjectAdviceFor(':lib-test-utils'),
+      projectAdviceForDependencies(':lib', removeUnusedTestFixturesImplementation())
+    ]
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/TestFixturesWithAbiProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/TestFixturesWithAbiProject.groovy
@@ -1,0 +1,84 @@
+// Copyright (c) 2024. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.android.projects
+
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.kit.gradle.GradleProperties
+import com.autonomousapps.kit.gradle.android.TestFixturesOptions
+import com.autonomousapps.model.Advice
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.actualProjectAdvice
+import static com.autonomousapps.AdviceHelper.moduleCoordinates
+import static com.autonomousapps.AdviceHelper.projectAdviceForDependencies
+import static com.autonomousapps.kit.gradle.dependencies.Dependencies.mockitoCore
+
+final class TestFixturesWithAbiProject extends AbstractAndroidProject {
+
+  final GradleProject gradleProject
+
+  private final String agpVersion
+
+  TestFixturesWithAbiProject(String agpVersion) {
+    super(agpVersion)
+    this.agpVersion = agpVersion
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newAndroidGradleProjectBuilder(agpVersion)
+      .withRootProject { r ->
+        r.gradleProperties = GradleProperties.minimalAndroidProperties() +
+          "android.experimental.enableTestFixturesKotlinSupport=true"
+      }
+      .withAndroidSubproject('lib') { s ->
+        s.sources = libWithFixturesSources
+        s.manifest = libraryManifest('lib.with.fixtures')
+        s.withBuildScript { bs ->
+          bs.plugins = androidLibWithKotlin
+          bs.android = defaultAndroidLibBlock(true).tap {
+            testFixturesOptions = new TestFixturesOptions(true)
+          }
+          bs.dependencies = [
+            mockitoCore('testFixturesImplementation'),
+          ]
+        }
+      }
+      .write()
+  }
+
+  private List<Source> libWithFixturesSources = [
+    new Source(
+      SourceType.KOTLIN, 'ClassInFixtures', 'com/example/lib',
+      """\
+      package com.example.fixtures
+
+      import org.mockito.ArgumentMatcher
+      import org.mockito.internal.matchers.Equals
+      
+      object ClassInFixtures {
+          fun typePresentInApi(): ArgumentMatcher<in String> = Equals("myString")
+      }
+      """.stripIndent(),
+      'testFixtures'
+    )
+  ]
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  private static Set<Advice> changeMockitoImplToApi() {
+    return [
+      Advice.ofChange(moduleCoordinates('org.mockito:mockito-core:4.0.0'), 'testFixturesImplementation', 'testFixturesApi'),
+    ]
+  }
+
+  static Set<ProjectAdvice> expectedBuildHealth() {
+    [
+      projectAdviceForDependencies(':lib', changeMockitoImplToApi())
+    ]
+  }
+}

--- a/src/functionalTest/kotlin/com/autonomousapps/kit/gradle/dependencies/DependencyProvider.kt
+++ b/src/functionalTest/kotlin/com/autonomousapps/kit/gradle/dependencies/DependencyProvider.kt
@@ -212,7 +212,7 @@ class DependencyProvider(
   }
 
   fun mockitoCore(configuration: String): Dependency {
-    return Dependency(configuration, "org.mockito.kotlin:mockito-core:4.0.0")
+    return Dependency(configuration, "org.mockito:mockito-core:4.0.0")
   }
 
   fun mockitoKotlin(configuration: String): Dependency {

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidProjectAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidProjectAnalyzer.kt
@@ -55,6 +55,7 @@ internal abstract class AndroidAnalyzer(
   private fun suffix() = when (sourceKind.kind) {
     SourceKind.MAIN_KIND -> "Main"
     SourceKind.TEST_KIND -> "Test"
+    SourceKind.ANDROID_TEST_FIXTURES_KIND -> "TestFixtures"
     SourceKind.ANDROID_TEST_KIND -> "AndroidTest"
     else -> error("Unknown kind. Was '${sourceKind.kind}'")
   }
@@ -145,6 +146,7 @@ internal abstract class AndroidAnalyzer(
     return when (sourceKind.kind) {
       SourceKind.MAIN_KIND -> "kapt${variantName.capitalizeSafely()}"
       SourceKind.TEST_KIND -> "kaptTest"
+      SourceKind.ANDROID_TEST_FIXTURES_KIND -> "kaptTestFixtures"
       SourceKind.ANDROID_TEST_KIND -> "kaptAndroidTest"
       SourceKind.CUSTOM_JVM_KIND -> error("Custom JVM source sets are not supported in Android context")
       else -> error("Unknown kind: '${sourceKind.kind}'")

--- a/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
@@ -206,6 +206,34 @@ internal inline fun <T> Iterable<T>.mutPartitionOf(
   return Quadruple(first, second, third, fourth)
 }
 
+internal inline fun <T> Iterable<T>.mutPartitionOf(
+  predicate1: (T) -> Boolean,
+  predicate2: (T) -> Boolean,
+  predicate3: (T) -> Boolean,
+  predicate4: (T) -> Boolean,
+  predicate5: (T) -> Boolean,
+): Pentuple<MutableSet<T>, MutableSet<T>, MutableSet<T>, MutableSet<T>, MutableSet<T>> {
+  val first = LinkedHashSet<T>()
+  val second = LinkedHashSet<T>()
+  val third = LinkedHashSet<T>()
+  val fourth = LinkedHashSet<T>()
+  val fifth = LinkedHashSet<T>()
+  for (element in this) {
+    if (predicate1(element)) {
+      first.add(element)
+    } else if (predicate2(element)) {
+      second.add(element)
+    } else if (predicate3(element)) {
+      third.add(element)
+    } else if (predicate4(element)) {
+      fourth.add(element)
+    } else if (predicate5(element)) {
+      fifth.add(element)
+    }
+  }
+  return Pentuple(first, second, third, fourth, fifth)
+}
+
 data class Quadruple<out A, out B, out C, out D>(
   val first: A,
   val second: B,
@@ -213,6 +241,16 @@ data class Quadruple<out A, out B, out C, out D>(
   val fourth: D,
 ) {
   override fun toString(): String = "($first, $second, $third, $fourth)"
+}
+
+data class Pentuple<out A, out B, out C, out D, out F>(
+  val first: A,
+  val second: B,
+  val third: C,
+  val fourth: D,
+  val fifth: F,
+) {
+  override fun toString(): String = "($first, $second, $third, $fourth, $fifth)"
 }
 
 // standard `all` function returns true if collection is empty!

--- a/src/main/kotlin/com/autonomousapps/model/declaration/internal/Configurations.kt
+++ b/src/main/kotlin/com/autonomousapps/model/declaration/internal/Configurations.kt
@@ -131,6 +131,16 @@ internal object Configurations {
       // can't be Android
       require(!isAndroidProject) { "Expected JVM project" }
       JvmSourceKind.of(variantSlug)
+    } else if (variantSlug == SourceKind.ANDROID_TEST_FIXTURES_NAME) {
+      require(isAndroidProject) { "Expected Android project" }
+      AndroidSourceKind.ANDROID_TEST_FIXTURES
+    } else if (variantSlug.startsWith(SourceKind.ANDROID_TEST_FIXTURES_NAME)) {
+      require(isAndroidProject) { "Expected Android project" }
+      val name = variantSlug
+        .removePrefix(SourceKind.ANDROID_TEST_FIXTURES_NAME)
+        .replaceFirstChar(Char::lowercase)
+
+      AndroidSourceKind.testFixtures(name)
     } else if (variantSlug.startsWith(SourceKind.TEST_NAME)) {
       // must be Android
       require(isAndroidProject) { "Expected Android project" }

--- a/src/main/kotlin/com/autonomousapps/model/source/SourceKind.kt
+++ b/src/main/kotlin/com/autonomousapps/model/source/SourceKind.kt
@@ -36,10 +36,12 @@ sealed class SourceKind : Comparable<SourceKind>, Serializable {
   internal companion object {
     const val MAIN_NAME = "main"
     const val TEST_NAME = "test"
+    const val ANDROID_TEST_FIXTURES_NAME = "testFixtures"
     const val ANDROID_TEST_NAME = "androidTest"
 
     const val MAIN_KIND = "MAIN"
     const val TEST_KIND = "TEST"
+    const val ANDROID_TEST_FIXTURES_KIND = "ANDROID_TEST_FIXTURES"
     const val ANDROID_TEST_KIND = "ANDROID_TEST"
     const val CUSTOM_JVM_KIND = "CUSTOM_JVM"
   }
@@ -58,6 +60,7 @@ data class AndroidSourceKind(
     return when (kind) {
       MAIN_KIND -> main(MAIN_NAME)
       TEST_KIND -> test(TEST_NAME)
+      ANDROID_TEST_FIXTURES_KIND -> testFixtures(ANDROID_TEST_FIXTURES_NAME)
       ANDROID_TEST_KIND -> androidTest(ANDROID_TEST_NAME)
       else -> error("Expected one of 'main', 'test', or 'androidTest'. Was '$kind'.")
     }
@@ -79,6 +82,7 @@ data class AndroidSourceKind(
         when {
           m.endsWith("UnitTest") -> kind == TEST_KIND
           m.endsWith("AndroidTest") -> kind == ANDROID_TEST_KIND
+          m.endsWith("TestFixtures") -> kind == ANDROID_TEST_FIXTURES_KIND
           // Android app modules do something weird to the androidTest runtime classpaths, so we say that, if it's on a
           // main runtime classpath, it's also on the androidTest runtime classpath.
           else -> kind == MAIN_KIND || kind == ANDROID_TEST_KIND
@@ -104,8 +108,9 @@ data class AndroidSourceKind(
     val MAIN = main(MAIN_NAME)
     val TEST = test(TEST_NAME)
     val ANDROID_TEST = androidTest(ANDROID_TEST_NAME)
+    val ANDROID_TEST_FIXTURES = testFixtures(ANDROID_TEST_FIXTURES_NAME)
 
-    val VIRTUAL_CLASSPATHS = listOf("runtimeClasspath", "unitTestRuntimeClasspath", "androidTestRuntimeClasspath")
+    val VIRTUAL_CLASSPATHS = listOf("runtimeClasspath", "unitTestRuntimeClasspath", "androidTestRuntimeClasspath", "testFixturesRuntimeClasspath")
 
     fun main(variantName: String): AndroidSourceKind {
       return AndroidSourceKind(
@@ -138,6 +143,23 @@ data class AndroidSourceKind(
         } else {
           "${variantName}UnitTestRuntimeClasspath"
         },
+      )
+    }
+
+    fun testFixtures(variantName: String): AndroidSourceKind {
+      return AndroidSourceKind(
+        name = variantName,
+        kind = ANDROID_TEST_FIXTURES_KIND,
+        compileClasspathName = if (variantName == ANDROID_TEST_FIXTURES_NAME) {
+          "testFixturesCompileClasspath"
+        } else {
+          "${variantName}TestFixturesCompileClasspath"
+        },
+        runtimeClasspathName = if (variantName == ANDROID_TEST_FIXTURES_NAME) {
+          "testFixturesRuntimeClasspath"
+        } else {
+          "${variantName}TestFixturesRuntimeClasspath"
+        }
       )
     }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeUsagesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeUsagesTask.kt
@@ -165,8 +165,7 @@ private class GraphVisitor(
     var hasNativeLib = false
 
     dependency.capabilities.values.forEach { capability ->
-      @Suppress("UNUSED_VARIABLE", "unused") // exhaustive when
-      val ignored: Any = when (capability) {
+      when (capability) {
         is AndroidLinterCapability -> {
           isLintJar = capability.isLintJar
           reportBuilder[dependencyCoordinates, Kind.DEPENDENCY] = Reason.LintJar.of(capability.lintRegistry)

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/android/AndroidBlock.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/android/AndroidBlock.kt
@@ -21,6 +21,7 @@ public class AndroidBlock @JvmOverloads constructor(
   public var compileSdkVersion: Int = 34,
   public var defaultConfig: DefaultConfig = DefaultConfig.DEFAULT_APP,
   public var compileOptions: CompileOptions = CompileOptions.DEFAULT,
+  public var testFixturesOptions: TestFixturesOptions? = null,
   public var kotlinOptions: KotlinOptions? = null,
   /** Used by `com.android.test` projects */
   public var targetProjectPath: String? = null,
@@ -58,7 +59,8 @@ public class AndroidBlock @JvmOverloads constructor(
     defaultConfig.render(s)
     compileOptions.render(s)
     kotlinOptions?.render(s)
-    
+    testFixturesOptions?.render(s)
+
     if (additions.isNotBlank()) {
       if (usesKotlin) {
         error("You called withGroovy() but you're using Kotlin DSL")

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/android/TestFixturesOptions.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/android/TestFixturesOptions.kt
@@ -1,0 +1,17 @@
+package com.autonomousapps.kit.gradle.android
+
+import com.autonomousapps.kit.render.Element
+import com.autonomousapps.kit.render.Scribe
+
+public class TestFixturesOptions(
+  private val enable: Boolean = false
+) : Element.Block {
+
+  override fun render(scribe: Scribe): String = scribe.block(this) {
+    scribe.line {
+      it.append("enable = $enable")
+    }
+  }
+
+  override val name: String = "testFixtures"
+}


### PR DESCRIPTION
I added a unit test reproducing the issue and came up with a solution. This PR adds support for android `testFixtures` configuration. 

Notes:
- I'm not quite sure about which test cases I should add except the most basic one. Feel free to suggest anything :)
- Although I don't like that `Quadruple` became a `Pentuple`, I think this is out of scope for this fix