### PR TITLE
A new task to build type usage report (ComputeTypeUsageTask).

### DIFF
--- a/api/api.txt
+++ b/api/api.txt
@@ -4,6 +4,7 @@ package com.autonomousapps {
   public abstract class AbstractExtension {
     ctor @javax.inject.Inject public AbstractExtension(org.gradle.api.model.ObjectFactory objects, org.gradle.api.invocation.Gradle gradle);
     method public final org.gradle.api.file.RegularFileProperty adviceOutput();
+    method public final org.gradle.api.file.RegularFileProperty typeUsageOutput();
     method public final void app();
     method public final void registerPostProcessingTask(org.gradle.api.tasks.TaskProvider<? extends com.autonomousapps.AbstractPostProcessingTask> task);
     field public static final String NAME = "dependencyAnalysis";
@@ -28,6 +29,7 @@ package com.autonomousapps {
     method public final void issues(org.gradle.api.Action<com.autonomousapps.extension.IssueHandler> action);
     method public final void reporting(org.gradle.api.Action<com.autonomousapps.extension.ReportingHandler> action);
     method public final void structure(org.gradle.api.Action<com.autonomousapps.extension.DependenciesHandler> action);
+    method public final void typeUsage(org.gradle.api.Action<com.autonomousapps.extension.TypeUsageHandler> action);
     method public final void usage(org.gradle.api.Action<com.autonomousapps.extension.UsageHandler> action);
     method @Deprecated public final void usages(org.gradle.api.Action<com.autonomousapps.extension.UsageHandler> action);
     method public final void useTypesafeProjectAccessors(boolean enable);
@@ -44,6 +46,7 @@ package com.autonomousapps {
     method public final void abi(org.gradle.api.Action<com.autonomousapps.extension.AbiHandler> action);
     method public final void issues(org.gradle.api.Action<com.autonomousapps.extension.ProjectIssueHandler> action);
     method public final void structure(org.gradle.api.Action<com.autonomousapps.extension.DependenciesHandler> action);
+    method public final void typeUsage(org.gradle.api.Action<com.autonomousapps.extension.TypeUsageHandler> action);
   }
 
   public final class Flags {
@@ -215,6 +218,13 @@ package com.autonomousapps.extension {
     method @InaccessibleFromKotlin @org.gradle.api.tasks.Input public org.gradle.api.provider.Property<java.lang.String> getPostscript();
     property @org.gradle.api.tasks.Input public abstract org.gradle.api.provider.Property<java.lang.Boolean> onlyOnFailure;
     property @org.gradle.api.tasks.Input public abstract org.gradle.api.provider.Property<java.lang.String> postscript;
+  }
+
+  public abstract class TypeUsageHandler {
+    ctor @javax.inject.Inject public TypeUsageHandler(org.gradle.api.model.ObjectFactory objects);
+    method public final void excludePackages(java.lang.String... packages);
+    method public final void excludeRegex(@org.intellij.lang.annotations.Language("RegExp") java.lang.String... patterns);
+    method public final void excludeTypes(java.lang.String... types);
   }
 
   public abstract class SourceSetsHandler implements org.gradle.api.Named {
@@ -517,6 +527,48 @@ package com.autonomousapps.model {
     property public String? buildPath;
     property public com.autonomousapps.model.GradleVariantIdentification gradleVariantIdentification;
     property public String identifier;
+  }
+
+  @com.squareup.moshi.JsonClass(generateAdapter=false) public final class ProjectTypeUsage implements java.lang.Comparable<com.autonomousapps.model.ProjectTypeUsage> {
+    ctor public ProjectTypeUsage(String projectPath, com.autonomousapps.model.TypeUsageSummary summary, java.util.Map<java.lang.String,java.lang.Integer> internal, java.util.Map<java.lang.String,? extends java.util.Map<java.lang.String,java.lang.Integer>> projectDependencies, java.util.Map<java.lang.String,? extends java.util.Map<java.lang.String,java.lang.Integer>> libraryDependencies);
+    method public int compareTo(com.autonomousapps.model.ProjectTypeUsage other);
+    method public String component1();
+    method public com.autonomousapps.model.TypeUsageSummary component2();
+    method public java.util.Map<java.lang.String,java.lang.Integer> component3();
+    method public java.util.Map<java.lang.String,java.util.Map<java.lang.String,java.lang.Integer>> component4();
+    method public java.util.Map<java.lang.String,java.util.Map<java.lang.String,java.lang.Integer>> component5();
+    method public com.autonomousapps.model.ProjectTypeUsage copy(String projectPath, com.autonomousapps.model.TypeUsageSummary summary, java.util.Map<java.lang.String,java.lang.Integer> internal, java.util.Map<java.lang.String,? extends java.util.Map<java.lang.String,java.lang.Integer>> projectDependencies, java.util.Map<java.lang.String,? extends java.util.Map<java.lang.String,java.lang.Integer>> libraryDependencies);
+    method public java.util.Map<java.lang.String,java.lang.Integer> getInternal();
+    method public java.util.Map<java.lang.String,java.util.Map<java.lang.String,java.lang.Integer>> getLibraryDependencies();
+    method public java.util.Map<java.lang.String,java.util.Map<java.lang.String,java.lang.Integer>> getProjectDependencies();
+    method public String getProjectPath();
+    method public com.autonomousapps.model.TypeUsageSummary getSummary();
+    method public boolean isEmpty();
+    property public final java.util.Map<java.lang.String,java.lang.Integer> internal;
+    property public final java.util.Map<java.lang.String,java.util.Map<java.lang.String,java.lang.Integer>> libraryDependencies;
+    property public final java.util.Map<java.lang.String,java.util.Map<java.lang.String,java.lang.Integer>> projectDependencies;
+    property public final String projectPath;
+    property public final com.autonomousapps.model.TypeUsageSummary summary;
+  }
+
+  @com.squareup.moshi.JsonClass(generateAdapter=false) public final class TypeUsageSummary {
+    ctor public TypeUsageSummary(int totalTypes, int totalFiles, int internalTypes, int projectDependencies, int libraryDependencies);
+    method public int component1();
+    method public int component2();
+    method public int component3();
+    method public int component4();
+    method public int component5();
+    method public com.autonomousapps.model.TypeUsageSummary copy(int totalTypes, int totalFiles, int internalTypes, int projectDependencies, int libraryDependencies);
+    method public int getInternalTypes();
+    method public int getLibraryDependencies();
+    method public int getProjectDependencies();
+    method public int getTotalFiles();
+    method public int getTotalTypes();
+    property public final int internalTypes;
+    property public final int libraryDependencies;
+    property public final int projectDependencies;
+    property public final int totalFiles;
+    property public final int totalTypes;
   }
 
   @com.squareup.moshi.JsonClass(generateAdapter=false) public final class Warning implements java.lang.Comparable<com.autonomousapps.model.Warning> {

--- a/api/api.txt
+++ b/api/api.txt
@@ -4,9 +4,9 @@ package com.autonomousapps {
   public abstract class AbstractExtension {
     ctor @javax.inject.Inject public AbstractExtension(org.gradle.api.model.ObjectFactory objects, org.gradle.api.invocation.Gradle gradle);
     method public final org.gradle.api.file.RegularFileProperty adviceOutput();
-    method public final org.gradle.api.file.RegularFileProperty typeUsageOutput();
     method public final void app();
     method public final void registerPostProcessingTask(org.gradle.api.tasks.TaskProvider<? extends com.autonomousapps.AbstractPostProcessingTask> task);
+    method public final org.gradle.api.provider.MapProperty<java.lang.String,org.gradle.api.file.RegularFile> typeUsageOutputs();
     field public static final String NAME = "dependencyAnalysis";
   }
 
@@ -220,16 +220,16 @@ package com.autonomousapps.extension {
     property @org.gradle.api.tasks.Input public abstract org.gradle.api.provider.Property<java.lang.String> postscript;
   }
 
+  public abstract class SourceSetsHandler implements org.gradle.api.Named {
+    ctor @javax.inject.Inject public SourceSetsHandler(String sourceSetName, String projectPath, org.gradle.api.model.ObjectFactory objects);
+    method public String getName();
+  }
+
   public abstract class TypeUsageHandler {
     ctor @javax.inject.Inject public TypeUsageHandler(org.gradle.api.model.ObjectFactory objects);
     method public final void excludePackages(java.lang.String... packages);
     method public final void excludeRegex(@org.intellij.lang.annotations.Language("RegExp") java.lang.String... patterns);
     method public final void excludeTypes(java.lang.String... types);
-  }
-
-  public abstract class SourceSetsHandler implements org.gradle.api.Named {
-    ctor @javax.inject.Inject public SourceSetsHandler(String sourceSetName, String projectPath, org.gradle.api.model.ObjectFactory objects);
-    method public String getName();
   }
 
   public final class Undefined extends com.autonomousapps.extension.Behavior {
@@ -529,26 +529,28 @@ package com.autonomousapps.model {
     property public String identifier;
   }
 
-  @com.squareup.moshi.JsonClass(generateAdapter=false) public final class ProjectTypeUsage implements java.lang.Comparable<com.autonomousapps.model.ProjectTypeUsage> {
-    ctor public ProjectTypeUsage(String projectPath, com.autonomousapps.model.TypeUsageSummary summary, java.util.Map<java.lang.String,java.lang.Integer> internal, java.util.Map<java.lang.String,? extends java.util.Map<java.lang.String,java.lang.Integer>> projectDependencies, java.util.Map<java.lang.String,? extends java.util.Map<java.lang.String,java.lang.Integer>> libraryDependencies);
-    method public int compareTo(com.autonomousapps.model.ProjectTypeUsage other);
+  @com.squareup.moshi.JsonClass(generateAdapter=false) public final class ProjectTypeUsage {
+    ctor public ProjectTypeUsage(String projectPath, com.autonomousapps.model.TypeUsageSummary summary, java.util.Map<java.lang.String,java.lang.Integer> internal, java.util.Map<java.lang.String,? extends java.util.Map<java.lang.String,java.lang.Integer>> projectDependencies, java.util.Map<java.lang.String,? extends java.util.Map<java.lang.String,java.lang.Integer>> libraryDependencies, optional java.util.Map<java.lang.String,java.lang.Integer> unknownDependencies);
     method public String component1();
     method public com.autonomousapps.model.TypeUsageSummary component2();
     method public java.util.Map<java.lang.String,java.lang.Integer> component3();
     method public java.util.Map<java.lang.String,java.util.Map<java.lang.String,java.lang.Integer>> component4();
     method public java.util.Map<java.lang.String,java.util.Map<java.lang.String,java.lang.Integer>> component5();
-    method public com.autonomousapps.model.ProjectTypeUsage copy(String projectPath, com.autonomousapps.model.TypeUsageSummary summary, java.util.Map<java.lang.String,java.lang.Integer> internal, java.util.Map<java.lang.String,? extends java.util.Map<java.lang.String,java.lang.Integer>> projectDependencies, java.util.Map<java.lang.String,? extends java.util.Map<java.lang.String,java.lang.Integer>> libraryDependencies);
-    method public java.util.Map<java.lang.String,java.lang.Integer> getInternal();
-    method public java.util.Map<java.lang.String,java.util.Map<java.lang.String,java.lang.Integer>> getLibraryDependencies();
-    method public java.util.Map<java.lang.String,java.util.Map<java.lang.String,java.lang.Integer>> getProjectDependencies();
-    method public String getProjectPath();
-    method public com.autonomousapps.model.TypeUsageSummary getSummary();
+    method public java.util.Map<java.lang.String,java.lang.Integer> component6();
+    method public com.autonomousapps.model.ProjectTypeUsage copy(optional String projectPath, optional com.autonomousapps.model.TypeUsageSummary summary, optional java.util.Map<java.lang.String,java.lang.Integer> internal, optional java.util.Map<java.lang.String,? extends java.util.Map<java.lang.String,java.lang.Integer>> projectDependencies, optional java.util.Map<java.lang.String,? extends java.util.Map<java.lang.String,java.lang.Integer>> libraryDependencies, optional java.util.Map<java.lang.String,java.lang.Integer> unknownDependencies);
+    method @InaccessibleFromKotlin public java.util.Map<java.lang.String,java.lang.Integer> getInternal();
+    method @InaccessibleFromKotlin public java.util.Map<java.lang.String,java.util.Map<java.lang.String,java.lang.Integer>> getLibraryDependencies();
+    method @InaccessibleFromKotlin public java.util.Map<java.lang.String,java.util.Map<java.lang.String,java.lang.Integer>> getProjectDependencies();
+    method @InaccessibleFromKotlin public String getProjectPath();
+    method @InaccessibleFromKotlin public com.autonomousapps.model.TypeUsageSummary getSummary();
+    method @InaccessibleFromKotlin public java.util.Map<java.lang.String,java.lang.Integer> getUnknownDependencies();
     method public boolean isEmpty();
-    property public final java.util.Map<java.lang.String,java.lang.Integer> internal;
-    property public final java.util.Map<java.lang.String,java.util.Map<java.lang.String,java.lang.Integer>> libraryDependencies;
-    property public final java.util.Map<java.lang.String,java.util.Map<java.lang.String,java.lang.Integer>> projectDependencies;
-    property public final String projectPath;
-    property public final com.autonomousapps.model.TypeUsageSummary summary;
+    property public java.util.Map<java.lang.String,java.lang.Integer> internal;
+    property public java.util.Map<java.lang.String,java.util.Map<java.lang.String,java.lang.Integer>> libraryDependencies;
+    property public java.util.Map<java.lang.String,java.util.Map<java.lang.String,java.lang.Integer>> projectDependencies;
+    property public String projectPath;
+    property public com.autonomousapps.model.TypeUsageSummary summary;
+    property public java.util.Map<java.lang.String,java.lang.Integer> unknownDependencies;
   }
 
   @com.squareup.moshi.JsonClass(generateAdapter=false) public final class TypeUsageSummary {
@@ -558,17 +560,17 @@ package com.autonomousapps.model {
     method public int component3();
     method public int component4();
     method public int component5();
-    method public com.autonomousapps.model.TypeUsageSummary copy(int totalTypes, int totalFiles, int internalTypes, int projectDependencies, int libraryDependencies);
-    method public int getInternalTypes();
-    method public int getLibraryDependencies();
-    method public int getProjectDependencies();
-    method public int getTotalFiles();
-    method public int getTotalTypes();
-    property public final int internalTypes;
-    property public final int libraryDependencies;
-    property public final int projectDependencies;
-    property public final int totalFiles;
-    property public final int totalTypes;
+    method public com.autonomousapps.model.TypeUsageSummary copy(optional int totalTypes, optional int totalFiles, optional int internalTypes, optional int projectDependencies, optional int libraryDependencies);
+    method @InaccessibleFromKotlin public int getInternalTypes();
+    method @InaccessibleFromKotlin public int getLibraryDependencies();
+    method @InaccessibleFromKotlin public int getProjectDependencies();
+    method @InaccessibleFromKotlin public int getTotalFiles();
+    method @InaccessibleFromKotlin public int getTotalTypes();
+    property public int internalTypes;
+    property public int libraryDependencies;
+    property public int projectDependencies;
+    property public int totalFiles;
+    property public int totalTypes;
   }
 
   @com.squareup.moshi.JsonClass(generateAdapter=false) public final class Warning implements java.lang.Comparable<com.autonomousapps.model.Warning> {

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/TypeUsageSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/TypeUsageSpec.groovy
@@ -1,0 +1,196 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.jvm
+
+import com.autonomousapps.jvm.projects.TypeUsageProject
+import com.autonomousapps.jvm.projects.TypeUsageWithFiltersProject
+import com.autonomousapps.jvm.projects.TypeUsageMultiModuleProject
+
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertThat
+
+final class TypeUsageSpec extends AbstractJvmSpec {
+
+  def "generates type usage report (#gradleVersion)"() {
+    given:
+    def project = new TypeUsageProject()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'computeTypeUsageMain')
+
+    then: 'has correct summary'
+    def usage = project.actualTypeUsage()
+    assertThat(usage.projectPath).isEqualTo(':proj')
+    assertThat(usage.summary.totalTypes).isGreaterThan(0)
+    assertThat(usage.summary.totalFiles).isEqualTo(2)
+    assertThat(usage.summary.internalTypes).isEqualTo(1)
+
+    and: 'tracks internal usage'
+    assertThat(usage.internal).containsKey('com.example.Example')
+    // Note: Internal class is not tracked because it's defined but never used
+
+    and: 'tracks library dependencies'
+    assertThat(usage.libraryDependencies).isNotEmpty()
+
+    and: 'tracks commons-collections usage'
+    assertThat(usage.libraryDependencies)
+      .containsKey('org.apache.commons:commons-collections4')
+    def commonsUsage = usage.libraryDependencies.get('org.apache.commons:commons-collections4')
+    assertThat(commonsUsage).containsKey('org.apache.commons.collections4.bag.HashBag')
+
+    and: 'tracks kotlin stdlib usage'
+    assert usage.libraryDependencies.keySet().any { it.startsWith('org.jetbrains.kotlin:kotlin-stdlib') }
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+
+  def "excludes filtered types (#gradleVersion)"() {
+    given:
+    def project = new TypeUsageWithFiltersProject()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'computeTypeUsageMain')
+
+    then: 'excluded packages are not present'
+    def usage = project.actualTypeUsage()
+    def allTypes = usage.libraryDependencies.values()
+      .collectMany { it.keySet() }
+
+    assertThat(allTypes).doesNotContain('org.apache.commons.collections4.bag.HashBag')
+
+    and: 'excluded types are not present'
+    assertThat(allTypes).doesNotContain('kotlin.Unit')
+
+    and: 'non-excluded types are still present'
+    assertThat(usage.internal).containsKey('com.example.Example')
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+
+  def "categorizes dependencies correctly (#gradleVersion)"() {
+    given:
+    def project = new TypeUsageProject()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'computeTypeUsageMain')
+
+    then: 'internal types are in internal map'
+    def usage = project.actualTypeUsage()
+    assertThat(usage.internal).isNotEmpty()
+    assertThat(usage.internal).containsKey('com.example.Example')
+
+    and: 'library types are in libraryDependencies map'
+    assertThat(usage.libraryDependencies).isNotEmpty()
+
+    and: 'no project dependencies (single-project)'
+    assertThat(usage.projectDependencies).isEmpty()
+
+    and: 'summary counts match'
+    assertThat(usage.summary.internalTypes).isEqualTo(usage.internal.size())
+    assertThat(usage.summary.libraryDependencies).isEqualTo(usage.libraryDependencies.size())
+    assertThat(usage.summary.projectDependencies).isEqualTo(0)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+
+  def "tracks type usage across multiple modules (#gradleVersion)"() {
+    given:
+    def project = new TypeUsageMultiModuleProject()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'computeTypeUsageMain')
+
+    then: 'app module tracks project dependencies'
+    def appUsage = project.actualTypeUsageFor(':app')
+    assertThat(appUsage.projectPath).isEqualTo(':app')
+    assertThat(appUsage.projectDependencies).hasSize(2)
+    assertThat(appUsage.projectDependencies).containsKey(':core')
+    assertThat(appUsage.projectDependencies).containsKey(':utils')
+
+    and: 'app tracks types from core'
+    def coreTypes = appUsage.projectDependencies[':core']
+    assertThat(coreTypes).containsKey('com.example.core.UserRepository')
+    assertThat(coreTypes).containsKey('com.example.core.User')
+
+    and: 'app tracks types from utils'
+    def utilsTypes = appUsage.projectDependencies[':utils']
+    assertThat(utilsTypes).containsKey('com.example.utils.Logger')
+
+    and: 'app tracks library dependencies'
+    assertThat(appUsage.libraryDependencies).containsKey('org.apache.commons:commons-collections4')
+
+    and: 'app tracks internal types'
+    assertThat(appUsage.internal).containsKey('com.example.app.MainActivity')
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+
+  def "core module tracks its dependencies (#gradleVersion)"() {
+    given:
+    def project = new TypeUsageMultiModuleProject()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'computeTypeUsageMain')
+
+    then: 'core tracks utils as project dependency'
+    def coreUsage = project.actualTypeUsageFor(':core')
+    assertThat(coreUsage.projectPath).isEqualTo(':core')
+    assertThat(coreUsage.projectDependencies).hasSize(1)
+    assertThat(coreUsage.projectDependencies).containsKey(':utils')
+
+    and: 'core tracks Logger from utils'
+    def utilsTypes = coreUsage.projectDependencies[':utils']
+    assertThat(utilsTypes).containsKey('com.example.utils.Logger')
+
+    and: 'core tracks its own internal types'
+    assertThat(coreUsage.internal).containsKey('com.example.core.User')
+
+    and: 'core has no library dependencies beyond kotlin stdlib'
+    def nonKotlinLibs = coreUsage.libraryDependencies.keySet().findAll {
+      !it.startsWith('org.jetbrains')
+    }
+    assertThat(nonKotlinLibs).isEmpty()
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+
+  def "utils module has only library dependencies (#gradleVersion)"() {
+    given:
+    def project = new TypeUsageMultiModuleProject()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'computeTypeUsageMain')
+
+    then: 'utils has no project dependencies'
+    def utilsUsage = project.actualTypeUsageFor(':utils')
+    assertThat(utilsUsage.projectPath).isEqualTo(':utils')
+    assertThat(utilsUsage.projectDependencies).isEmpty()
+
+    and: 'utils tracks commons-io'
+    assertThat(utilsUsage.libraryDependencies).containsKey('commons-io:commons-io')
+    def commonsIoTypes = utilsUsage.libraryDependencies['commons-io:commons-io']
+    assertThat(commonsIoTypes).containsKey('org.apache.commons.io.FileUtils')
+
+    and: 'utils tracks internal Logger type'
+    assertThat(utilsUsage.internal).containsKey('com.example.utils.Logger')
+
+    and: 'summary counts are correct'
+    assertThat(utilsUsage.summary.projectDependencies).isEqualTo(0)
+    assertThat(utilsUsage.summary.libraryDependencies).isGreaterThan(0)
+    assertThat(utilsUsage.summary.internalTypes).isEqualTo(utilsUsage.internal.size())
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/TypeUsageSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/TypeUsageSpec.groovy
@@ -19,28 +19,8 @@ final class TypeUsageSpec extends AbstractJvmSpec {
     when:
     build(gradleVersion, gradleProject.rootDir, 'computeTypeUsageMain')
 
-    then: 'has correct summary'
-    def usage = project.actualTypeUsage()
-    assertThat(usage.projectPath).isEqualTo(':proj')
-    assertThat(usage.summary.totalTypes).isGreaterThan(0)
-    assertThat(usage.summary.totalFiles).isEqualTo(2)
-    assertThat(usage.summary.internalTypes).isEqualTo(1)
-
-    and: 'tracks internal usage'
-    assertThat(usage.internal).containsKey('com.example.Example')
-    // Note: Internal class is not tracked because it's defined but never used
-
-    and: 'tracks library dependencies'
-    assertThat(usage.libraryDependencies).isNotEmpty()
-
-    and: 'tracks commons-collections usage'
-    assertThat(usage.libraryDependencies)
-      .containsKey('org.apache.commons:commons-collections4')
-    def commonsUsage = usage.libraryDependencies.get('org.apache.commons:commons-collections4')
-    assertThat(commonsUsage).containsKey('org.apache.commons.collections4.bag.HashBag')
-
-    and: 'tracks kotlin stdlib usage'
-    assert usage.libraryDependencies.keySet().any { it.startsWith('org.jetbrains.kotlin:kotlin-stdlib') }
+    then:
+    assertThat(project.actualTypeUsage()).isEqualTo(project.expectedTypeUsage())
 
     where:
     gradleVersion << gradleVersions()
@@ -54,46 +34,8 @@ final class TypeUsageSpec extends AbstractJvmSpec {
     when:
     build(gradleVersion, gradleProject.rootDir, 'computeTypeUsageMain')
 
-    then: 'excluded packages are not present'
-    def usage = project.actualTypeUsage()
-    def allTypes = usage.libraryDependencies.values()
-      .collectMany { it.keySet() }
-
-    assertThat(allTypes).doesNotContain('org.apache.commons.collections4.bag.HashBag')
-
-    and: 'excluded types are not present'
-    assertThat(allTypes).doesNotContain('kotlin.Unit')
-
-    and: 'non-excluded types are still present'
-    assertThat(usage.internal).containsKey('com.example.Example')
-
-    where:
-    gradleVersion << gradleVersions()
-  }
-
-  def "categorizes dependencies correctly (#gradleVersion)"() {
-    given:
-    def project = new TypeUsageProject()
-    gradleProject = project.gradleProject
-
-    when:
-    build(gradleVersion, gradleProject.rootDir, 'computeTypeUsageMain')
-
-    then: 'internal types are in internal map'
-    def usage = project.actualTypeUsage()
-    assertThat(usage.internal).isNotEmpty()
-    assertThat(usage.internal).containsKey('com.example.Example')
-
-    and: 'library types are in libraryDependencies map'
-    assertThat(usage.libraryDependencies).isNotEmpty()
-
-    and: 'no project dependencies (single-project)'
-    assertThat(usage.projectDependencies).isEmpty()
-
-    and: 'summary counts match'
-    assertThat(usage.summary.internalTypes).isEqualTo(usage.internal.size())
-    assertThat(usage.summary.libraryDependencies).isEqualTo(usage.libraryDependencies.size())
-    assertThat(usage.summary.projectDependencies).isEqualTo(0)
+    then:
+    assertThat(project.actualTypeUsage()).isEqualTo(project.expectedTypeUsage())
 
     where:
     gradleVersion << gradleVersions()
@@ -107,88 +49,14 @@ final class TypeUsageSpec extends AbstractJvmSpec {
     when:
     build(gradleVersion, gradleProject.rootDir, 'computeTypeUsageMain')
 
-    then: 'app module tracks project dependencies'
-    def appUsage = project.actualTypeUsageFor(':app')
-    assertThat(appUsage.projectPath).isEqualTo(':app')
-    assertThat(appUsage.projectDependencies).hasSize(2)
-    assertThat(appUsage.projectDependencies).containsKey(':core')
-    assertThat(appUsage.projectDependencies).containsKey(':utils')
+    then: 'app module'
+    assertThat(project.actualTypeUsageFor(':app')).isEqualTo(project.expectedAppTypeUsage())
 
-    and: 'app tracks types from core'
-    def coreTypes = appUsage.projectDependencies[':core']
-    assertThat(coreTypes).containsKey('com.example.core.UserRepository')
-    assertThat(coreTypes).containsKey('com.example.core.User')
+    and: 'core module'
+    assertThat(project.actualTypeUsageFor(':core')).isEqualTo(project.expectedCoreTypeUsage())
 
-    and: 'app tracks types from utils'
-    def utilsTypes = appUsage.projectDependencies[':utils']
-    assertThat(utilsTypes).containsKey('com.example.utils.Logger')
-
-    and: 'app tracks library dependencies'
-    assertThat(appUsage.libraryDependencies).containsKey('org.apache.commons:commons-collections4')
-
-    and: 'app tracks internal types'
-    assertThat(appUsage.internal).containsKey('com.example.app.MainActivity')
-
-    where:
-    gradleVersion << gradleVersions()
-  }
-
-  def "core module tracks its dependencies (#gradleVersion)"() {
-    given:
-    def project = new TypeUsageMultiModuleProject()
-    gradleProject = project.gradleProject
-
-    when:
-    build(gradleVersion, gradleProject.rootDir, 'computeTypeUsageMain')
-
-    then: 'core tracks utils as project dependency'
-    def coreUsage = project.actualTypeUsageFor(':core')
-    assertThat(coreUsage.projectPath).isEqualTo(':core')
-    assertThat(coreUsage.projectDependencies).hasSize(1)
-    assertThat(coreUsage.projectDependencies).containsKey(':utils')
-
-    and: 'core tracks Logger from utils'
-    def utilsTypes = coreUsage.projectDependencies[':utils']
-    assertThat(utilsTypes).containsKey('com.example.utils.Logger')
-
-    and: 'core tracks its own internal types'
-    assertThat(coreUsage.internal).containsKey('com.example.core.User')
-
-    and: 'core has no library dependencies beyond kotlin stdlib'
-    def nonKotlinLibs = coreUsage.libraryDependencies.keySet().findAll {
-      !it.startsWith('org.jetbrains')
-    }
-    assertThat(nonKotlinLibs).isEmpty()
-
-    where:
-    gradleVersion << gradleVersions()
-  }
-
-  def "utils module has only library dependencies (#gradleVersion)"() {
-    given:
-    def project = new TypeUsageMultiModuleProject()
-    gradleProject = project.gradleProject
-
-    when:
-    build(gradleVersion, gradleProject.rootDir, 'computeTypeUsageMain')
-
-    then: 'utils has no project dependencies'
-    def utilsUsage = project.actualTypeUsageFor(':utils')
-    assertThat(utilsUsage.projectPath).isEqualTo(':utils')
-    assertThat(utilsUsage.projectDependencies).isEmpty()
-
-    and: 'utils tracks commons-io'
-    assertThat(utilsUsage.libraryDependencies).containsKey('commons-io:commons-io')
-    def commonsIoTypes = utilsUsage.libraryDependencies['commons-io:commons-io']
-    assertThat(commonsIoTypes).containsKey('org.apache.commons.io.FileUtils')
-
-    and: 'utils tracks internal Logger type'
-    assertThat(utilsUsage.internal).containsKey('com.example.utils.Logger')
-
-    and: 'summary counts are correct'
-    assertThat(utilsUsage.summary.projectDependencies).isEqualTo(0)
-    assertThat(utilsUsage.summary.libraryDependencies).isGreaterThan(0)
-    assertThat(utilsUsage.summary.internalTypes).isEqualTo(utilsUsage.internal.size())
+    and: 'utils module'
+    assertThat(project.actualTypeUsageFor(':utils')).isEqualTo(project.expectedUtilsTypeUsage())
 
     where:
     gradleVersion << gradleVersions()

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TypeUsageMultiModuleProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TypeUsageMultiModuleProject.groovy
@@ -6,10 +6,11 @@ import com.autonomousapps.AbstractProject
 import com.autonomousapps.kit.GradleProject
 import com.autonomousapps.kit.Source
 import com.autonomousapps.kit.SourceType
-import com.autonomousapps.internal.OutputPathsKt
-import com.autonomousapps.internal.utils.MoshiUtils
 import com.autonomousapps.model.ProjectTypeUsage
+import com.autonomousapps.model.TypeUsageSummary
 
+import static com.autonomousapps.internal.OutputPathsKt.getTypeUsagePath
+import static com.autonomousapps.internal.utils.MoshiUtils.MOSHI
 import static com.autonomousapps.kit.gradle.Dependency.project
 import static com.autonomousapps.kit.gradle.dependencies.Dependencies.*
 
@@ -161,9 +162,75 @@ final class TypeUsageMultiModuleProject extends AbstractProject {
   ]
 
   ProjectTypeUsage actualTypeUsageFor(String projectPath) {
-    def typeUsage = gradleProject.singleArtifact(projectPath,
-      OutputPathsKt.getTypeUsagePath('main'))
-    def adapter = MoshiUtils.MOSHI.adapter(ProjectTypeUsage)
+    def typeUsage = gradleProject.singleArtifact(projectPath, getTypeUsagePath('main'))
+    def adapter = MOSHI.adapter(ProjectTypeUsage)
     return adapter.fromJson(typeUsage.asPath.text)
+  }
+
+  ProjectTypeUsage expectedAppTypeUsage() {
+    return new ProjectTypeUsage(
+      ':app',
+      new TypeUsageSummary(
+        /* totalTypes */ 8,
+        /* totalFiles */ 2,
+        /* internalTypes */ 1,
+        /* projectDependencies */ 2,
+        /* libraryDependencies */ 3
+      ),
+      ['com.example.app.MainActivity': 1],
+      [
+        ':core': ['com.example.core.User': 1, 'com.example.core.UserRepository': 1],
+        ':utils': ['com.example.utils.Logger': 1],
+      ],
+      [
+        'org.apache.commons:commons-collections4': ['org.apache.commons.collections4.bag.HashBag': 1],
+        'org.jetbrains.kotlin:kotlin-stdlib': ['kotlin.Metadata': 2, 'kotlin.jvm.internal.SourceDebugExtension': 1],
+        'org.jetbrains:annotations': ['org.jetbrains.annotations.NotNull': 2],
+      ],
+      [:]
+    )
+  }
+
+  ProjectTypeUsage expectedCoreTypeUsage() {
+    return new ProjectTypeUsage(
+      ':core',
+      new TypeUsageSummary(
+        /* totalTypes */ 7,
+        /* totalFiles */ 3,
+        /* internalTypes */ 1,
+        /* projectDependencies */ 1,
+        /* libraryDependencies */ 2
+      ),
+      ['com.example.core.User': 2],
+      [
+        ':utils': ['com.example.utils.Logger': 1],
+      ],
+      [
+        'org.jetbrains.kotlin:kotlin-stdlib': ['kotlin.jvm.internal.Intrinsics': 2, 'kotlin.Metadata': 3, 'kotlin.collections.CollectionsKt': 1],
+        'org.jetbrains:annotations': ['org.jetbrains.annotations.NotNull': 3, 'org.jetbrains.annotations.Nullable': 1],
+      ],
+      [:]
+    )
+  }
+
+  ProjectTypeUsage expectedUtilsTypeUsage() {
+    return new ProjectTypeUsage(
+      ':utils',
+      new TypeUsageSummary(
+        /* totalTypes */ 5,
+        /* totalFiles */ 2,
+        /* internalTypes */ 1,
+        /* projectDependencies */ 0,
+        /* libraryDependencies */ 3
+      ),
+      ['com.example.utils.Logger': 1],
+      [:],
+      [
+        'commons-io:commons-io': ['org.apache.commons.io.FileUtils': 1],
+        'org.jetbrains.kotlin:kotlin-stdlib': ['kotlin.jvm.internal.Intrinsics': 1, 'kotlin.Metadata': 2],
+        'org.jetbrains:annotations': ['org.jetbrains.annotations.NotNull': 2],
+      ],
+      [:]
+    )
   }
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TypeUsageMultiModuleProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TypeUsageMultiModuleProject.groovy
@@ -1,0 +1,169 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.internal.OutputPathsKt
+import com.autonomousapps.internal.utils.MoshiUtils
+import com.autonomousapps.model.ProjectTypeUsage
+
+import static com.autonomousapps.kit.gradle.Dependency.project
+import static com.autonomousapps.kit.gradle.dependencies.Dependencies.*
+
+final class TypeUsageMultiModuleProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  TypeUsageMultiModuleProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newGradleProjectBuilder()
+      .withSubproject('app') { s ->
+        s.sources = appSources
+        s.withBuildScript { bs ->
+          bs.plugins = kotlin
+          bs.dependencies = [
+            project('implementation', ':core'),
+            project('implementation', ':utils'),
+            commonsCollections('implementation'),
+            kotlinStdLib('implementation')
+          ]
+        }
+      }
+      .withSubproject('core') { s ->
+        s.sources = coreSources
+        s.withBuildScript { bs ->
+          bs.plugins = kotlin
+          bs.dependencies = [
+            project('implementation', ':utils'),
+            kotlinStdLib('implementation')
+          ]
+        }
+      }
+      .withSubproject('utils') { s ->
+        s.sources = utilsSources
+        s.withBuildScript { bs ->
+          bs.plugins = kotlin
+          bs.dependencies = [
+            commonsIO('implementation'),
+            kotlinStdLib('implementation')
+          ]
+        }
+      }
+      .write()
+  }
+
+  private appSources = [
+    new Source(
+      SourceType.KOTLIN, "MainActivity", "com/example/app",
+      """\
+        package com.example.app
+
+        import com.example.core.UserRepository
+        import com.example.core.User
+        import com.example.utils.Logger
+        import org.apache.commons.collections4.bag.HashBag
+
+        class MainActivity {
+          private val repository = UserRepository()
+          private val logger = Logger()
+          private val cache = HashBag<String>()
+
+          fun loadUsers() {
+            val users = repository.getUsers()
+            logger.log("Loaded \${users.size} users")
+            users.forEach { cache.add(it.name) }
+          }
+        }
+      """.stripIndent()
+    ),
+    new Source(
+      SourceType.KOTLIN, "AppHelper", "com/example/app",
+      """\
+        package com.example.app
+
+        internal class AppHelper {
+          fun getMainActivity() = MainActivity()
+        }
+      """.stripIndent()
+    )
+  ]
+
+  private coreSources = [
+    new Source(
+      SourceType.KOTLIN, "UserRepository", "com/example/core",
+      """\
+        package com.example.core
+
+        import com.example.utils.Logger
+
+        class UserRepository {
+          private val logger = Logger()
+
+          fun getUsers(): List<User> {
+            logger.log("Fetching users")
+            return listOf(User("Alice"), User("Bob"))
+          }
+        }
+      """.stripIndent()
+    ),
+    new Source(
+      SourceType.KOTLIN, "User", "com/example/core",
+      """\
+        package com.example.core
+
+        data class User(val name: String)
+      """.stripIndent()
+    ),
+    new Source(
+      SourceType.KOTLIN, "CoreInternal", "com/example/core",
+      """\
+        package com.example.core
+
+        internal class CoreInternal {
+          fun createUser(name: String) = User(name)
+        }
+      """.stripIndent()
+    )
+  ]
+
+  private utilsSources = [
+    new Source(
+      SourceType.KOTLIN, "Logger", "com/example/utils",
+      """\
+        package com.example.utils
+
+        import org.apache.commons.io.FileUtils
+        import java.io.File
+
+        class Logger {
+          fun log(message: String) {
+            FileUtils.write(File("log.txt"), message, "UTF-8", true)
+          }
+        }
+      """.stripIndent()
+    ),
+    new Source(
+      SourceType.KOTLIN, "UtilsHelper", "com/example/utils",
+      """\
+        package com.example.utils
+
+        internal class UtilsHelper {
+          fun createLogger() = Logger()
+        }
+      """.stripIndent()
+    )
+  ]
+
+  ProjectTypeUsage actualTypeUsageFor(String projectPath) {
+    def typeUsage = gradleProject.singleArtifact(projectPath,
+      OutputPathsKt.getTypeUsagePath('main'))
+    def adapter = MoshiUtils.MOSHI.adapter(ProjectTypeUsage)
+    return adapter.fromJson(typeUsage.asPath.text)
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TypeUsageProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TypeUsageProject.groovy
@@ -6,10 +6,11 @@ import com.autonomousapps.AbstractProject
 import com.autonomousapps.kit.GradleProject
 import com.autonomousapps.kit.Source
 import com.autonomousapps.kit.SourceType
-import com.autonomousapps.internal.OutputPathsKt
-import com.autonomousapps.internal.utils.MoshiUtils
 import com.autonomousapps.model.ProjectTypeUsage
+import com.autonomousapps.model.TypeUsageSummary
 
+import static com.autonomousapps.internal.OutputPathsKt.getTypeUsagePath
+import static com.autonomousapps.internal.utils.MoshiUtils.MOSHI
 import static com.autonomousapps.kit.gradle.dependencies.Dependencies.*
 
 final class TypeUsageProject extends AbstractProject {
@@ -65,9 +66,29 @@ final class TypeUsageProject extends AbstractProject {
   ]
 
   ProjectTypeUsage actualTypeUsage() {
-    def typeUsage = gradleProject.singleArtifact(':proj',
-      OutputPathsKt.getTypeUsagePath('main'))
-    def adapter = MoshiUtils.MOSHI.adapter(ProjectTypeUsage)
+    def typeUsage = gradleProject.singleArtifact(':proj', getTypeUsagePath('main'))
+    def adapter = MOSHI.adapter(ProjectTypeUsage)
     return adapter.fromJson(typeUsage.asPath.text)
+  }
+
+  ProjectTypeUsage expectedTypeUsage() {
+    return new ProjectTypeUsage(
+      ':proj',
+      new TypeUsageSummary(
+        /* totalTypes */ 4,
+        /* totalFiles */ 2,
+        /* internalTypes */ 1,
+        /* projectDependencies */ 0,
+        /* libraryDependencies */ 3
+      ),
+      ['com.example.Example': 1],
+      [:],
+      [
+        'org.apache.commons:commons-collections4': ['org.apache.commons.collections4.bag.HashBag': 1],
+        'org.jetbrains.kotlin:kotlin-stdlib': ['kotlin.Metadata': 2],
+        'org.jetbrains:annotations': ['org.jetbrains.annotations.NotNull': 2],
+      ],
+      [:]
+    )
   }
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TypeUsageProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TypeUsageProject.groovy
@@ -1,0 +1,73 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.internal.OutputPathsKt
+import com.autonomousapps.internal.utils.MoshiUtils
+import com.autonomousapps.model.ProjectTypeUsage
+
+import static com.autonomousapps.kit.gradle.dependencies.Dependencies.*
+
+final class TypeUsageProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  TypeUsageProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newGradleProjectBuilder()
+      .withSubproject('proj') { s ->
+        s.sources = sources
+        s.withBuildScript { bs ->
+          bs.plugins = kotlin
+          bs.dependencies = [
+            commonsCollections('implementation'),
+            kotlinStdLib('implementation')
+          ]
+        }
+      }
+      .write()
+  }
+
+  private sources = [
+    new Source(
+      SourceType.KOTLIN, "Example", "com/example",
+      """\
+        package com.example
+
+        import org.apache.commons.collections4.bag.HashBag
+
+        class Example {
+          private val bag = HashBag<String>()
+
+          fun doSomething() {
+            bag.add("test")
+          }
+        }
+      """.stripIndent()
+    ),
+    new Source(
+      SourceType.KOTLIN, "Internal", "com/example",
+      """\
+        package com.example
+
+        internal class Internal {
+          fun helper() = Example()
+        }
+      """.stripIndent()
+    )
+  ]
+
+  ProjectTypeUsage actualTypeUsage() {
+    def typeUsage = gradleProject.singleArtifact(':proj',
+      OutputPathsKt.getTypeUsagePath('main'))
+    def adapter = MoshiUtils.MOSHI.adapter(ProjectTypeUsage)
+    return adapter.fromJson(typeUsage.asPath.text)
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TypeUsageWithFiltersProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TypeUsageWithFiltersProject.groovy
@@ -1,0 +1,80 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.model.ProjectTypeUsage
+
+import static com.autonomousapps.kit.gradle.dependencies.Dependencies.*
+
+final class TypeUsageWithFiltersProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  TypeUsageWithFiltersProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newGradleProjectBuilder()
+      .withSubproject('proj') { s ->
+        s.sources = sources
+        s.withBuildScript { bs ->
+          bs.plugins = kotlin
+          bs.dependencies = [
+            commonsCollections('implementation'),
+            kotlinStdLib('implementation')
+          ]
+          bs.additions = """\
+            dependencyAnalysis {
+              typeUsage {
+                excludePackages('org.apache.commons')
+                excludeTypes('kotlin.Unit')
+              }
+            }
+          """.stripIndent()
+        }
+      }
+      .write()
+  }
+
+  private sources = [
+    new Source(
+      SourceType.KOTLIN, "Example", "com/example",
+      """\
+        package com.example
+
+        import org.apache.commons.collections4.bag.HashBag
+
+        class Example {
+          private val bag = HashBag<String>()
+
+          fun doSomething(): Unit {
+            bag.add("test")
+          }
+        }
+      """.stripIndent()
+    ),
+    new Source(
+      SourceType.KOTLIN, "Internal", "com/example",
+      """\
+        package com.example
+
+        internal class Internal {
+          fun helper() = Example()
+        }
+      """.stripIndent()
+    )
+  ]
+
+  ProjectTypeUsage actualTypeUsage() {
+    def typeUsage = gradleProject.singleArtifact(':proj',
+      com.autonomousapps.internal.OutputPathsKt.getTypeUsagePath('main'))
+    def adapter = com.autonomousapps.internal.utils.MoshiUtils.MOSHI
+      .adapter(com.autonomousapps.model.ProjectTypeUsage)
+    return adapter.fromJson(typeUsage.asPath.text)
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TypeUsageWithFiltersProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TypeUsageWithFiltersProject.groovy
@@ -7,7 +7,10 @@ import com.autonomousapps.kit.GradleProject
 import com.autonomousapps.kit.Source
 import com.autonomousapps.kit.SourceType
 import com.autonomousapps.model.ProjectTypeUsage
+import com.autonomousapps.model.TypeUsageSummary
 
+import static com.autonomousapps.internal.OutputPathsKt.getTypeUsagePath
+import static com.autonomousapps.internal.utils.MoshiUtils.MOSHI
 import static com.autonomousapps.kit.gradle.dependencies.Dependencies.*
 
 final class TypeUsageWithFiltersProject extends AbstractProject {
@@ -71,10 +74,28 @@ final class TypeUsageWithFiltersProject extends AbstractProject {
   ]
 
   ProjectTypeUsage actualTypeUsage() {
-    def typeUsage = gradleProject.singleArtifact(':proj',
-      com.autonomousapps.internal.OutputPathsKt.getTypeUsagePath('main'))
-    def adapter = com.autonomousapps.internal.utils.MoshiUtils.MOSHI
-      .adapter(com.autonomousapps.model.ProjectTypeUsage)
+    def typeUsage = gradleProject.singleArtifact(':proj', getTypeUsagePath('main'))
+    def adapter = MOSHI.adapter(ProjectTypeUsage)
     return adapter.fromJson(typeUsage.asPath.text)
+  }
+
+  ProjectTypeUsage expectedTypeUsage() {
+    return new ProjectTypeUsage(
+      ':proj',
+      new TypeUsageSummary(
+        /* totalTypes */ 3,
+        /* totalFiles */ 2,
+        /* internalTypes */ 1,
+        /* projectDependencies */ 0,
+        /* libraryDependencies */ 2
+      ),
+      ['com.example.Example': 1],
+      [:],
+      [
+        'org.jetbrains.kotlin:kotlin-stdlib': ['kotlin.Metadata': 2],
+        'org.jetbrains:annotations': ['org.jetbrains.annotations.NotNull': 2],
+      ],
+      [:]
+    )
   }
 }

--- a/src/main/kotlin/com/autonomousapps/AbstractExtension.kt
+++ b/src/main/kotlin/com/autonomousapps/AbstractExtension.kt
@@ -34,8 +34,10 @@ public abstract class AbstractExtension @Inject constructor(
   internal val dependenciesHandler: DependenciesHandler = dslService.get().dependenciesHandler
   internal val reportingHandler: ReportingHandler = dslService.get().reportingHandler
   internal val usageHandler: UsageHandler = dslService.get().usageHandler
+  internal val typeUsageHandler: TypeUsageHandler = objects.newInstance(TypeUsageHandler::class.java)
 
   private val adviceOutput = objects.fileProperty()
+  private val typeUsageOutput = objects.fileProperty()
   private var postProcessingTask: TaskProvider<out AbstractPostProcessingTask>? = null
 
   internal var forceAppProject = false
@@ -47,6 +49,13 @@ public abstract class AbstractExtension @Inject constructor(
     adviceOutput.set(output)
   }
 
+  internal fun storeTypeUsageOutput(provider: Provider<RegularFile>) {
+    val output = objects.fileProperty().also {
+      it.set(provider)
+    }
+    typeUsageOutput.set(output)
+  }
+
   /**
    * Returns the output from the project-level advice.
    *
@@ -54,6 +63,14 @@ public abstract class AbstractExtension @Inject constructor(
    */
   @Suppress("MemberVisibilityCanBePrivate") // explicit API
   public fun adviceOutput(): RegularFileProperty = adviceOutput
+
+  /**
+   * Returns the output from the project-level type usage analysis.
+   *
+   * Never null, but may _contain_ a null value. Use with [RegularFileProperty.getOrNull].
+   */
+  @Suppress("MemberVisibilityCanBePrivate") // explicit API
+  public fun typeUsageOutput(): RegularFileProperty = typeUsageOutput
 
   /**
    * Whether to force the project being treated as an app project even if only the `java` plugin is applied.

--- a/src/main/kotlin/com/autonomousapps/AbstractExtension.kt
+++ b/src/main/kotlin/com/autonomousapps/AbstractExtension.kt
@@ -8,6 +8,7 @@ import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.invocation.Gradle
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
@@ -37,7 +38,7 @@ public abstract class AbstractExtension @Inject constructor(
   internal val typeUsageHandler: TypeUsageHandler = objects.newInstance(TypeUsageHandler::class.java)
 
   private val adviceOutput = objects.fileProperty()
-  private val typeUsageOutput = objects.fileProperty()
+  private val typeUsageOutputs = objects.mapProperty(String::class.java, RegularFile::class.java)
   private var postProcessingTask: TaskProvider<out AbstractPostProcessingTask>? = null
 
   internal var forceAppProject = false
@@ -49,11 +50,8 @@ public abstract class AbstractExtension @Inject constructor(
     adviceOutput.set(output)
   }
 
-  internal fun storeTypeUsageOutput(provider: Provider<RegularFile>) {
-    val output = objects.fileProperty().also {
-      it.set(provider)
-    }
-    typeUsageOutput.set(output)
+  internal fun storeTypeUsageOutput(variantName: String, provider: Provider<RegularFile>) {
+    typeUsageOutputs.put(variantName, provider)
   }
 
   /**
@@ -65,12 +63,11 @@ public abstract class AbstractExtension @Inject constructor(
   public fun adviceOutput(): RegularFileProperty = adviceOutput
 
   /**
-   * Returns the output from the project-level type usage analysis.
-   *
-   * Never null, but may _contain_ a null value. Use with [RegularFileProperty.getOrNull].
+   * Returns the per-variant outputs from the project-level type usage analysis.
+   * Keyed by variant name (e.g., "Main", "Debug", "Release").
    */
   @Suppress("MemberVisibilityCanBePrivate") // explicit API
-  public fun typeUsageOutput(): RegularFileProperty = typeUsageOutput
+  public fun typeUsageOutputs(): MapProperty<String, RegularFile> = typeUsageOutputs
 
   /**
    * Whether to force the project being treated as an app project even if only the `java` plugin is applied.

--- a/src/main/kotlin/com/autonomousapps/AbstractExtension.kt
+++ b/src/main/kotlin/com/autonomousapps/AbstractExtension.kt
@@ -64,7 +64,7 @@ public abstract class AbstractExtension @Inject constructor(
 
   /**
    * Returns the per-variant outputs from the project-level type usage analysis.
-   * Keyed by variant name (e.g., "Main", "Debug", "Release").
+   * Keyed by variant name (e.g., "Main", "Debug", "Release", "DebugFlavor", etc.).
    */
   @Suppress("MemberVisibilityCanBePrivate") // explicit API
   public fun typeUsageOutputs(): MapProperty<String, RegularFile> = typeUsageOutputs

--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisExtension.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisExtension.kt
@@ -36,6 +36,9 @@ import javax.inject.Inject
  *
  *   // Configure usage rules.
  *   usage { ... }
+ *
+ *   // Configure type usage analysis filtering.
+ *   typeUsage { ... }
  * }
  * ```
  */
@@ -79,6 +82,11 @@ public abstract class DependencyAnalysisExtension @Inject constructor(
   @Deprecated(message = "Use 'usage' instead", replaceWith = ReplaceWith("usage"))
   public fun usages(action: Action<UsageHandler>) {
     action.execute(usageHandler)
+  }
+
+  /** Customize type usage analysis filtering. See [TypeUsageHandler] for more information. */
+  public fun typeUsage(action: Action<TypeUsageHandler>) {
+    action.execute(typeUsageHandler)
   }
 
   internal companion object {

--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisSubExtension.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisSubExtension.kt
@@ -5,6 +5,7 @@ package com.autonomousapps
 import com.autonomousapps.extension.AbiHandler
 import com.autonomousapps.extension.DependenciesHandler
 import com.autonomousapps.extension.ProjectIssueHandler
+import com.autonomousapps.extension.TypeUsageHandler
 import org.gradle.api.Action
 import org.gradle.api.Project
 import javax.naming.OperationNotSupportedException
@@ -51,6 +52,11 @@ public abstract class DependencyAnalysisSubExtension(
   @Suppress("UNUSED_PARAMETER")
   public fun structure(action: Action<DependenciesHandler>) {
     throw OperationNotSupportedException("Dependency bundles must be declared in the root project only")
+  }
+
+  /** Customize type usage analysis filtering. See [TypeUsageHandler] for more information. */
+  public fun typeUsage(action: Action<TypeUsageHandler>) {
+    action.execute(typeUsageHandler)
   }
 
   internal companion object {

--- a/src/main/kotlin/com/autonomousapps/extension/TypeUsageHandler.kt
+++ b/src/main/kotlin/com/autonomousapps/extension/TypeUsageHandler.kt
@@ -1,0 +1,94 @@
+// Copyright (c) 2025. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.extension
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.SetProperty
+import javax.inject.Inject
+
+/**
+ * Configuration for type usage analysis filtering.
+ *
+ * Example usage:
+ * ```
+ * dependencyAnalysis {
+ *   typeUsage {
+ *     excludePackages("kotlin.jvm.internal", "android")
+ *     excludeTypes("kotlin.Unit", "dagger.internal.Factory")
+ *     excludeRegex(".*_Factory$", ".*Companion$")
+ *   }
+ * }
+ * ```
+ */
+public abstract class TypeUsageHandler @Inject constructor(
+  objects: ObjectFactory
+) {
+
+  // Excluded package prefixes
+  internal val excludedPackages: SetProperty<String> = objects.setProperty(String::class.java)
+    .convention(setOf(
+      "kotlin.jvm.internal",
+      "androidx.compose.runtime.internal",
+      "kotlin.jvm.functions",
+      "android"
+    ))
+
+  // Excluded specific types
+  internal val excludedTypes: SetProperty<String> = objects.setProperty(String::class.java)
+    .convention(setOf(
+      "kotlin.Unit",
+      "kotlin.coroutines.Continuation",
+      "kotlin.reflect.KClass",
+      "kotlin.Lazy",
+      "dagger.internal.Factory"
+    ))
+
+  // Regex patterns for flexible matching
+  internal val excludedRegexPatterns: ListProperty<String> = objects.listProperty(String::class.java)
+    .convention(listOf(
+      "^anvil\\.hint\\..*",
+      ".*_Factory$",
+      ".*_Factory\\$.*",
+      ".*_MembersInjector$",
+      ".*_MembersInjector\\$.*"
+    ))
+
+  /**
+   * Exclude types by package prefix.
+   *
+   * Example:
+   * ```
+   * excludePackages("com.example.internal", "kotlin.jvm.internal")
+   * ```
+   */
+  public fun excludePackages(vararg packages: String) {
+    excludedPackages.addAll(packages.toList())
+  }
+
+  /**
+   * Exclude specific types by fully-qualified name.
+   *
+   * Example:
+   * ```
+   * excludeTypes("kotlin.Unit", "com.example.GeneratedClass")
+   * ```
+   */
+  public fun excludeTypes(vararg types: String) {
+    excludedTypes.addAll(types.toList())
+  }
+
+  /**
+   * Exclude types matching regex patterns.
+   *
+   * Example:
+   * ```
+   * excludeRegex(".*Companion$", ".*\\.internal\\..*")
+   * ```
+   */
+  public fun excludeRegex(
+    @org.intellij.lang.annotations.Language("RegExp") vararg patterns: String
+  ) {
+    excludedRegexPatterns.addAll(patterns.toList())
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/extension/TypeUsageHandler.kt
+++ b/src/main/kotlin/com/autonomousapps/extension/TypeUsageHandler.kt
@@ -27,32 +27,12 @@ public abstract class TypeUsageHandler @Inject constructor(
 
   // Excluded package prefixes
   internal val excludedPackages: SetProperty<String> = objects.setProperty(String::class.java)
-    .convention(setOf(
-      "kotlin.jvm.internal",
-      "androidx.compose.runtime.internal",
-      "kotlin.jvm.functions",
-      "android"
-    ))
 
   // Excluded specific types
   internal val excludedTypes: SetProperty<String> = objects.setProperty(String::class.java)
-    .convention(setOf(
-      "kotlin.Unit",
-      "kotlin.coroutines.Continuation",
-      "kotlin.reflect.KClass",
-      "kotlin.Lazy",
-      "dagger.internal.Factory"
-    ))
 
   // Regex patterns for flexible matching
   internal val excludedRegexPatterns: ListProperty<String> = objects.listProperty(String::class.java)
-    .convention(listOf(
-      "^anvil\\.hint\\..*",
-      ".*_Factory$",
-      ".*_Factory\\$.*",
-      ".*_MembersInjector$",
-      ".*_MembersInjector\\$.*"
-    ))
 
   /**
    * Exclude types by package prefix.
@@ -63,6 +43,7 @@ public abstract class TypeUsageHandler @Inject constructor(
    * ```
    */
   public fun excludePackages(vararg packages: String) {
+    require(packages.isNotEmpty()) { "Must provide at least one package to exclude." }
     excludedPackages.addAll(packages.toList())
   }
 
@@ -75,6 +56,7 @@ public abstract class TypeUsageHandler @Inject constructor(
    * ```
    */
   public fun excludeTypes(vararg types: String) {
+    require(types.isNotEmpty()) { "Must provide at least one type to exclude." }
     excludedTypes.addAll(types.toList())
   }
 
@@ -89,6 +71,7 @@ public abstract class TypeUsageHandler @Inject constructor(
   public fun excludeRegex(
     @org.intellij.lang.annotations.Language("RegExp") vararg patterns: String
   ) {
+    require(patterns.isNotEmpty()) { "Must provide at least one pattern to exclude." }
     excludedRegexPatterns.addAll(patterns.toList())
   }
 }

--- a/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
@@ -140,4 +140,4 @@ public fun getDuplicateDependenciesReport(): String = "$ROOT_DIR/duplicate-depen
 public fun getAllLibsVersionsTomlPath(): String = "$ROOT_DIR/allLibs.versions.toml"
 public fun getResolvedDependenciesReport(): String = "$ROOT_DIR/resolved-dependencies-report.txt"
 public fun getResolvedVersionsTomlPath(): String = "$ROOT_DIR/resolvedAllLibs.versions.toml"
-public fun getTypeUsagePath(variantName: String = "main"): String = "$ROOT_DIR/$variantName/intermediates/type-usage.json"
+public fun getTypeUsagePath(variantName: String = "main"): String = "$ROOT_DIR/$variantName/type-usage.json"

--- a/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
@@ -50,6 +50,7 @@ internal class OutputPaths(
   val explodingBytecodePath = file("${intermediatesDir}/exploding-bytecode.json")
   val syntheticProjectPath = file("${intermediatesDir}/synthetic-project.json")
   val dependencyTraceReportPath = file("${variantDirectory}/dependency-trace-report.json")
+  val typeUsagePath = file("${variantDirectory}/type-usage.json")
   val androidScorePath = file("${variantDirectory}/android-score.json")
 
   /*
@@ -139,3 +140,4 @@ public fun getDuplicateDependenciesReport(): String = "$ROOT_DIR/duplicate-depen
 public fun getAllLibsVersionsTomlPath(): String = "$ROOT_DIR/allLibs.versions.toml"
 public fun getResolvedDependenciesReport(): String = "$ROOT_DIR/resolved-dependencies-report.txt"
 public fun getResolvedVersionsTomlPath(): String = "$ROOT_DIR/resolvedAllLibs.versions.toml"
+public fun getTypeUsagePath(variantName: String = "main"): String = "$ROOT_DIR/$variantName/intermediates/type-usage.json"

--- a/src/main/kotlin/com/autonomousapps/internal/utils/strings/strings.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/strings/strings.kt
@@ -32,3 +32,7 @@ internal fun String.replaceExceptLast(oldValue: String, newValue: String, ignore
 
   return stringBuilder.append(this, i, length).toString()
 }
+
+internal fun String.ensureSuffix(suffix: String): String {
+  return if (endsWith(suffix)) this else "$this$suffix"
+}

--- a/src/main/kotlin/com/autonomousapps/model/ProjectTypeUsage.kt
+++ b/src/main/kotlin/com/autonomousapps/model/ProjectTypeUsage.kt
@@ -1,0 +1,61 @@
+// Copyright (c) 2025. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.model
+
+import com.squareup.moshi.JsonClass
+
+/**
+ * Type usage information for a single project.
+ *
+ * This report shows which types (classes/interfaces) are used from each dependency,
+ * enabling coupling analysis and complexity metrics.
+ */
+@JsonClass(generateAdapter = false)
+public data class ProjectTypeUsage(
+  /** The project path (e.g., ":app", ":feature-home"). */
+  val projectPath: String,
+
+  /** Summary statistics. */
+  val summary: TypeUsageSummary,
+
+  /** Types defined in this project that are used by itself. Map: className -> usageCount. */
+  val internal: Map<String, Int>,
+
+  /** Types used from project dependencies (other modules). Map: coordinates -> (className -> usageCount). */
+  val projectDependencies: Map<String, Map<String, Int>>,
+
+  /** Types used from external library dependencies. Map: coordinates -> (className -> usageCount). */
+  val libraryDependencies: Map<String, Map<String, Int>>,
+) : Comparable<ProjectTypeUsage> {
+
+  override fun compareTo(other: ProjectTypeUsage): Int = projectPath.compareTo(other.projectPath)
+
+  /**
+   * Returns true if there are no usages tracked.
+   */
+  public fun isEmpty(): Boolean =
+    internal.isEmpty() &&
+    projectDependencies.isEmpty() &&
+    libraryDependencies.isEmpty()
+}
+
+/**
+ * Summary statistics about type usage in a project.
+ */
+@JsonClass(generateAdapter = false)
+public data class TypeUsageSummary(
+  /** Total number of unique types used (internal + external). */
+  val totalTypes: Int,
+
+  /** Total number of source files analyzed. */
+  val totalFiles: Int,
+
+  /** Number of types defined and used within this project. */
+  val internalTypes: Int,
+
+  /** Number of project dependencies (other modules). */
+  val projectDependencies: Int,
+
+  /** Number of external library dependencies. */
+  val libraryDependencies: Int,
+)

--- a/src/main/kotlin/com/autonomousapps/model/ProjectTypeUsage.kt
+++ b/src/main/kotlin/com/autonomousapps/model/ProjectTypeUsage.kt
@@ -21,14 +21,15 @@ public data class ProjectTypeUsage(
   /** Types defined in this project that are used by itself. Map: className -> usageCount. */
   val internal: Map<String, Int>,
 
-  /** Types used from project dependencies (other modules). Map: coordinates -> (className -> usageCount). */
+  /** Types used from project dependencies (other modules). Map: dependencyIdentifier -> (className -> usageCount). */
   val projectDependencies: Map<String, Map<String, Int>>,
 
-  /** Types used from external library dependencies. Map: coordinates -> (className -> usageCount). */
+  /** Types used from external library dependencies. Map: dependencyIdentifier -> (className -> usageCount). */
   val libraryDependencies: Map<String, Map<String, Int>>,
-) : Comparable<ProjectTypeUsage> {
 
-  override fun compareTo(other: ProjectTypeUsage): Int = projectPath.compareTo(other.projectPath)
+  /** Types used that could not be resolved to any dependency. Map: className -> usageCount. */
+  val unknownDependencies: Map<String, Int> = emptyMap(),
+) {
 
   /**
    * Returns true if there are no usages tracked.

--- a/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
@@ -1027,20 +1027,22 @@ internal class ProjectPlugin(private val project: Project) {
       duplicateClassesRuntime = duplicateClassesRuntime,
     )
 
+    // TODO(tsr): push this into DependencyAnalyzer similar to above
     // Computes type-level usage statistics for complexity analysis.
-    val computeTypeUsageTask = tasks.register("computeTypeUsage${dependencyAnalyzer.taskNameSuffix}", ComputeTypeUsageTask::class.java) { t ->
-      t.projectPath.set(path)
-      t.buildPath.set(buildPath(dependencyAnalyzer.compileConfigurationName))
-      t.syntheticProject.set(synthesizeProjectViewTask.flatMap { it.output })
-      t.explodedJars.set(explodeJarTask.flatMap { it.output })
+    val computeTypeUsageTask =
+      tasks.register("computeTypeUsage${dependencyAnalyzer.taskNameSuffix}", ComputeTypeUsageTask::class.java) { t ->
+        t.projectPath.set(path)
+        t.buildPath.set(buildPath(dependencyAnalyzer.compileConfigurationName))
+        t.syntheticProject.set(synthesizeProjectViewTask.flatMap { it.output })
+        t.explodedJars.set(explodeJarTask.flatMap { it.output })
 
-      // Configuration from extension
-      t.excludedPackages.set(dagpExtension.typeUsageHandler.excludedPackages)
-      t.excludedTypes.set(dagpExtension.typeUsageHandler.excludedTypes)
-      t.excludedRegexPatterns.set(dagpExtension.typeUsageHandler.excludedRegexPatterns)
+        // Configuration from extension
+        t.excludedPackages.set(dagpExtension.typeUsageHandler.excludedPackages)
+        t.excludedTypes.set(dagpExtension.typeUsageHandler.excludedTypes)
+        t.excludedRegexPatterns.set(dagpExtension.typeUsageHandler.excludedRegexPatterns)
 
-      t.output.set(dependencyAnalyzer.outputPaths.typeUsagePath)
-    }
+        t.output.set(dependencyAnalyzer.outputPaths.typeUsagePath)
+      }
     storeTypeUsageOutput(dependencyAnalyzer.taskNameSuffix, computeTypeUsageTask.flatMap { it.output })
 
     // Null for JVM projects

--- a/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
@@ -1027,6 +1027,21 @@ internal class ProjectPlugin(private val project: Project) {
       duplicateClassesRuntime = duplicateClassesRuntime,
     )
 
+    // Computes type-level usage statistics for complexity analysis.
+    val computeTypeUsageTask = tasks.register("computeTypeUsage${dependencyAnalyzer.taskNameSuffix}", ComputeTypeUsageTask::class.java) { t ->
+      t.projectPath.set(path)
+      t.syntheticProject.set(synthesizeProjectViewTask.flatMap { it.output })
+      t.explodedJars.set(explodeJarTask.flatMap { it.output })
+
+      // Configuration from extension
+      t.excludedPackages.set(dagpExtension.typeUsageHandler.excludedPackages)
+      t.excludedTypes.set(dagpExtension.typeUsageHandler.excludedTypes)
+      t.excludedRegexPatterns.set(dagpExtension.typeUsageHandler.excludedRegexPatterns)
+
+      t.output.set(dependencyAnalyzer.outputPaths.typeUsagePath)
+    }
+    storeTypeUsageOutput(computeTypeUsageTask.flatMap { it.output })
+
     // Null for JVM projects
     val androidScoreTask = dependencyAnalyzer.registerAndroidScoreTask(
       synthesizeDependenciesTask,
@@ -1230,6 +1245,11 @@ internal class ProjectPlugin(private val project: Project) {
   /** Stores advice output in either root extension or subproject extension. */
   private fun storeAdviceOutput(advice: Provider<RegularFile>) {
     dagpExtension.storeAdviceOutput(advice)
+  }
+
+  /** Stores type usage output in either root extension or subproject extension. */
+  private fun storeTypeUsageOutput(typeUsage: Provider<RegularFile>) {
+    dagpExtension.storeTypeUsageOutput(typeUsage)
   }
 
   private class JavaSources(project: Project, dagpExtension: AbstractExtension) {

--- a/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
@@ -1030,6 +1030,7 @@ internal class ProjectPlugin(private val project: Project) {
     // Computes type-level usage statistics for complexity analysis.
     val computeTypeUsageTask = tasks.register("computeTypeUsage${dependencyAnalyzer.taskNameSuffix}", ComputeTypeUsageTask::class.java) { t ->
       t.projectPath.set(path)
+      t.buildPath.set(buildPath(dependencyAnalyzer.compileConfigurationName))
       t.syntheticProject.set(synthesizeProjectViewTask.flatMap { it.output })
       t.explodedJars.set(explodeJarTask.flatMap { it.output })
 
@@ -1040,7 +1041,7 @@ internal class ProjectPlugin(private val project: Project) {
 
       t.output.set(dependencyAnalyzer.outputPaths.typeUsagePath)
     }
-    storeTypeUsageOutput(computeTypeUsageTask.flatMap { it.output })
+    storeTypeUsageOutput(dependencyAnalyzer.taskNameSuffix, computeTypeUsageTask.flatMap { it.output })
 
     // Null for JVM projects
     val androidScoreTask = dependencyAnalyzer.registerAndroidScoreTask(
@@ -1248,8 +1249,8 @@ internal class ProjectPlugin(private val project: Project) {
   }
 
   /** Stores type usage output in either root extension or subproject extension. */
-  private fun storeTypeUsageOutput(typeUsage: Provider<RegularFile>) {
-    dagpExtension.storeTypeUsageOutput(typeUsage)
+  private fun storeTypeUsageOutput(variantName: String, typeUsage: Provider<RegularFile>) {
+    dagpExtension.storeTypeUsageOutput(variantName, typeUsage)
   }
 
   private class JavaSources(project: Project, dagpExtension: AbstractExtension) {

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeTypeUsageTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeTypeUsageTask.kt
@@ -1,0 +1,203 @@
+// Copyright (c) 2025. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.tasks
+
+import com.autonomousapps.internal.utils.bufferWriteJson
+import com.autonomousapps.internal.utils.fromJson
+import com.autonomousapps.internal.utils.getAndDelete
+import com.autonomousapps.internal.utils.getJsonListAdapter
+import com.autonomousapps.model.ProjectTypeUsage
+import com.autonomousapps.model.TypeUsageSummary
+import com.autonomousapps.model.internal.intermediates.producer.ExplodedJar
+import com.autonomousapps.model.internal.ProjectVariant
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.*
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import org.gradle.workers.WorkerExecutor
+import okio.buffer
+import okio.source
+import java.io.File
+import java.util.zip.GZIPInputStream
+import javax.inject.Inject
+
+@CacheableTask
+public abstract class ComputeTypeUsageTask @Inject constructor(
+  private val workerExecutor: WorkerExecutor,
+) : DefaultTask() {
+
+  init {
+    description = "Computes type-level dependency usage"
+  }
+
+  @get:Input
+  public abstract val projectPath: Property<String>
+
+  @get:PathSensitive(PathSensitivity.NONE)
+  @get:InputFile
+  public abstract val syntheticProject: RegularFileProperty
+
+  @get:PathSensitive(PathSensitivity.NONE)
+  @get:InputFile
+  public abstract val explodedJars: RegularFileProperty
+
+  @get:Input
+  public abstract val excludedPackages: SetProperty<String>
+
+  @get:Input
+  public abstract val excludedTypes: SetProperty<String>
+
+  @get:Input
+  public abstract val excludedRegexPatterns: ListProperty<String>
+
+  @get:OutputFile
+  public abstract val output: RegularFileProperty
+
+  @TaskAction
+  public fun action() {
+    workerExecutor.noIsolation().submit(ComputeTypeUsageAction::class.java) {
+      it.projectPath.set(projectPath)
+      it.syntheticProject.set(syntheticProject)
+      it.explodedJars.set(explodedJars)
+      it.excludedPackages.set(excludedPackages)
+      it.excludedTypes.set(excludedTypes)
+      it.excludedRegexPatterns.set(excludedRegexPatterns)
+      it.output.set(output)
+    }
+  }
+
+  public interface ComputeTypeUsageParameters : WorkParameters {
+    public val projectPath: Property<String>
+    public val syntheticProject: RegularFileProperty
+    public val explodedJars: RegularFileProperty
+    public val excludedPackages: SetProperty<String>
+    public val excludedTypes: SetProperty<String>
+    public val excludedRegexPatterns: ListProperty<String>
+    public val output: RegularFileProperty
+  }
+
+  public abstract class ComputeTypeUsageAction : WorkAction<ComputeTypeUsageParameters> {
+
+    override fun execute() {
+      val output = parameters.output.getAndDelete()
+
+      // 1. Load data
+      val project = parameters.syntheticProject.fromJson<ProjectVariant>()
+      val classToCoords = buildClassIndex(parameters.explodedJars.get().asFile)
+
+      // 2. Build filter
+      val filter = TypeFilter(
+        excludedPackages = parameters.excludedPackages.get(),
+        excludedTypes = parameters.excludedTypes.get(),
+        excludedRegexPatterns = parameters.excludedRegexPatterns.get()
+      )
+
+      // 3. Analyze usage
+      val analyzer = TypeUsageAnalyzer(project, classToCoords, filter)
+      val typeUsage = analyzer.analyze()
+
+      // 4. Write output
+      output.bufferWriteJson(typeUsage)
+    }
+
+    private fun buildClassIndex(explodedJarsFile: File): Map<String, String> {
+      if (!explodedJarsFile.exists()) return emptyMap()
+
+      val map = mutableMapOf<String, String>()
+
+      GZIPInputStream(explodedJarsFile.inputStream()).use { gzipStream ->
+        val explodedJars = gzipStream.source().buffer().use { bufferedSource ->
+          getJsonListAdapter<ExplodedJar>().fromJson(bufferedSource)!!
+        }
+
+        explodedJars.forEach { jar ->
+          // Normalize identifier to handle included builds (convert "build:project" to ":project")
+          val identifier = jar.coordinates.normalizedIdentifier(":")
+          jar.binaryClasses.forEach { binaryClass ->
+            map[binaryClass.className] = identifier
+          }
+        }
+      }
+
+      return map
+    }
+  }
+}
+
+private class TypeFilter(
+  val excludedPackages: Set<String>,
+  val excludedTypes: Set<String>,
+  excludedRegexPatterns: List<String>
+) {
+  private val compiledPatterns = excludedRegexPatterns.map { it.toRegex() }
+
+  fun shouldExclude(className: String): Boolean {
+    if (excludedTypes.contains(className)) return true
+    if (excludedPackages.any { className.startsWith("$it.") }) return true
+    if (compiledPatterns.any { it.matches(className) }) return true
+    return false
+  }
+}
+
+private class TypeUsageAnalyzer(
+  private val project: ProjectVariant,
+  private val classToCoords: Map<String, String>,
+  private val filter: TypeFilter
+) {
+  fun analyze(): ProjectTypeUsage {
+    val usageMap = mutableMapOf<String, MutableMap<String, Int>>()
+
+    // Get project's own class names for internal type detection
+    val projectClasses = project.classNames
+
+    // Count usage per class per dependency (both non-annotation and annotation classes)
+    project.codeSource.forEach { source ->
+      val allUsedClasses = source.usedNonAnnotationClasses + source.usedAnnotationClasses
+
+      allUsedClasses.forEach { className ->
+        if (filter.shouldExclude(className)) return@forEach
+
+        // Determine coordinates: check project classes first, then external
+        val coords = when {
+          projectClasses.contains(className) -> project.coordinates.identifier
+          else -> classToCoords[className] ?: "UNKNOWN"
+        }
+
+        usageMap
+          .getOrPut(coords) { mutableMapOf() }
+          .merge(className, 1, Int::plus)
+      }
+    }
+
+    // Categorize dependencies
+    val internal = mutableMapOf<String, Int>()
+    val projectDeps = mutableMapOf<String, Map<String, Int>>()
+    val libraryDeps = mutableMapOf<String, Map<String, Int>>()
+
+    usageMap.forEach { (coords, typeUsages) ->
+      when {
+        coords == project.coordinates.identifier -> internal.putAll(typeUsages)
+        coords.startsWith(":") -> projectDeps[coords] = typeUsages
+        coords != "UNKNOWN" -> libraryDeps[coords] = typeUsages
+      }
+    }
+
+    return ProjectTypeUsage(
+      projectPath = project.coordinates.identifier,
+      summary = TypeUsageSummary(
+        totalTypes = usageMap.values.sumOf { it.size },
+        totalFiles = project.codeSource.size,
+        internalTypes = internal.size,
+        projectDependencies = projectDeps.size,
+        libraryDependencies = libraryDeps.size
+      ),
+      internal = internal,
+      projectDependencies = projectDeps,
+      libraryDependencies = libraryDeps
+    )
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeTypeUsageTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeTypeUsageTask.kt
@@ -172,15 +172,15 @@ private class TypeUsageAnalyzer(
     }
 
     // Categorize dependencies
-    val internal = mutableMapOf<String, Int>()
-    val projectDeps = mutableMapOf<String, Map<String, Int>>()
-    val libraryDeps = mutableMapOf<String, Map<String, Int>>()
+    val internal = sortedMapOf<String, Int>()
+    val projectDeps = sortedMapOf<String, Map<String, Int>>()
+    val libraryDeps = sortedMapOf<String, Map<String, Int>>()
 
     usageMap.forEach { (coords, typeUsages) ->
       when (coords) {
         project.coordinates -> internal.putAll(typeUsages)
-        is ProjectCoordinates -> projectDeps[coords.identifier] = typeUsages
-        is ModuleCoordinates -> libraryDeps[coords.identifier] = typeUsages
+        is ProjectCoordinates -> projectDeps[coords.identifier] = typeUsages.toSortedMap()
+        is ModuleCoordinates -> libraryDeps[coords.identifier] = typeUsages.toSortedMap()
         else -> libraryDeps[coords.identifier] = typeUsages
       }
     }

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeTypeUsageTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeTypeUsageTask.kt
@@ -2,10 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.tasks
 
+import com.autonomousapps.internal.utils.strings.ensureSuffix
 import com.autonomousapps.internal.utils.bufferWriteJson
 import com.autonomousapps.internal.utils.fromJson
+import com.autonomousapps.internal.utils.fromJsonSet
 import com.autonomousapps.internal.utils.getAndDelete
-import com.autonomousapps.internal.utils.getJsonListAdapter
+import com.autonomousapps.model.Coordinates
+import com.autonomousapps.model.ModuleCoordinates
+import com.autonomousapps.model.ProjectCoordinates
 import com.autonomousapps.model.ProjectTypeUsage
 import com.autonomousapps.model.TypeUsageSummary
 import com.autonomousapps.model.internal.intermediates.producer.ExplodedJar
@@ -19,10 +23,6 @@ import org.gradle.api.tasks.*
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 import org.gradle.workers.WorkerExecutor
-import okio.buffer
-import okio.source
-import java.io.File
-import java.util.zip.GZIPInputStream
 import javax.inject.Inject
 
 @CacheableTask
@@ -36,6 +36,9 @@ public abstract class ComputeTypeUsageTask @Inject constructor(
 
   @get:Input
   public abstract val projectPath: Property<String>
+
+  @get:Input
+  public abstract val buildPath: Property<String>
 
   @get:PathSensitive(PathSensitivity.NONE)
   @get:InputFile
@@ -61,6 +64,7 @@ public abstract class ComputeTypeUsageTask @Inject constructor(
   public fun action() {
     workerExecutor.noIsolation().submit(ComputeTypeUsageAction::class.java) {
       it.projectPath.set(projectPath)
+      it.buildPath.set(buildPath)
       it.syntheticProject.set(syntheticProject)
       it.explodedJars.set(explodedJars)
       it.excludedPackages.set(excludedPackages)
@@ -72,6 +76,7 @@ public abstract class ComputeTypeUsageTask @Inject constructor(
 
   public interface ComputeTypeUsageParameters : WorkParameters {
     public val projectPath: Property<String>
+    public val buildPath: Property<String>
     public val syntheticProject: RegularFileProperty
     public val explodedJars: RegularFileProperty
     public val excludedPackages: SetProperty<String>
@@ -87,7 +92,7 @@ public abstract class ComputeTypeUsageTask @Inject constructor(
 
       // 1. Load data
       val project = parameters.syntheticProject.fromJson<ProjectVariant>()
-      val classToCoords = buildClassIndex(parameters.explodedJars.get().asFile)
+      val classToCoords = buildClassIndex()
 
       // 2. Build filter
       val filter = TypeFilter(
@@ -104,22 +109,14 @@ public abstract class ComputeTypeUsageTask @Inject constructor(
       output.bufferWriteJson(typeUsage)
     }
 
-    private fun buildClassIndex(explodedJarsFile: File): Map<String, String> {
-      if (!explodedJarsFile.exists()) return emptyMap()
+    private fun buildClassIndex(): Map<String, Coordinates> {
+      val explodedJars = parameters.explodedJars.fromJsonSet<ExplodedJar>(compressed = true)
 
-      val map = mutableMapOf<String, String>()
-
-      GZIPInputStream(explodedJarsFile.inputStream()).use { gzipStream ->
-        val explodedJars = gzipStream.source().buffer().use { bufferedSource ->
-          getJsonListAdapter<ExplodedJar>().fromJson(bufferedSource)!!
-        }
-
-        explodedJars.forEach { jar ->
-          // Normalize identifier to handle included builds (convert "build:project" to ":project")
-          val identifier = jar.coordinates.normalizedIdentifier(":")
-          jar.binaryClasses.forEach { binaryClass ->
-            map[binaryClass.className] = identifier
-          }
+      val map = mutableMapOf<String, Coordinates>()
+      explodedJars.forEach { jar ->
+        val coordinates = jar.coordinates.normalized(parameters.buildPath.get())
+        jar.binaryClasses.forEach { binaryClass ->
+          map[binaryClass.className] = coordinates
         }
       }
 
@@ -129,15 +126,16 @@ public abstract class ComputeTypeUsageTask @Inject constructor(
 }
 
 private class TypeFilter(
-  val excludedPackages: Set<String>,
+  excludedPackages: Set<String>,
   val excludedTypes: Set<String>,
   excludedRegexPatterns: List<String>
 ) {
+  private val normalizedPackages = excludedPackages.map { it.ensureSuffix(".") }.toSet()
   private val compiledPatterns = excludedRegexPatterns.map { it.toRegex() }
 
   fun shouldExclude(className: String): Boolean {
     if (excludedTypes.contains(className)) return true
-    if (excludedPackages.any { className.startsWith("$it.") }) return true
+    if (normalizedPackages.any { className.startsWith(it) }) return true
     if (compiledPatterns.any { it.matches(className) }) return true
     return false
   }
@@ -145,11 +143,12 @@ private class TypeFilter(
 
 private class TypeUsageAnalyzer(
   private val project: ProjectVariant,
-  private val classToCoords: Map<String, String>,
+  private val classToCoords: Map<String, Coordinates>,
   private val filter: TypeFilter
 ) {
   fun analyze(): ProjectTypeUsage {
-    val usageMap = mutableMapOf<String, MutableMap<String, Int>>()
+    val usageMap = mutableMapOf<Coordinates, MutableMap<String, Int>>()
+    val unknown = mutableMapOf<String, Int>()
 
     // Get project's own class names for internal type detection
     val projectClasses = project.classNames
@@ -158,18 +157,17 @@ private class TypeUsageAnalyzer(
     project.codeSource.forEach { source ->
       val allUsedClasses = source.usedNonAnnotationClasses + source.usedAnnotationClasses
 
-      allUsedClasses.forEach { className ->
-        if (filter.shouldExclude(className)) return@forEach
-
+      allUsedClasses.filter { !filter.shouldExclude(it) }.forEach { className ->
         // Determine coordinates: check project classes first, then external
-        val coords = when {
-          projectClasses.contains(className) -> project.coordinates.identifier
-          else -> classToCoords[className] ?: "UNKNOWN"
-        }
+        val coords = classToCoords[className]
 
-        usageMap
-          .getOrPut(coords) { mutableMapOf() }
-          .merge(className, 1, Int::plus)
+        if (coords != null || projectClasses.contains(className)) {
+          usageMap
+            .getOrPut(coords ?: project.coordinates) { mutableMapOf() }
+            .merge(className, 1, Int::plus)
+        } else {
+          unknown.merge(className, 1, Int::plus)
+        }
       }
     }
 
@@ -179,10 +177,11 @@ private class TypeUsageAnalyzer(
     val libraryDeps = mutableMapOf<String, Map<String, Int>>()
 
     usageMap.forEach { (coords, typeUsages) ->
-      when {
-        coords == project.coordinates.identifier -> internal.putAll(typeUsages)
-        coords.startsWith(":") -> projectDeps[coords] = typeUsages
-        coords != "UNKNOWN" -> libraryDeps[coords] = typeUsages
+      when (coords) {
+        project.coordinates -> internal.putAll(typeUsages)
+        is ProjectCoordinates -> projectDeps[coords.identifier] = typeUsages
+        is ModuleCoordinates -> libraryDeps[coords.identifier] = typeUsages
+        else -> libraryDeps[coords.identifier] = typeUsages
       }
     }
 
@@ -195,9 +194,10 @@ private class TypeUsageAnalyzer(
         projectDependencies = projectDeps.size,
         libraryDependencies = libraryDeps.size
       ),
-      internal = internal,
-      projectDependencies = projectDeps,
-      libraryDependencies = libraryDeps
+      internal = internal.toSortedMap(),
+      projectDependencies = projectDeps.toSortedMap(),
+      libraryDependencies = libraryDeps.toSortedMap(),
+      unknownDependencies = unknown.toSortedMap()
     )
   }
 }


### PR DESCRIPTION
### Summary 
A new task to build type usage report (#1637).

Introducing a new `ComputeTypeUsageTask` task. It generates `type-usage.json` reporting which types (classes) your code uses from each dependency. Designed for analyzing module dependency usage and complexity.
```json
{
  "projectPath": ":app",
  "summary": {
    "totalTypes": 245,
    "totalFiles": 67,
    "internalTypes": 12,
    "projectDependencies": 3,
    "libraryDependencies": 18
  },
  "internal": {
    "com.example.MyClass": 5
  },
  "projectDependencies": {
    ":core": {
      "com.example.core.Utils": 2
    }
  },
  "libraryDependencies": {
    "org.apache.commons:commons-collections4": {
      "org.apache.commons.collections4.bag.HashBag": 3
    }
  }
}
```



**Usage:**
```bash
./gradlew computeTypeUsageMain
```

**Output location:**
```
build/reports/dependency-analysis/main/intermediates/type-usage.json
```

**Configuration:**
```kotlin
dependencyAnalysis {
  typeUsage {
    excludePackages("kotlin.jvm.internal")
    excludeTypes("kotlin.Unit")
    excludeRegex(".*_Factory$", ".*Companion$")
  }
}
```

**Key design decisions:**
- Task runs **on-demand only** (not part of `buildHealth` or other critical paths)
- Uses existing intermediate files (`synthetic-project.json`, `exploded-jars.json.gz`)
- Tracks both annotation and non-annotation class usage
- Sensible defaults exclude common generated/internal types
