### PR TITLE
Detect androidTest source set as a test sourceset

### DIFF
--- a/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
@@ -1226,6 +1226,11 @@ private fun Project.shouldAnalyzeSourceSetForProject(
   sourceSetName: String,
   projectPath: String,
 ): Boolean {
-  return dagpExtension.issueHandler.shouldAnalyzeSourceSet(sourceSetName, projectPath)
-    && (project.shouldAnalyzeTests() || sourceSetName != SourceSet.TEST_SOURCE_SET_NAME)
+  val analysisEnabledForSourceSet = dagpExtension.issueHandler.shouldAnalyzeSourceSet(sourceSetName, projectPath)
+  val isTestSourceSet = when (sourceSetName) {
+    SourceSet.TEST_SOURCE_SET_NAME -> true
+    SourceKind.ANDROID_TEST_NAME -> true
+    else -> false
+  }
+  return analysisEnabledForSourceSet && (project.shouldAnalyzeTests() || !isTestSourceSet)
 }


### PR DESCRIPTION
We currently have test analysis disabled, but are getting advice for androidTest configurations because DAGP is only checking if the source set name == `test`