### PR TITLE
Update to AGP 8.12 stable

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
@@ -23,24 +23,25 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
   protected static final AGP_8_8 = AgpVersion.version('8.8.2')
   protected static final AGP_8_9 = AgpVersion.version('8.9.3')
   protected static final AGP_8_10 = AgpVersion.version('8.10.1')
-  protected static final AGP_8_11 = AgpVersion.version('8.11.0')
-  protected static final AGP_8_12 = AgpVersion.version('8.12.0-alpha08')
+  protected static final AGP_8_11 = AgpVersion.version('8.11.1')
+  protected static final AGP_8_12 = AgpVersion.version('8.12.0')
+  protected static final AGP_8_13 = AgpVersion.version('8.13.0-alpha03')
 
-  protected static final AGP_LATEST = AGP_8_12
+  protected static final AGP_LATEST = AGP_8_13
 
   /**
    * TODO(tsr): this doc is perpetually out of date.
    *
-   * {@code AGP_8_3} represents the minimum stable _tested_ version. {@code AGP_8_11} represents the maximum stable
-   * _tested_ version. We also test against the latest alpha, {@code AGP_8_12} at time of writing. DAGP may work with
+   * {@code AGP_8_3} represents the minimum stable _tested_ version. {@code AGP_8_12} represents the maximum stable
+   * _tested_ version. We also test against the latest alpha, {@code AGP_8_13} at time of writing. DAGP may work with
    * other versions of AGP, but they aren't tested, primarily for CI performance reasons.
    *
    * @see <a href="https://maven.google.com/web/index.html?#com.android.tools.build:gradle">AGP releases</a>
    */
   protected static final SUPPORTED_AGP_VERSIONS = [
     AGP_8_3,
-    AGP_8_11,
     AGP_8_12,
+    AGP_8_13,
   ]
 
   protected static List<AgpVersion> agpVersions(AgpVersion minAgpVersion = AgpVersion.AGP_MIN) {

--- a/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
@@ -15,7 +15,7 @@ internal class AgpVersion private constructor(val version: String) : Comparable<
   companion object {
 
     @JvmStatic val AGP_MIN = version("8.3.0")
-    @JvmStatic val AGP_MAX = version("8.11.0")
+    @JvmStatic val AGP_MAX = version("8.12.0")
 
     @JvmStatic fun current(): AgpVersion = AgpVersion(agpVersion())
     @JvmStatic fun version(version: String): AgpVersion = AgpVersion(version)


### PR DESCRIPTION
This PR updates the tested supported AGP versions:
- 8.11.0 → 8.11.1
- 8.12.0-alpha08 → 8.12.0
- Introduce 8.13.0-alpha03