### PR TITLE
Update AGP to the latest stable version (8.11.0)

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/AbstractFunctionalSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/AbstractFunctionalSpec.groovy
@@ -15,7 +15,7 @@ abstract class AbstractFunctionalSpec extends Specification {
   protected static final String FLAG_LOG_BYTECODE = "-D${Flags.BYTECODE_LOGGING}=true"
 
   protected static final GRADLE_7_5 = GradleVersion.version('7.5.1')
-  protected static final GRADLE_7_6 = GradleVersion.version('7.6.2')
+  protected static final GRADLE_7_6 = GradleVersion.version('7.6.5')
   protected static final GRADLE_8_0 = GradleVersion.version('8.0.2')
   protected static final GRADLE_8_4 = GradleVersion.version('8.4')
   protected static final GRADLE_8_9 = GradleVersion.version('8.9')
@@ -23,7 +23,7 @@ abstract class AbstractFunctionalSpec extends Specification {
   protected static final GRADLE_8_11 = GradleVersion.version('8.11.1')
   protected static final GRADLE_8_12 = GradleVersion.version('8.12.1')
   protected static final GRADLE_8_13 = GradleVersion.version('8.13')
-  protected static final GRADLE_8_14 = GradleVersion.version('8.14')
+  protected static final GRADLE_8_14 = GradleVersion.version('8.14.2')
 
   protected static final GRADLE_LATEST = GRADLE_8_14
 

--- a/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
@@ -24,23 +24,21 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
   protected static final AGP_8_9 = AgpVersion.version('8.9.3')
   protected static final AGP_8_10 = AgpVersion.version('8.10.1')
   protected static final AGP_8_11 = AgpVersion.version('8.11.0')
-  protected static final AGP_8_12 = AgpVersion.version('8.12.0-alpha06')
 
-  protected static final AGP_LATEST = AGP_8_12
+  protected static final AGP_LATEST = AGP_8_11
 
   /**
    * TODO(tsr): this doc is perpetually out of date.
    *
    * {@code AGP_8_3} represents the minimum stable _tested_ version. {@code AGP_8_11} represents the maximum stable
-   * _tested_ version. We also test against the latest alpha, {@code AGP_8_12} at time of writing. DAGP may work with
-   * other versions of AGP, but they aren't tested, primarily for CI performance reasons.
+   * _tested_ version. DAGP may work with other versions of AGP, but they aren't tested, primarily for CI performance
+   * reasons.
    *
    * @see <a href="https://maven.google.com/web/index.html?#com.android.tools.build:gradle">AGP releases</a>
    */
   protected static final SUPPORTED_AGP_VERSIONS = [
     AGP_8_3,
     AGP_8_11,
-    AGP_8_12,
   ]
 
   protected static List<AgpVersion> agpVersions(AgpVersion minAgpVersion = AgpVersion.AGP_MIN) {

--- a/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
@@ -21,25 +21,26 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
   protected static final AGP_8_6 = AgpVersion.version('8.6.1')
   protected static final AGP_8_7 = AgpVersion.version('8.7.3')
   protected static final AGP_8_8 = AgpVersion.version('8.8.2')
-  protected static final AGP_8_9 = AgpVersion.version('8.9.2')
-  protected static final AGP_8_10 = AgpVersion.version('8.10.0')
-  protected static final AGP_8_11 = AgpVersion.version('8.11.0-alpha09')
+  protected static final AGP_8_9 = AgpVersion.version('8.9.3')
+  protected static final AGP_8_10 = AgpVersion.version('8.10.1')
+  protected static final AGP_8_11 = AgpVersion.version('8.11.0')
+  protected static final AGP_8_12 = AgpVersion.version('8.12.0-alpha06')
 
-  protected static final AGP_LATEST = AGP_8_11
+  protected static final AGP_LATEST = AGP_8_12
 
   /**
    * TODO(tsr): this doc is perpetually out of date.
    *
-   * {@code AGP_8_3} represents the minimum stable _tested_ version. {@code AGP_8_10} represents the maximum stable
-   * _tested_ version. We also test against the latest alpha, {@code AGP_8_11} at time of writing. DAGP may work with
+   * {@code AGP_8_3} represents the minimum stable _tested_ version. {@code AGP_8_11} represents the maximum stable
+   * _tested_ version. We also test against the latest alpha, {@code AGP_8_12} at time of writing. DAGP may work with
    * other versions of AGP, but they aren't tested, primarily for CI performance reasons.
    *
    * @see <a href="https://maven.google.com/web/index.html?#com.android.tools.build:gradle">AGP releases</a>
    */
   protected static final SUPPORTED_AGP_VERSIONS = [
     AGP_8_3,
-    AGP_8_10,
     AGP_8_11,
+    AGP_8_12,
   ]
 
   protected static List<AgpVersion> agpVersions(AgpVersion minAgpVersion = AgpVersion.AGP_MIN) {

--- a/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
@@ -15,7 +15,7 @@ internal class AgpVersion private constructor(val version: String) : Comparable<
   companion object {
 
     @JvmStatic val AGP_MIN = version("8.3.0")
-    @JvmStatic val AGP_MAX = version("8.10.0")
+    @JvmStatic val AGP_MAX = version("8.11.0")
 
     @JvmStatic fun current(): AgpVersion = AgpVersion(agpVersion())
     @JvmStatic fun version(version: String): AgpVersion = AgpVersion(version)


### PR DESCRIPTION
This PR updates:
- AGP 8.9 to the latest fix (8.9.2 → 8.9.3).
- AGP 8.10 to the latest fix (8.10.0 → 8.10.1).
- AGP 8.11 to the stable version (8.11.0-alpha09 → 8.11.0).
- Gradle 7.6 to the latest fix (7.6.2 → 7.6.5).
- Gradle 8.14 to the latest fix (8.14 → 8.14.2).