### PR TITLE
fix: Move useTypesafeProjectAccessors to global dsl service

### DIFF
--- a/src/main/kotlin/com/autonomousapps/AbstractExtension.kt
+++ b/src/main/kotlin/com/autonomousapps/AbstractExtension.kt
@@ -28,9 +28,9 @@ abstract class AbstractExtension @Inject constructor(
   // One instance of this per project
   internal val issueHandler: IssueHandler = objects.newInstance(dslService)
 
-  internal val useTypesafeProjectAccessors: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
-
   // Only one instance of each of these is allowed globally, so we delegate to the build service
+
+  internal val useTypesafeProjectAccessors: Property<Boolean> = dslService.get().useTypesafeProjectAccessors
   internal val abiHandler: AbiHandler = dslService.get().abiHandler
   internal val dependenciesHandler: DependenciesHandler = dslService.get().dependenciesHandler
   internal val reportingHandler: ReportingHandler = dslService.get().reportingHandler

--- a/src/main/kotlin/com/autonomousapps/services/GlobalDslService.kt
+++ b/src/main/kotlin/com/autonomousapps/services/GlobalDslService.kt
@@ -10,6 +10,7 @@ import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.invocation.Gradle
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
@@ -171,6 +172,7 @@ abstract class GlobalDslService @Inject constructor(
   }
 
   // Global handlers, one instance each for the whole build.
+  internal val useTypesafeProjectAccessors: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
   internal val abiHandler: AbiHandler = objects.newInstance()
   internal val dependenciesHandler: DependenciesHandler = objects.newInstance()
   internal val reportingHandler: ReportingHandler = objects.newInstance()


### PR DESCRIPTION
This feature can only be enabled globally in gradle builds, so we should not have to enable this setting in the DAGP DSL in every project