### PR TITLE
Allow excluding violations by regex patterns

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/RegexExclusionsSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/RegexExclusionsSpec.groovy
@@ -1,0 +1,23 @@
+package com.autonomousapps.jvm
+
+import com.autonomousapps.jvm.projects.RegexExclusionsProject
+
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertThat
+
+class RegexExclusionsSpec extends AbstractJvmSpec {
+  def "project can exclude dependencies by regex patterns (#gradleVersion)"() {
+    given:
+    def project = new RegexExclusionsProject()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, "buildHealth")
+
+    then:
+    assertThat(project.actualProjectAdvice().isEmpty())
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/RegexExclusionsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/RegexExclusionsProject.groovy
@@ -1,0 +1,75 @@
+// Copyright (c) 2024. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.actualProjectAdvice
+import static com.autonomousapps.kit.gradle.Dependency.project
+
+final class RegexExclusionsProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  RegexExclusionsProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newGradleProjectBuilder()
+      .withSubproject(':proj') { s ->
+        s.sources = [
+          new Source(
+            SourceType.JAVA, 'Main', 'com/example',
+            """\
+            package com.example;
+           
+            public class Main {
+              public Main() {}
+            
+              public void hello() {
+                System.out.println("hello");
+              }
+            }""".stripIndent()
+          )
+        ]
+        s.withBuildScript { bs ->
+          bs.plugins = javaLibrary
+          bs.dependencies = [project("implementation", ":proj:internal")]
+          bs.withGroovy("""\
+          dependencyAnalysis {
+            issues { 
+              onUnusedDependencies {
+                severity('fail')
+                excludeRegex(".*:internal")
+              }
+            }
+          }""")
+        }
+      }
+      .withSubproject(':proj:internal') { s ->
+        s.sources = [
+          new Source(
+            SourceType.JAVA, "Internal", "com/example/internal",
+            """\
+            package com.example.internal;
+           
+            public class Internal {}
+            """.stripIndent()
+          )
+        ]
+        s.withBuildScript { bs ->
+          bs.plugins = javaLibrary
+        }
+      }
+      .write()
+  }
+
+  Set<ProjectAdvice> actualProjectAdvice() {
+    return actualProjectAdvice(gradleProject)
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/extension/Behavior.kt
+++ b/src/main/kotlin/com/autonomousapps/extension/Behavior.kt
@@ -5,7 +5,7 @@ package com.autonomousapps.extension
 import java.io.Serializable
 
 sealed class Behavior(
-  val filter: Set<String> = setOf(),
+  val filter: Set<Exclusion> = setOf(),
   val sourceSetName: String = Issue.ALL_SOURCE_SETS
 ) : Serializable, Comparable<Behavior> {
 
@@ -44,7 +44,7 @@ sealed class Behavior(
 }
 
 class Fail(
-  filter: Set<String> = mutableSetOf(),
+  filter: Set<Exclusion> = mutableSetOf(),
   sourceSetName: String = Issue.ALL_SOURCE_SETS
 ) : Behavior(
   filter = filter,
@@ -52,7 +52,7 @@ class Fail(
 )
 
 class Warn(
-  filter: Set<String> = mutableSetOf(),
+  filter: Set<Exclusion> = mutableSetOf(),
   sourceSetName: String = Issue.ALL_SOURCE_SETS
 ) : Behavior(
   filter = filter,
@@ -66,7 +66,7 @@ class Ignore(
 )
 
 class Undefined(
-  filter: Set<String> = mutableSetOf(),
+  filter: Set<Exclusion> = mutableSetOf(),
   sourceSetName: String = Issue.ALL_SOURCE_SETS
 ) : Behavior(
   filter = filter,

--- a/src/main/kotlin/com/autonomousapps/extension/Exclusion.kt
+++ b/src/main/kotlin/com/autonomousapps/extension/Exclusion.kt
@@ -1,0 +1,17 @@
+package com.autonomousapps.extension
+
+import java.io.Serializable
+
+sealed interface Exclusion: Serializable {
+  fun matches(name: String): Boolean
+
+  data class ExactMatch(val name: String): Exclusion {
+    override fun matches(name: String) = this.name == name
+  }
+
+  data class PatternMatch(val pattern: Regex): Exclusion {
+    override fun matches(name: String) = name.matches(pattern)
+  }
+}
+
+internal fun Collection<Exclusion>.anyMatches(name: String): Boolean = this.any { it.matches(name) }

--- a/src/main/kotlin/com/autonomousapps/model/DuplicateClass.kt
+++ b/src/main/kotlin/com/autonomousapps/model/DuplicateClass.kt
@@ -1,6 +1,7 @@
 package com.autonomousapps.model
 
 import com.autonomousapps.extension.Behavior
+import com.autonomousapps.extension.anyMatches
 import com.autonomousapps.internal.utils.LexicographicIterableComparator
 import com.autonomousapps.model.source.SourceKind
 import com.squareup.moshi.JsonClass
@@ -30,7 +31,7 @@ data class DuplicateClass(
   private val dotty = className.replace('/', '.')
 
   internal fun containsMatchIn(behavior: Behavior): Boolean {
-    return behavior.filter.contains(className) || behavior.filter.contains(dotty)
+    return behavior.filter.anyMatches(className) || behavior.filter.anyMatches(dotty)
   }
 
   override fun compareTo(other: DuplicateClass): Int {

--- a/src/main/kotlin/com/autonomousapps/model/ModuleAdvice.kt
+++ b/src/main/kotlin/com/autonomousapps/model/ModuleAdvice.kt
@@ -3,6 +3,8 @@
 package com.autonomousapps.model
 
 import com.autonomousapps.extension.Behavior
+import com.autonomousapps.extension.Exclusion
+import com.autonomousapps.extension.anyMatches
 import com.autonomousapps.internal.unsafeLazy
 import com.autonomousapps.model.internal.intermediates.AndroidScoreVariant
 import com.squareup.moshi.JsonClass
@@ -14,7 +16,7 @@ sealed class ModuleAdvice : Comparable<ModuleAdvice> {
   abstract val name: String
 
   internal fun shouldIgnore(behavior: Behavior): Boolean {
-    return behavior.filter.contains(name)
+    return behavior.filter.anyMatches(name)
   }
 
   internal abstract fun isActionable(): Boolean

--- a/src/main/kotlin/com/autonomousapps/tasks/DetectRedundantJvmPluginTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/DetectRedundantJvmPluginTask.kt
@@ -49,8 +49,8 @@ abstract class DetectRedundantJvmPluginTask : DefaultTask() {
       if (!hasKotlin.get() && !shouldIgnore) mutableSetOf(PluginAdvice.redundantKotlinJvm())
       else mutableSetOf()
 
-    pluginAdvices.removeIf {
-      behavior.filter.contains(it.redundantPlugin)
+    pluginAdvices.removeIf { pluginAdvice ->
+      behavior.filter.any { it.matches(pluginAdvice.redundantPlugin) }
     }
 
     outputFile.bufferWriteJsonSet(pluginAdvices)

--- a/src/main/kotlin/com/autonomousapps/tasks/FilterAdviceTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FilterAdviceTask.kt
@@ -5,6 +5,7 @@ package com.autonomousapps.tasks
 import com.autonomousapps.extension.Behavior
 import com.autonomousapps.extension.Ignore
 import com.autonomousapps.extension.Issue
+import com.autonomousapps.extension.anyMatches
 import com.autonomousapps.internal.DependencyScope
 import com.autonomousapps.internal.advice.SeverityHandler
 import com.autonomousapps.internal.utils.bufferWriteJson
@@ -152,11 +153,11 @@ abstract class FilterAdviceTask @Inject constructor(
         .toSortedSet()
 
       val pluginAdvice: Set<PluginAdvice> = projectAdvice.pluginAdvice.asSequence()
-        .filterNot {
-          anyBehavior.first is Ignore || anyBehavior.first.filter.contains(it.redundantPlugin)
+        .filterNot { pa ->
+          anyBehavior.first is Ignore || anyBehavior.first.filter.any { it.matches(pa.redundantPlugin) }
         }
-        .filterNot {
-          redundantPluginsBehavior is Ignore || redundantPluginsBehavior.filter.contains(it.redundantPlugin)
+        .filterNot { pa ->
+          redundantPluginsBehavior is Ignore || redundantPluginsBehavior.filter.any { it.matches(pa.redundantPlugin) }
         }
         .toSortedSet()
 
@@ -209,8 +210,8 @@ abstract class FilterAdviceTask @Inject constructor(
 
       val byGlobal: (Advice) -> Boolean = { a ->
         globalBehavior is Ignore
-          || globalBehavior.filter.contains(a.coordinates.identifier)
-          || globalBehavior.filter.contains(a.coordinates.gav())
+          || globalBehavior.filter.anyMatches(a.coordinates.identifier)
+          || globalBehavior.filter.anyMatches(a.coordinates.gav())
       }
 
       val bySourceSets: (Advice) -> Boolean = { a ->
@@ -225,8 +226,8 @@ abstract class FilterAdviceTask @Inject constructor(
         // reduce() will fail on an empty collection, so use reduceOrNull().
         behaviors.map {
           it is Ignore
-            || it.filter.contains(a.coordinates.identifier)
-            || it.filter.contains(a.coordinates.gav())
+            || it.filter.anyMatches(a.coordinates.identifier)
+            || it.filter.anyMatches(a.coordinates.gav())
         }.reduceOrNull { acc, b ->
           acc || b
         } ?: false


### PR DESCRIPTION
Something we run into semi-frequently is that DAGP will correctly indicate a used dependency that should be declared but it violates other checks that forbid "internal" dependencies being declared outside of their "sibiling" modules. This becomes particularly annoying inside projects using Anvil where all of the uses of the transitive dependencies are inside generated sources or bytecode. While the advice given by the plugin may be correct in those cases, it is not particularly useful and results in an excessively large `dependencies` block.