### PR TITLE
Refactor: Increase consistency in KotlinMagicFinder/JarExploder

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/JarExploder.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/JarExploder.kt
@@ -4,7 +4,6 @@ package com.autonomousapps.internal
 
 import com.autonomousapps.internal.asm.ClassReader
 import com.autonomousapps.internal.utils.asSequenceOfClassFiles
-import com.autonomousapps.internal.utils.filterToClassFiles
 import com.autonomousapps.internal.utils.getLogger
 import com.autonomousapps.model.internal.KtFile
 import com.autonomousapps.model.internal.PhysicalArtifact
@@ -78,9 +77,7 @@ internal class JarExploder(
       Mode.CLASSES -> {
         ktFiles = KtFile.fromDirectory(artifact.file)
 
-        artifact.file.walkBottomUp()
-          .filter { it.isFile }
-          .filterToClassFiles()
+        artifact.file.asSequenceOfClassFiles()
           .map { classFile ->
             ClassNameAndAnnotationsVisitor(logger).apply {
               val reader = classFile.inputStream().use { ClassReader(it.readBytes()) }

--- a/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
@@ -56,6 +56,11 @@ internal fun Iterable<ZipEntry>.asSequenceOfClassFiles(): Sequence<ZipEntry> {
   }
 }
 
+internal fun File.asSequenceOfClassFiles(): Sequence<File> {
+  check(isDirectory) { "Expected directory. Was '${absolutePath}'" }
+  return walkBottomUp().filter { it.isFile }.filterToClassFiles()
+}
+
 // Can't use Iterable<File> because of signature clash with Iterable<ZipEntry> above.
 internal fun Collection<File>.asSequenceOfClassFiles(): Sequence<File> {
   return asSequence().filterToClassFiles()

--- a/src/main/kotlin/com/autonomousapps/tasks/FindKotlinMagicTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindKotlinMagicTask.kt
@@ -221,9 +221,7 @@ internal class KotlinMagicFinder(
           return KotlinCapabilities.EMPTY
         }
 
-        artifact.file.walkBottomUp()
-          .filter { it.isFile }
-          .filterToClassFiles()
+        artifact.file.asSequenceOfClassFiles()
           .mapNotNull { classFile ->
             val kotlinMagic = readClass(
               classFile.inputStream().use { ClassReader(it.readBytes()) },


### PR DESCRIPTION
Looking at the code I found some inconsistencies, which I fixed here.

Unfortunately I was unable to try out the classes dir cases, with our large project.
I found `MixedSourceSpec` which already says it's unable to trigger the case.
Had a try with artifact transforms but was unable to trigger it.
In my understanding on JVM this will never trigger because of the `c.artifactsFor(dependencyAnalyzer.attributeValueJar)` in the `ProjectPlugin` requesting jars, don't know about `android-classes` on android.