### PR TITLE
feat(testkit): expose pluginManagement.repositories.repositories.

### DIFF
--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/PluginManagement.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/PluginManagement.kt
@@ -6,7 +6,7 @@ import com.autonomousapps.kit.render.Element
 import com.autonomousapps.kit.render.Scribe
 
 public class PluginManagement(
-  private val repositories: Repositories,
+  public val repositories: Repositories,
 ) : Element.Block {
 
   override val name: String = "pluginManagement"

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/Repositories.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/Repositories.kt
@@ -23,7 +23,7 @@ import com.autonomousapps.kit.render.Scribe
  * ```
  */
 public class Repositories @JvmOverloads constructor(
-  private val repositories: MutableList<Repository> = mutableListOf(),
+  public val repositories: MutableList<Repository> = mutableListOf(),
 ) : Element.Block {
 
   public constructor(vararg repositories: Repository) : this(repositories.toMutableList())


### PR DESCRIPTION
This enables modifying the default repositories such that users don't have to recreate a PluginManagement instance just to change the default incrementally.