### PR TITLE
fix: for builds with Gradle 9.1.0+, get the buildPath from the Gradle instance.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/GradleVersions.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/GradleVersions.kt
@@ -19,6 +19,7 @@ internal object GradleVersions {
 
   private val gradle811: GradleVersion = GradleVersion.version("8.11.1")
   private val gradle900: GradleVersion = GradleVersion.version("9.0.0")
+  private val gradle910: GradleVersion = GradleVersion.version("9.1.0")
 
   val isAtLeastMinimum: Boolean = current >= minGradleVersion
 
@@ -26,4 +27,5 @@ internal object GradleVersions {
   val isAtLeastGradle811: Boolean = current >= gradle811
 
   val isAtLeastGradle900: Boolean = current >= gradle900
+  val isAtLeastGradle910: Boolean = current >= gradle910
 }

--- a/src/main/kotlin/com/autonomousapps/internal/utils/project/projects.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/project/projects.kt
@@ -7,30 +7,21 @@ import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
-import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.provider.Provider
-import org.gradle.internal.build.BuildState
 
-/** Get the buildPath of the current build from the root component of the resolution result. */
+/** Get the buildPath of the current build. */
 internal fun Project.buildPath(configurationName: String): Provider<String> {
-  return buildPath(configurations.named(configurationName))
-}
-
-// TODO(tsr): update to use project.gradle.buildPath with Gradle 9.1.0
-internal fun Project.buildPath(configuration: Configuration): Provider<String> {
-  return if (GradleVersions.isAtLeastGradle900) {
-    project.provider { getIdentityPath() }
+  return if (GradleVersions.isAtLeastGradle910) {
+    provider { gradle.buildPath }
   } else {
-    configuration.incoming.resolutionResult.let {
-      it.rootComponent.map { root -> (root.id as ProjectComponentIdentifier).build.buildPath }
-    }
+    return buildPath(configurations.named(configurationName))
   }
 }
 
-// TODO(tsr): update to use project.gradle.buildPath with Gradle 9.1.0
+/** Get the buildPath of the current build. */
 internal fun Project.buildPath(configuration: NamedDomainObjectProvider<Configuration>): Provider<String> {
-  return if (GradleVersions.isAtLeastGradle900) {
-    project.provider { getIdentityPath() }
+  return if (GradleVersions.isAtLeastGradle910) {
+    provider { gradle.buildPath }
   } else {
     configuration.flatMap { c ->
       c.incoming.resolutionResult.let { result ->
@@ -39,10 +30,3 @@ internal fun Project.buildPath(configuration: NamedDomainObjectProvider<Configur
     }
   }
 }
-
-/**
- * @see <a href="https://github.com/gradle/gradle/pull/34007">Gradle PR #34007</a>
- * @see <a href="https://github.com/JetBrains/kotlin/blob/fb3d7ebc67466a2e1a30217337fc76df96d4732e/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/utils/CurrentBuildIdentifier.kt#L15-L17">KGP</a>
- */
-internal fun Project.getIdentityPath(): String =
-  (project as ProjectInternal).services.get(BuildState::class.java).identityPath.toString()


### PR DESCRIPTION
Resolves https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1564