### PR TITLE
chore: mark GHA steps as 'continue-on-error: true'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,34 +60,44 @@ jobs:
 
       - name: Execute buildHealth for build-logic
         run: './gradlew -p build-logic/ buildHealth'
+        continue-on-error: true
 
       - name: Execute check (build-logic)
         run: './gradlew -p build-logic/ check'
+        continue-on-error: true
 
       - name: Execute buildHealth for main project
         run: './gradlew buildHealth'
+        continue-on-error: true
 
       - name: Execute buildHealth for testkit project
         run: './gradlew -p testkit/ buildHealth'
+        continue-on-error: true
 
       - name: Execute check (non-functional tests)
         run: './gradlew check -s -x :functionalTest'
+        continue-on-error: true
 
       - name: Execute check (testkit)
         run: './gradlew -p testkit/ check'
+        continue-on-error: true
 
       - name: Execute JVM functional tests
         run: './gradlew :functionalTest -DfuncTest.package=jvm -DfuncTest.quick'
+        continue-on-error: true
 
       - name: Execute Android functional tests
         run: './gradlew :functionalTest -DfuncTest.package=android -DfuncTest.quick'
+        continue-on-error: true
 
       - name: Check API
         run: './gradlew :checkApi'
+        continue-on-error: true
 
       - name: Publish snapshot
         if: github.repository == 'autonomousapps/dependency-analysis-gradle-plugin' && github.ref == 'refs/heads/main'
         run: './gradlew :publishToMavenCentral'
+        continue-on-error: true
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}


### PR DESCRIPTION
This will let the whole job complete even if earlier steps fail, making it easier to see what is failing universally in the PR.