### PR TITLE
feat: move snapshot publishing to new central.sonatype.com repo.

### DIFF
--- a/PUBLISHING.asciidoc
+++ b/PUBLISHING.asciidoc
@@ -252,8 +252,9 @@ publishing {
       if (sonatypeUsername != null && sonatypePassword != null) {
         maven {
           name = "sonatype"
+          // TODO(tsr): update URL
           val releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-          val snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
+          val snapshotsRepoUrl = "https://central.sonatype.com/repository/maven-snapshots/"
           url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
           credentials {
             username = sonatypeUsername
@@ -335,7 +336,7 @@ Plugin Portal, you must tell Gradle about other repositories. Do that by opening
 pluginsManagement {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
     gradlePluginPortal() // there by default
   }
@@ -369,7 +370,7 @@ this will now publish to the staging repository.
 It is possible to automate this process, but I haven't attempted it, yet. When I do, I will update this
 documentation.
 
-Go to https://oss.sonatype.org/ and login with your Jira credentials. Click on *Staging Repositories* on
+Go to https://central.sonatype.com/ and login with your Jira credentials. Click on *Staging Repositories* on
 the left. You should see one repo, which you just staged with that Gradle command. Click on it. Now verify
 that all the files are there as expected. In addition to all of the normal files, you should see a duplicate
 of each with the extension `.asc`, indicating they have been signed. Every file must be signed or Maven Central

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1,6 +1,7 @@
 image::https://img.shields.io/maven-metadata/v.svg?label=release&metadataUrl=https%3A%2F%2Frepo1.maven.org%2Fmaven2%2Fcom%2Fautonomousapps%2Fdependency-analysis%2Fcom.autonomousapps.dependency-analysis.gradle.plugin%2Fmaven-metadata.xml[Latest version,link="https://mvnrepository.com/artifact/com.autonomousapps.dependency-analysis/com.autonomousapps.dependency-analysis.gradle.plugin"]
 image::https://img.shields.io/nexus/s/com.autonomousapps/dependency-analysis-gradle-plugin?label=snapshot&server=https%3A%2F%2Foss.sonatype.org[Latest snapshot,link="https://oss.sonatype.org/#nexus-search;gav~com.autonomousapps.dependency-analysis~com.autonomousapps.dependency-analysis.gradle.plugin~~~~kw,versionexpand"]
 image::https://github.com/autonomousapps/dependency-analysis-gradle-plugin/actions/workflows/test.yml/badge.svg[Build status,link="https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/actions/workflows/test.yml"]
+// TODO(tsr): update URL above
 
 == Detect unused and misused dependencies
 The Dependency Analysis Gradle Plugin (DAGP, née Dependency Analysis Android Gradle Plugin) detects the following:

--- a/build-logic/convention/src/main/kotlin/com/autonomousapps/convention/DagpExtension.kt
+++ b/build-logic/convention/src/main/kotlin/com/autonomousapps/convention/DagpExtension.kt
@@ -41,7 +41,8 @@ public abstract class DagpExtension(
 
   private fun setupPublishingRepo() {
     // TODO(tsr): enable automatic publishing once correctness is confirmed.
-    mavenPublish.publishToMavenCentral(SonatypeHost.DEFAULT)//, automaticRelease = true)
+    mavenPublish.publishToMavenCentral()
+    // mavenPublish.publishToMavenCentral(automaticRelease = true)
 
     project.tasks.named("publishToMavenCentral") { t ->
       t.notCompatibleWithConfigurationCache("Cannot serialize object of type DefaultProject")
@@ -49,9 +50,10 @@ public abstract class DagpExtension(
 
       t.doLast {
         if (isSnapshot.get()) {
-          t.logger.quiet("Browse files at https://oss.sonatype.org/content/repositories/snapshots/com/autonomousapps/")
+          t.logger.quiet("Browse files at https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/autonomousapps/")
         } else {
           t.logger.quiet(
+            // TODO(tsr): update URL and instructions
             "After publishing to Sonatype, visit https://oss.sonatype.org to close and release from staging"
           )
         }
@@ -82,8 +84,9 @@ public abstract class DagpExtension(
       }
     }
 
+    // TODO(tsr): update URL
     //val releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-    //val snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
+    //val snapshotsRepoUrl = "https://central.sonatype.com/repository/maven-snapshots/"
   }
 
   internal companion object {

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -17,7 +17,7 @@ dependencyResolutionManagement {
     google()
     mavenCentral()
     gradlePluginPortal() // gradle-publish-plugin
-//    maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots/") }
+//    maven { url = uri("https://central.sonatype.com/repository/maven-snapshots/") }
   }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ kryo = "5.6.2"
 # Cannot be called kotlin-editor as it causes `libs.versions.kotlin.get()` to fail
 kotlineditor-core = "0.18"
 kotlineditor-relocated = "0.18.0"
-mavenPublish = "0.32.0"
+mavenPublish = "0.33.0"
 moshi = "1.15.1"
 moshix = "0.25.1"
 okio = "3.9.0"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,7 +20,7 @@ pluginManagement {
 
     // snapshots are permitted, but only for dependencies I own
     maven {
-      url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+      url = uri("https://central.sonatype.com/repository/maven-snapshots/")
       content {
         includeGroup("com.autonomousapps")
         includeGroup("com.autonomousapps.dependency-analysis")
@@ -48,7 +48,7 @@ dependencyResolutionManagement {
     }
     // snapshots are permitted, but only for dependencies I own
     maven {
-      url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+      url = uri("https://central.sonatype.com/repository/maven-snapshots/")
       content {
         includeGroup("com.autonomousapps")
         includeGroup("com.autonomousapps.dependency-analysis")

--- a/src/smokeTest/kotlin/com/autonomousapps/fixtures/SimpleProject.kt
+++ b/src/smokeTest/kotlin/com/autonomousapps/fixtures/SimpleProject.kt
@@ -15,7 +15,7 @@ fun newSimpleProject(projectVersion: String): File {
   buildSrc.resolve("build.gradle").writeText("""
         repositories {
             gradlePluginPortal()
-            maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+            maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
             mavenCentral()
         }
         dependencies {

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/Repository.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/Repository.kt
@@ -63,7 +63,7 @@ public sealed class Repository : Element.Line {
     @JvmField public val GRADLE_PLUGIN_PORTAL: Repository = Method("gradlePluginPortal()")
     @JvmField public val MAVEN_CENTRAL: Repository = Method("mavenCentral()")
     @JvmField public val MAVEN_LOCAL: Repository = Method("mavenLocal()")
-    @JvmField public val SNAPSHOTS: Repository = ofMaven("https://oss.sonatype.org/content/repositories/snapshots/")
+    @JvmField public val SNAPSHOTS: Repository = ofMaven("https://central.sonatype.com/repository/maven-snapshots/")
     @JvmField public val LIBS: Repository = FlatDir("libs")
 
     /**

--- a/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestGroovy.kt
+++ b/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestGroovy.kt
@@ -46,7 +46,7 @@ internal class ScribeTestGroovy {
         repositories {
           google()
           mavenCentral()
-          maven { url = 'https://oss.sonatype.org/content/repositories/snapshots/' }
+          maven { url = 'https://central.sonatype.com/repository/maven-snapshots/' }
         }
         
       """.trimIndent()

--- a/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestKotlin.kt
+++ b/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestKotlin.kt
@@ -46,7 +46,7 @@ internal class ScribeTestKotlin {
         repositories {
           google()
           mavenCentral()
-          maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots/") }
+          maven { url = uri("https://central.sonatype.com/repository/maven-snapshots/") }
         }
         
       """.trimIndent()

--- a/testkit/settings.gradle.kts
+++ b/testkit/settings.gradle.kts
@@ -15,7 +15,7 @@ pluginManagement {
 
     // snapshots are permitted, but only for dependencies I own
     maven {
-      url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+      url = uri("https://central.sonatype.com/repository/maven-snapshots/")
       content {
         includeGroup("com.autonomousapps")
         includeGroup("com.autonomousapps.dependency-analysis")
@@ -37,7 +37,7 @@ dependencyResolutionManagement {
     }
     // snapshots are permitted, but only for dependencies I own
     maven {
-      url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+      url = uri("https://central.sonatype.com/repository/maven-snapshots/")
       content {
         includeGroup("com.autonomousapps")
         includeGroup("com.autonomousapps.dependency-analysis")


### PR DESCRIPTION
See also https://github.com/vanniktech/gradle-maven-publish-plugin/releases/tag/0.33.0