### PR TITLE
Support typesafe project accessors in IssueHandler

### DIFF
--- a/src/main/kotlin/com/autonomousapps/extension/Issue.kt
+++ b/src/main/kotlin/com/autonomousapps/extension/Issue.kt
@@ -6,6 +6,7 @@ package com.autonomousapps.extension
 
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.MinimalExternalModuleDependency
+import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderConvertible
@@ -79,6 +80,17 @@ open class Issue @Inject constructor(
    */
   fun exclude(vararg ignore: ProviderConvertible<MinimalExternalModuleDependency>) {
     exclude(*ignore.map { it.asProvider() }.toTypedArray())
+  }
+
+  /**
+   * All provided elements will be filtered out of the final advice. For example:
+   * ```
+   * exclude(projects.example, projects.lib)
+   * ```
+   * tells the plugin to exclude those dependencies in the final advice.
+   */
+  fun exclude(vararg ignore: ProjectDependency) {
+    exclude(*ignore.map { it.path }.toTypedArray())
   }
 
   /**

--- a/src/main/kotlin/com/autonomousapps/extension/IssueHandler.kt
+++ b/src/main/kotlin/com/autonomousapps/extension/IssueHandler.kt
@@ -4,6 +4,7 @@ package com.autonomousapps.extension
 
 import com.autonomousapps.services.GlobalDslService
 import org.gradle.api.Action
+import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.provider.Provider
 import javax.inject.Inject
 
@@ -27,6 +28,10 @@ abstract class IssueHandler @Inject constructor(
 
   fun all(action: Action<ProjectIssueHandler>) {
     globalDslService.all(action)
+  }
+
+  fun project(project: ProjectDependency, action: Action<ProjectIssueHandler>) {
+    project(project.path, action)
   }
 
   fun project(projectPath: String, action: Action<ProjectIssueHandler>) {


### PR DESCRIPTION
With support for type-safe project accessors, it would be nice to allow them in the plugin's configuration DSL.

This MR adds support for using type-safe project accessors as inputs in the `IssueHandler` DSL as an alternative to plain `projectPath` Strings.

Here's an example snippet how this would look like from one of our projects:
```kotlin
dependencyAnalysis {
    issues {
        project(projects.core.ui.impl) {
            onIncorrectConfiguration {
                exclude(projects.core.ui.api)
            }
        }
    }
}
```

As of today, we are already using project accessors in the plugin configuration similar to this, but it currently requires us to always convert them to a String ourselves using `.path`, e.g. `project(projects.core.ui.impl.path)`. This change would eliminate this inconvenience.

If you expect tests to be added for this, please point me to the place where they should go, and I will look into it.

One open question I had was whether `ProjectDependency` should also be allowed as an input to the `Bundle` APIs (like `primary()` and `includeDependency()`? I'm unsure if project dependencies are actually a thing there and supported by the plugin. If yes, I'm happy to make similar changes there.


