### PR TITLE
feat: Print advice to console by default

### DIFF
--- a/src/main/kotlin/com/autonomousapps/Flags.kt
+++ b/src/main/kotlin/com/autonomousapps/Flags.kt
@@ -40,7 +40,7 @@ object Flags {
    *
    * @see [com.autonomousapps.extension.ReportingHandler.printBuildHealth]
    */
-  internal fun Project.printBuildHealth() = getGradlePropForConfiguration(PRINT_BUILD_HEALTH, false)
+  internal fun Project.printBuildHealth() = getGradlePropForConfiguration(PRINT_BUILD_HEALTH, true)
 
   internal fun Project.androidIgnoredVariants() = getGradlePropForConfiguration(
     ANDROID_IGNORED_VARIANTS, ""


### PR DESCRIPTION
I don't find it very ergonomic to open the report file to view the advice generated by the plugin and want console reporting to be enabled by default. From what I can divine from the repo history, v1 had this on by default, but v2 removed console reporting entirely? Then someone requested the console report be brought back in #571, and #593 did so, but made it off by default without stating a reason why.

It looks like we both enable reporting to console in all our projects, so hopefully this is an agreeable default! The gradle property and DSL options to enable console reporting are not currently documented in the README or wiki so whenever I set up analysis in a new project I am mildly frustrated that this is not the default and I have to instead go look at an existing project to figure out how the configuration is supposed to work.