### PR TITLE
Support ABI inclusions

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/AbiExclusionsSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/AbiExclusionsSpec.groovy
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.jvm
 
+import com.autonomousapps.jvm.projects.AbiClassAndAnnotationInclusionsProject
 import com.autonomousapps.jvm.projects.AbiExcludedSourceSetProject
 import com.autonomousapps.jvm.projects.AbiExclusionsProject
+import com.autonomousapps.jvm.projects.AbiPackageInclusionsCombinedProject
 
 import static com.autonomousapps.utils.Runner.build
 import static com.google.common.truth.Truth.assertThat
@@ -28,6 +30,36 @@ final class AbiExclusionsSpec extends AbstractJvmSpec {
   def "can exclude custom source set from ABI analysis (#gradleVersion)"() {
     given:
     def project = new AbiExcludedSourceSetProject()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+
+  def "can include classes and annotations from different configuration points (#gradleVersion)"() {
+    given:
+    def project = new AbiClassAndAnnotationInclusionsProject()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+
+  def "can include a package with excluding specific classes or annotations (#gradleVersion)"() {
+    given:
+    def project = new AbiPackageInclusionsCombinedProject()
     gradleProject = project.gradleProject
 
     when:

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiClassAndAnnotationInclusionsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiClassAndAnnotationInclusionsProject.groovy
@@ -1,0 +1,179 @@
+// Copyright (c) 2025. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.model.Advice
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.actualProjectAdvice
+import static com.autonomousapps.AdviceHelper.emptyProjectAdviceFor
+import static com.autonomousapps.AdviceHelper.projectAdviceForDependencies
+import static com.autonomousapps.AdviceHelper.projectCoordinates
+import static com.autonomousapps.kit.gradle.Dependency.project
+
+final class AbiClassAndAnnotationInclusionsProject extends AbstractProject {
+
+  final GradleProject gradleProject = build()
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  final Set<ProjectAdvice> expectedBuildHealth = [
+    projectAdviceForDependencies(':consumer', [
+      Advice.ofChange(projectCoordinates(':producer'), 'implementation', 'api'),
+      Advice.ofChange(projectCoordinates(':other'), 'implementation', 'api'),
+    ] as Set<Advice>),
+    emptyProjectAdviceFor(':producer'),
+    emptyProjectAdviceFor(':other'),
+    emptyProjectAdviceFor(':annotations'),
+  ] as Set<ProjectAdvice>
+
+  private GradleProject build() {
+    return newGradleProjectBuilder()
+      .withRootProject { r ->
+        r.withBuildScript { bs ->
+          bs.withGroovy("""\
+            dependencyAnalysis {
+              abi {
+                exclusions {
+                  includeClasses("com\\\\.example\\\\.consumer\\\\.root\\\\..*")
+                }
+              }
+            }""")
+        }
+      }
+      .withSubproject('consumer') { s ->
+        s.sources = consumerSources()
+        s.withBuildScript { bs ->
+          bs.plugins(javaLibrary)
+          bs.dependencies = [
+            project('implementation', ':producer'),
+            project('implementation', ':other'),
+            project('compileOnly', ':annotations'),
+          ]
+          bs.withGroovy("""\
+            dependencyAnalysis {
+              abi {
+                exclusions {
+                  includeAnnotations("com\\\\.example\\\\.annotations\\\\.PublicApi")
+                }
+              }
+            }""")
+        }
+      }
+      .withSubproject('producer') { s ->
+        s.sources = producerSources()
+        s.withBuildScript { bs ->
+          bs.plugins(javaLibrary)
+        }
+      }
+      .withSubproject('other') { s ->
+        s.sources = otherSources()
+        s.withBuildScript { bs ->
+          bs.plugins(javaLibrary)
+        }
+      }
+      .withSubproject('annotations') { s ->
+        s.sources = annotationSources()
+        s.withBuildScript { bs ->
+          bs.plugins(javaLibrary)
+        }
+      }
+      .write()
+  }
+
+  private List<Source> consumerSources() {
+    return [
+      new Source(
+        SourceType.JAVA, 'RootApi', 'com/example/consumer/root',
+        """\
+          package com.example.consumer.root;
+          
+          import com.example.other.OtherType;
+          
+          public class RootApi {
+            public OtherType other() {
+              return new OtherType();
+            }
+          }""".stripIndent()
+      ),
+      new Source(
+        SourceType.JAVA, 'AnnotationApi', 'com/example/consumer/internal',
+        """\
+          package com.example.consumer.internal;
+          
+          import com.example.annotations.PublicApi;
+          import com.example.producer.PublicType;
+          
+          @PublicApi
+          public class AnnotationApi {
+            public PublicType type() {
+              return new PublicType();
+            }
+          }""".stripIndent()
+      ),
+      new Source(
+        SourceType.JAVA, 'ExcludedApi', 'com/example/consumer/impl',
+        """\
+          package com.example.consumer.impl;
+          
+          import com.example.producer.PublicType;
+          
+          public class ExcludedApi {
+            public PublicType type() {
+              return new PublicType();
+            }
+          }""".stripIndent()
+      ),
+    ]
+  }
+
+  private List<Source> producerSources() {
+    return [
+      new Source(
+        SourceType.JAVA, 'PublicType', 'com/example/producer',
+        """\
+          package com.example.producer;
+          
+          public class PublicType {}""".stripIndent()
+      ),
+    ]
+  }
+
+  private List<Source> otherSources() {
+    return [
+      new Source(
+        SourceType.JAVA, 'OtherType', 'com/example/other',
+        """\
+          package com.example.other;
+          
+          public class OtherType {}""".stripIndent()
+      ),
+    ]
+  }
+
+  private List<Source> annotationSources() {
+    return [
+      new Source(
+        SourceType.JAVA, 'PublicApi', 'com/example/annotations',
+        """\
+          package com.example.annotations;
+          
+          import static java.lang.annotation.ElementType.TYPE;
+          import static java.lang.annotation.RetentionPolicy.CLASS;
+          
+          import java.lang.annotation.Retention;
+          import java.lang.annotation.Target;
+          
+          @Retention(CLASS)
+          @Target(TYPE)
+          public @interface PublicApi {}""".stripIndent()
+      ),
+    ]
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiPackageInclusionsCombinedProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiPackageInclusionsCombinedProject.groovy
@@ -1,0 +1,249 @@
+// Copyright (c) 2025. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.model.Advice
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.actualProjectAdvice
+import static com.autonomousapps.AdviceHelper.emptyProjectAdviceFor
+import static com.autonomousapps.AdviceHelper.projectAdviceForDependencies
+import static com.autonomousapps.AdviceHelper.projectCoordinates
+import static com.autonomousapps.kit.gradle.Dependency.project
+
+final class AbiPackageInclusionsCombinedProject extends AbstractProject {
+
+  final GradleProject gradleProject = build()
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  final Set<ProjectAdvice> expectedBuildHealth = [
+    projectAdviceForDependencies(':consumer', [
+      Advice.ofChange(projectCoordinates(':package-producer'), 'implementation', 'api'),
+      Advice.ofChange(projectCoordinates(':specific-producer'), 'implementation', 'api'),
+      Advice.ofChange(projectCoordinates(':annotated-producer'), 'implementation', 'api'),
+    ] as Set<Advice>),
+    emptyProjectAdviceFor(':package-producer'),
+    emptyProjectAdviceFor(':specific-producer'),
+    emptyProjectAdviceFor(':annotated-producer'),
+    emptyProjectAdviceFor(':excluded-producer'),
+    emptyProjectAdviceFor(':annotations'),
+  ] as Set<ProjectAdvice>
+
+  private GradleProject build() {
+    return newGradleProjectBuilder()
+      .withRootProject { r ->
+        r.withBuildScript { bs ->
+          bs.withGroovy("""\
+            dependencyAnalysis {
+              abi {
+                exclusions {
+                  includeClasses("com\\\\.example\\\\.consumer\\\\.pkg\\\\..*")
+                  includeClasses("com\\\\.example\\\\.consumer\\\\.specific\\\\.SpecificApi")
+                  excludeClasses("com\\\\.example\\\\.consumer\\\\.pkg\\\\.ExcludedApi")
+                }
+              }
+            }""")
+        }
+      }
+      .withSubproject('consumer') { s ->
+        s.sources = consumerSources()
+        s.withBuildScript { bs ->
+          bs.plugins(javaLibrary)
+          bs.dependencies = [
+            project('implementation', ':package-producer'),
+            project('implementation', ':specific-producer'),
+            project('implementation', ':annotated-producer'),
+            project('implementation', ':excluded-producer'),
+            project('compileOnly', ':annotations'),
+          ]
+          bs.withGroovy("""\
+            dependencyAnalysis {
+              abi {
+                exclusions {
+                  includeAnnotations("com\\\\.example\\\\.annotations\\\\.PublicApi")
+                  excludeClasses("com\\\\.example\\\\.consumer\\\\.pkg\\\\.ExcludedApi")
+                }
+              }
+            }""")
+        }
+      }
+      .withSubproject('package-producer') { s ->
+        s.sources = packageProducerSources()
+        s.withBuildScript { bs ->
+          bs.plugins(javaLibrary)
+        }
+      }
+      .withSubproject('specific-producer') { s ->
+        s.sources = specificProducerSources()
+        s.withBuildScript { bs ->
+          bs.plugins(javaLibrary)
+        }
+      }
+      .withSubproject('annotated-producer') { s ->
+        s.sources = annotatedProducerSources()
+        s.withBuildScript { bs ->
+          bs.plugins(javaLibrary)
+        }
+      }
+      .withSubproject('annotations') { s ->
+        s.sources = annotationSources()
+        s.withBuildScript { bs ->
+          bs.plugins(javaLibrary)
+        }
+      }
+      .withSubproject('excluded-producer') { s ->
+        s.sources = excludedProducerSources()
+        s.withBuildScript { bs ->
+          bs.plugins(javaLibrary)
+        }
+      }
+      .write()
+  }
+
+  private List<Source> consumerSources() {
+    return [
+      new Source(
+        SourceType.JAVA, 'PackageApi', 'com/example/consumer/pkg',
+        """\
+          package com.example.consumer.pkg;
+          
+          import com.example.packageproducer.PackageType;
+          
+          public class PackageApi {
+            public PackageType type() {
+              return new PackageType();
+            }
+          }""".stripIndent()
+      ),
+      new Source(
+        SourceType.JAVA, 'SpecificApi', 'com/example/consumer/specific',
+        """\
+          package com.example.consumer.specific;
+          
+          import com.example.specificproducer.SpecificType;
+          
+          public class SpecificApi {
+            public SpecificType type() {
+              return new SpecificType();
+            }
+          }""".stripIndent()
+      ),
+      new Source(
+        SourceType.JAVA, 'AnnotatedApi', 'com/example/consumer/misc',
+        """\
+          package com.example.consumer.misc;
+          
+          import com.example.annotations.PublicApi;
+          import com.example.annotatedproducer.AnnotatedType;
+          
+          @PublicApi
+          public class AnnotatedApi {
+            public AnnotatedType type() {
+              return new AnnotatedType();
+            }
+          }""".stripIndent()
+      ),
+      new Source(
+        SourceType.JAVA, 'ImplOnly', 'com/example/consumer/impl',
+        """\
+          package com.example.consumer.impl;
+          
+          import com.example.packageproducer.PackageType;
+          
+          public class ImplOnly {
+            public PackageType type() {
+              return new PackageType();
+            }
+          }""".stripIndent()
+      ),
+      new Source(
+        SourceType.JAVA, 'ExcludedApi', 'com/example/consumer/pkg',
+        """\
+          package com.example.consumer.pkg;
+          
+          import com.example.excludedproducer.ExcludedType;
+          
+          public class ExcludedApi {
+            public ExcludedType type() {
+              return new ExcludedType();
+            }
+          }""".stripIndent()
+      ),
+    ]
+  }
+
+  private List<Source> packageProducerSources() {
+    return [
+      new Source(
+        SourceType.JAVA, 'PackageType', 'com/example/packageproducer',
+        """\
+          package com.example.packageproducer;
+          
+          public class PackageType {}""".stripIndent()
+      ),
+    ]
+  }
+
+  private List<Source> specificProducerSources() {
+    return [
+      new Source(
+        SourceType.JAVA, 'SpecificType', 'com/example/specificproducer',
+        """\
+          package com.example.specificproducer;
+          
+          public class SpecificType {}""".stripIndent()
+      ),
+    ]
+  }
+
+  private List<Source> annotatedProducerSources() {
+    return [
+      new Source(
+        SourceType.JAVA, 'AnnotatedType', 'com/example/annotatedproducer',
+        """\
+          package com.example.annotatedproducer;
+          
+          public class AnnotatedType {}""".stripIndent()
+      ),
+    ]
+  }
+
+  private List<Source> excludedProducerSources() {
+    return [
+      new Source(
+        SourceType.JAVA, 'ExcludedType', 'com/example/excludedproducer',
+        """\
+          package com.example.excludedproducer;
+          
+          public class ExcludedType {}""".stripIndent()
+      ),
+    ]
+  }
+
+  private List<Source> annotationSources() {
+    return [
+      new Source(
+        SourceType.JAVA, 'PublicApi', 'com/example/annotations',
+        """\
+          package com.example.annotations;
+          
+          import static java.lang.annotation.ElementType.TYPE;
+          import static java.lang.annotation.RetentionPolicy.CLASS;
+          
+          import java.lang.annotation.Retention;
+          import java.lang.annotation.Target;
+          
+          @Retention(CLASS)
+          @Target(TYPE)
+          public @interface PublicApi {}""".stripIndent()
+      ),
+    ]
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/extension/AbiHandler.kt
+++ b/src/main/kotlin/com/autonomousapps/extension/AbiHandler.kt
@@ -18,6 +18,8 @@ import javax.inject.Inject
  *     exclusions {
  *       excludeSourceSets(/* source sets to exclude from ABI analysis */)
  *
+ *       includeClasses(".*\\api\\..*")
+ *       includeAnnotations(".*\\.PublicApi")
  *       ignoreSubPackage("internal")
  *       ignoreInternalPackages()
  *       ignoreGeneratedCode()
@@ -40,10 +42,28 @@ public abstract class AbiHandler @Inject constructor(objects: ObjectFactory) {
 /** @see [AbiHandler]. */
 public abstract class ExclusionsHandler @Inject constructor(objects: ObjectFactory) {
 
+  internal val classInclusions = objects.setProperty(String::class.java).convention(emptySet())
+  internal val annotationInclusions = objects.setProperty(String::class.java).convention(emptySet())
   internal val classExclusions = objects.setProperty(String::class.java).convention(emptySet())
   internal val annotationExclusions = objects.setProperty(String::class.java).convention(emptySet())
   internal val pathExclusions = objects.setProperty(String::class.java).convention(emptySet())
   internal val excludedSourceSets = objects.setProperty(String::class.java).convention(emptySet())
+
+  /**
+   * Include given classes into ABI analysis, which means that any class that does not match the given [classRegexes] regex
+   * will not be considered as part of the module's ABI.
+   */
+  public fun includeClasses(@Language("RegExp") vararg classRegexes: String) {
+    classInclusions.addAll(*classRegexes)
+  }
+
+  /**
+   * Include all classes into ABI analysis that are annotated with annotations matching the given [annotationRegexes] regex. 
+   * Any class without matching annotations will be excluded from ABI analysis.
+   */
+  public fun includeAnnotations(@Language("RegExp") vararg annotationRegexes: String) {
+    annotationInclusions.addAll(*annotationRegexes)
+  }
 
   /**
    * Exclude the given [sourceSets] from ABI analysis, which means that regardless of the level of exposure of any given

--- a/src/main/kotlin/com/autonomousapps/internal/kotlin/PublicApiDump.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/kotlin/PublicApiDump.kt
@@ -161,6 +161,14 @@ internal fun List<ClassBinarySignature>.filterOutNonPublic(
 ): List<ClassBinarySignature> {
   val classByName = associateBy { it.name }
 
+  fun ClassBinarySignature.isIncluded(): Boolean {
+    return exclusions.includeAll() ||
+      exclusions.includesClass(canonicalName) ||
+      annotations.any(exclusions::includesAnnotation) ||
+      invisibleAnnotations.any(exclusions::includesAnnotation) ||
+      memberSignatures.any { it.annotations.any(exclusions::includesAnnotation) }
+  }
+
   // Library note - this function (plus the exclusions parameter above) are modified from the original
   // Kotlin sources this was borrowed from.
   fun ClassBinarySignature.isExcluded(): Boolean {
@@ -196,7 +204,7 @@ internal fun List<ClassBinarySignature>.filterOutNonPublic(
   }
 
   return filter {
-    !it.isExcluded() && it.isPublicAndAccessible()
+    it.isIncluded() && !it.isExcluded() && it.isPublicAndAccessible()
   }.map {
     it.flattenNonPublicBases()
   }.filterNot {

--- a/src/main/kotlin/com/autonomousapps/internal/models.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/models.kt
@@ -119,10 +119,18 @@ internal data class Method(val types: Set<String>) {
 
 @JsonClass(generateAdapter = false)
 internal data class AbiExclusions(
+  val annotationInclusions: Set<String> = emptySet(),
+  val classInclusions: Set<String> = emptySet(),
   val annotationExclusions: Set<String> = emptySet(),
   val classExclusions: Set<String> = emptySet(),
   val pathExclusions: Set<String> = emptySet(),
 ) {
+
+  @Transient
+  private val includeAnnotationRegexes = annotationInclusions.mapToSet(String::toRegex)
+
+  @Transient
+  private val includeClassRegexes = classInclusions.mapToSet(String::toRegex)
 
   @Transient
   private val annotationRegexes = annotationExclusions.mapToSet(String::toRegex)
@@ -133,6 +141,9 @@ internal data class AbiExclusions(
   @Transient
   private val pathRegexes = pathExclusions.mapToSet(String::toRegex)
 
+  fun includeAll() = includeAnnotationRegexes.isEmpty() && includeClassRegexes.isEmpty()
+  fun includesAnnotation(fqcn: String): Boolean = includeAnnotationRegexes.any { it.containsMatchIn(fqcn.binaryToHuman()) }
+  fun includesClass(fqcn: String) = includeClassRegexes.any { it.containsMatchIn(fqcn.binaryToHuman()) }
   fun excludesAnnotation(fqcn: String): Boolean = annotationRegexes.any { it.containsMatchIn(fqcn.binaryToHuman()) }
   fun excludesClass(fqcn: String) = classRegexes.any { it.containsMatchIn(fqcn.binaryToHuman()) }
   fun excludesPath(path: String) = pathRegexes.any { it.containsMatchIn(path) }

--- a/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
@@ -985,6 +985,8 @@ internal class ProjectPlugin(private val project: Project) {
       // lazy ABI JSON
       with(dagpExtension.abiHandler.exclusionsHandler) {
         AbiExclusions(
+          annotationInclusions = annotationInclusions.get(),
+          classInclusions = classInclusions.get(),
           annotationExclusions = annotationExclusions.get(),
           classExclusions = classExclusions.get(),
           pathExclusions = pathExclusions.get()


### PR DESCRIPTION
Fixes https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1588

Top level DSL left to be exclusions for backward compatibility.

Example usage:
```
dependencyAnalysis {
  abi {
    exclusions {
      includeClasses(".*\\.api\\..*")
      excludeAnnotations('.Generated')
    }
  }
}
``` 