### PR TITLE
Don't try to parse files that don't exist

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/android/AndroidFileMutationSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AndroidFileMutationSpec.groovy
@@ -45,7 +45,7 @@ final class AndroidFileMutationSpec extends AbstractAndroidSpec {
       .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedDeletionBuildHealth)
 
     and: 'the configuration cache was used'
-    assertThat(result.getOutput()).contains("Configuration cache entry reused.")
+    assertThat(result.output).contains("Configuration cache entry reused.")
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()
@@ -84,7 +84,7 @@ final class AndroidFileMutationSpec extends AbstractAndroidSpec {
       .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedRenameBuildHealth)
 
     and: 'the configuration cache was used'
-    assertThat(result.getOutput()).contains("Configuration cache entry reused.")
+    assertThat(result.output).contains("Configuration cache entry reused.")
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()

--- a/src/functionalTest/groovy/com/autonomousapps/android/AndroidFileMutationSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AndroidFileMutationSpec.groovy
@@ -1,0 +1,92 @@
+// Copyright (c) 2025. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.android
+
+import com.autonomousapps.android.projects.AndroidFileMutationProject
+import org.gradle.util.GradleVersion
+
+import static com.autonomousapps.advice.truth.BuildHealthSubject.buildHealth
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertAbout
+import static com.google.common.truth.Truth.assertThat
+
+final class AndroidFileMutationSpec extends AbstractAndroidSpec {
+
+  def "buildHealth succeeds after deleting a file (#gradleVersion AGP #agpVersion)"() {
+    given:
+    def project = new AndroidFileMutationProject(agpVersion as String)
+    gradleProject = project.gradleProject
+
+    when: 'We build the first time'
+    build(
+      gradleVersion as GradleVersion,
+      gradleProject.rootDir,
+      'buildHealth', '--configuration-cache'
+    )
+
+    then: 'the build health is as expected'
+    assertAbout(buildHealth())
+      .that(project.actualBuildHealth())
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedOriginalBuildHealth)
+
+    when: 'We delete a source file'
+    project.deleteSourceFile()
+
+    and: 'We build again'
+    def result = build(
+      gradleVersion as GradleVersion,
+      gradleProject.rootDir,
+      'buildHealth', '--configuration-cache'
+    )
+
+    then: 'the build health is as expected'
+    assertAbout(buildHealth())
+      .that(project.actualBuildHealth())
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedDeletionBuildHealth)
+
+    and: 'the configuration cache was used'
+    assertThat(result.getOutput()).contains("Configuration cache entry reused.")
+
+    where:
+    [gradleVersion, agpVersion] << gradleAgpMatrix()
+  }
+
+  def "buildHealth succeeds after renaming a file (#gradleVersion AGP #agpVersion)"() {
+    given:
+    def project = new AndroidFileMutationProject(agpVersion as String)
+    gradleProject = project.gradleProject
+
+    when: 'We build the first time'
+    build(
+      gradleVersion as GradleVersion,
+      gradleProject.rootDir,
+      'buildHealth', '--configuration-cache'
+    )
+
+    then: 'the build health is as expected'
+    assertAbout(buildHealth())
+      .that(project.actualBuildHealth())
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedOriginalBuildHealth)
+
+    when: 'We rename and rewrite a source file'
+    project.renameAndRewriteSourceFile()
+
+    and: 'We build again'
+    def result = build(
+      gradleVersion as GradleVersion,
+      gradleProject.rootDir,
+      'buildHealth', '--configuration-cache'
+    )
+
+    then: 'the build health is as expected'
+    assertAbout(buildHealth())
+      .that(project.actualBuildHealth())
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedRenameBuildHealth)
+
+    and: 'the configuration cache was used'
+    assertThat(result.getOutput()).contains("Configuration cache entry reused.")
+
+    where:
+    [gradleVersion, agpVersion] << gradleAgpMatrix()
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/android/AndroidFileMutationSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AndroidFileMutationSpec.groovy
@@ -21,7 +21,7 @@ final class AndroidFileMutationSpec extends AbstractAndroidSpec {
     build(
       gradleVersion as GradleVersion,
       gradleProject.rootDir,
-      'buildHealth', '--configuration-cache'
+      'buildHealth'
     )
 
     then: 'the build health is as expected'
@@ -36,7 +36,7 @@ final class AndroidFileMutationSpec extends AbstractAndroidSpec {
     def result = build(
       gradleVersion as GradleVersion,
       gradleProject.rootDir,
-      'buildHealth', '--configuration-cache'
+      'buildHealth'
     )
 
     then: 'the build health is as expected'
@@ -60,7 +60,7 @@ final class AndroidFileMutationSpec extends AbstractAndroidSpec {
     build(
       gradleVersion as GradleVersion,
       gradleProject.rootDir,
-      'buildHealth', '--configuration-cache'
+      'buildHealth'
     )
 
     then: 'the build health is as expected'
@@ -75,7 +75,7 @@ final class AndroidFileMutationSpec extends AbstractAndroidSpec {
     def result = build(
       gradleVersion as GradleVersion,
       gradleProject.rootDir,
-      'buildHealth', '--configuration-cache'
+      'buildHealth'
     )
 
     then: 'the build health is as expected'

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidFileMutationProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidFileMutationProject.groovy
@@ -1,0 +1,133 @@
+// Copyright (c) 2025. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.android.projects
+
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.kit.android.AndroidManifest
+import com.autonomousapps.kit.gradle.dependencies.Plugins
+import com.autonomousapps.model.Advice
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.actualProjectAdvice
+import static com.autonomousapps.AdviceHelper.emptyProjectAdviceFor
+import static com.autonomousapps.AdviceHelper.moduleCoordinates
+import static com.autonomousapps.AdviceHelper.projectAdviceForDependencies
+import static com.autonomousapps.kit.gradle.dependencies.Dependencies.*
+
+final class AndroidFileMutationProject extends AbstractAndroidProject {
+
+  final GradleProject gradleProject
+  private final String agpVersion
+
+  AndroidFileMutationProject(String agpVersion) {
+    super(agpVersion)
+
+    this.agpVersion = agpVersion
+    this.gradleProject = build()
+  }
+
+  void deleteSourceFile() {
+    def subProjectDir = gradleProject.projectDir(gradleProject.subprojects.first())
+    def sourceInfo = sources.first()
+    def sourceInfoRootPath = "src/main/kotlin/" + sourceInfo.path + "/" + sourceInfo.name + ".kt"
+    def sourceFile = subProjectDir.resolve(sourceInfoRootPath).toFile()
+    sourceFile.delete()
+  }
+
+  void renameAndRewriteSourceFile() {
+    def subProjectDir = gradleProject.projectDir(gradleProject.subprojects.first())
+    def sourceInfo = sources.first()
+    def sourceInfoRootPath = "src/main/kotlin/" + sourceInfo.path + "/" + sourceInfo.name + ".kt"
+    def sourceFile = subProjectDir.resolve(sourceInfoRootPath).toFile()
+    def newFile = new File(sourceFile.parentFile, "NewLibrary.kt")
+    sourceFile.write(
+      """\
+        package com.example
+        
+        import android.content.Context
+      
+        class NewLibrary {
+          fun provideContext(context: Context): Context {
+            return context
+          }
+        }
+      """
+    )
+    sourceFile.renameTo(newFile)
+    println("${sourceFile.absolutePath} --> ${newFile.absolutePath}")
+  }
+
+  private GradleProject build() {
+    return newAndroidGradleProjectBuilder(agpVersion)
+      .withAndroidSubproject('lib') { l ->
+        l.manifest = AndroidManifest.defaultLib('com.example.lib')
+        l.withBuildScript { bs ->
+          bs.plugins = [Plugins.androidLib, Plugins.kotlinAndroidNoVersion, Plugins.dependencyAnalysisNoVersion]
+          bs.android = defaultAndroidLibBlock()
+          bs.dependencies = [
+            constraintLayout('api'),
+            coreKtx('implementation'),
+            core('implementation'),
+            kotlinStdLib('api')
+          ]
+        }
+        l.sources = sources
+      }.write()
+  }
+
+  private sources = [
+    new Source(
+      SourceType.KOTLIN, 'Library', 'com/example',
+      """\
+        package com.example
+        
+        import android.content.Context
+        import androidx.constraintlayout.widget.Group
+      
+        class Library {
+          fun provideGroup(context: Context): Group {
+            return Group(context)
+          }
+        }
+      """
+    ),
+    new Source(
+      SourceType.KOTLIN, 'Library2', 'com/example',
+      """\
+        package com.example
+        
+        import android.content.Context
+        import android.telephony.TelephonyManager
+        import androidx.core.content.getSystemService
+      
+        class Library2 {
+          fun provideTelephonyManager(context: Context): TelephonyManager {
+            return context.getSystemService()!!
+          }
+        }
+      """
+    )
+  ]
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  private final Set<Advice> libAdvice = [
+    Advice.ofRemove(moduleCoordinates("androidx.constraintlayout:constraintlayout:1.1.3"), "api"),
+  ] as Set<Advice>
+
+  final Set<ProjectAdvice> expectedDeletionBuildHealth = [
+    projectAdviceForDependencies(':lib', libAdvice),
+  ]
+
+  final Set<ProjectAdvice> expectedRenameBuildHealth = [
+    projectAdviceForDependencies(':lib', libAdvice),
+  ]
+
+  final Set<ProjectAdvice> expectedOriginalBuildHealth = [
+    emptyProjectAdviceFor(':lib'),
+  ]
+}

--- a/src/main/kotlin/com/autonomousapps/tasks/CodeSourceExploderTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/CodeSourceExploderTask.kt
@@ -101,7 +101,7 @@ private class SourceExploder(
 
   fun explode(): Set<ExplodingSourceCode> {
     val destination = sortedSetOf<ExplodingSourceCode>()
-    javaSourceFiles.mapTo(destination) {
+    javaSourceFiles.filter { it.exists() }.mapTo(destination) {
       val rel = relativize(it)
       ExplodingSourceCode(
         relativePath = rel,
@@ -110,7 +110,7 @@ private class SourceExploder(
         imports = SourceListener.parseSourceFileForImports(it)
       )
     }
-    kotlinSourceFiles.mapTo(destination) {
+    kotlinSourceFiles.filter { it.exists() }.mapTo(destination) {
       val rel = relativize(it)
       ExplodingSourceCode(
         relativePath = rel,
@@ -119,7 +119,7 @@ private class SourceExploder(
         imports = SourceListener.parseSourceFileForImports(it)
       )
     }
-    groovySourceFiles.mapTo(destination) {
+    groovySourceFiles.filter { it.exists() }.mapTo(destination) {
       val rel = relativize(it)
       ExplodingSourceCode(
         relativePath = rel,
@@ -128,7 +128,7 @@ private class SourceExploder(
         imports = SourceListener.parseSourceFileForImports(it)
       )
     }
-    scalaSourceFiles.mapTo(destination) {
+    scalaSourceFiles.filter { it.exists() }.mapTo(destination) {
       val rel = relativize(it)
       ExplodingSourceCode(
         relativePath = rel,


### PR DESCRIPTION
Fixes #1337 

I would think that the cache would get invalidated because of the file change, but either it doesn't, or something else is broken. In the meantime, this should stop the errors, and provide correct behavior.