### PR TITLE
chore: fix snapshot publishing by making task dependency more lazy.

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/autonomousapps/convention/ConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/autonomousapps/convention/ConventionPlugin.kt
@@ -146,9 +146,10 @@ class ConventionPlugin : Plugin<Project> {
     pluginManager.withPlugin("java-gradle-plugin") {
       extensions.getByType(GradlePluginDevelopmentExtension::class.java).plugins.all { pluginConfig ->
         publishToMavenCentral.configure { t ->
-          // e.g. publishDependencyAnalysisPluginPluginMarkerMavenPublicationToSonatypeRepository
           t.dependsOn(
-            "publish${pluginConfig.name.capitalizeSafely()}PluginMarkerMavenPublicationTo$SONATYPE_REPO_SUFFIX"
+            // e.g. publishDependencyAnalysisPluginPluginMarkerMavenPublicationToSonatypeRepository
+            tasks.named { it == "publish${pluginConfig.name.capitalizeSafely()}PluginMarkerMavenPublicationTo$SONATYPE_REPO_SUFFIX" }
+            // "publish${pluginConfig.name.capitalizeSafely()}PluginMarkerMavenPublicationTo$SONATYPE_REPO_SUFFIX"
           )
         }
       }


### PR DESCRIPTION
https://scans.gradle.com/s/uoprp4zoprffc/failure

Per `./gradlew :tasks --group publishing`, the task that can't be found definitely exists. So I think maybe it is added lazily. Let's see!