### PR TITLE
Update to AGP 8.13 stable

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/AbstractFunctionalSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/AbstractFunctionalSpec.groovy
@@ -15,7 +15,7 @@ abstract class AbstractFunctionalSpec extends Specification {
   protected static final String FLAG_LOG_BYTECODE = "-D${Flags.BYTECODE_LOGGING}=true"
 
   protected static final GRADLE_9_0_0 = GradleVersion.version('9.0.0')
-  protected static final GRADLE_9_1_0 = GradleVersion.version('9.1.0-rc-1')
+  protected static final GRADLE_9_1_0 = GradleVersion.version('9.1.0-rc-2')
 
   protected static final GRADLE_LATEST = GRADLE_9_0_0
   protected static final GRADLE_MAX = GradleVersions.maxGradleVersion

--- a/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
@@ -24,23 +24,22 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
   protected static final AGP_8_9 = AgpVersion.version('8.9.3')
   protected static final AGP_8_10 = AgpVersion.version('8.10.1')
   protected static final AGP_8_11 = AgpVersion.version('8.11.1')
-  protected static final AGP_8_12 = AgpVersion.version('8.12.0')
-  protected static final AGP_8_13 = AgpVersion.version('8.13.0-alpha03')
+  protected static final AGP_8_12 = AgpVersion.version('8.12.2')
+  protected static final AGP_8_13 = AgpVersion.version('8.13.0')
 
   protected static final AGP_LATEST = AGP_8_13
 
   /**
    * TODO(tsr): this doc is perpetually out of date.
    *
-   * {@code AGP_8_3} represents the minimum stable _tested_ version. {@code AGP_8_12} represents the maximum stable
-   * _tested_ version. We also test against the latest alpha, {@code AGP_8_13} at time of writing. DAGP may work with
-   * other versions of AGP, but they aren't tested, primarily for CI performance reasons.
+   * {@code AGP_8_3} represents the minimum stable _tested_ version. {@code AGP_8_13} represents the maximum stable
+   * _tested_ version. DAGP may work with other versions of AGP, but they aren't tested, primarily for CI performance
+   * reasons.
    *
    * @see <a href="https://maven.google.com/web/index.html?#com.android.tools.build:gradle">AGP releases</a>
    */
   protected static final SUPPORTED_AGP_VERSIONS = [
     AGP_8_3,
-    AGP_8_12,
     AGP_8_13,
   ]
 


### PR DESCRIPTION
This PR updates the tested supported AGP versions:
- 8.12.0 → 8.12.2
- 8.13.0-alpha03 → 8.13.0

This also updates Gradle 9.1 to the RC2 version.