### PR TITLE
Remove dependency to 'javax.inject'

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -55,11 +55,13 @@ gradlePlugin {
 }
 
 dependencies {
-  api(libs.javax.inject)
   api(libs.mavenPublishPlugin)
 
   implementation(platform(libs.kotlin.bom))
-  implementation(libs.dependencyAnalysisPlugin)
+  implementation(libs.dependencyAnalysisPlugin) {
+    // TODO can be removed after plugin update to 3.5.2
+    exclude(group = "javax.inject")
+  }
   implementation(libs.gradleTestKitPlugin)
   implementation(libs.gradle.publish.plugin) {
     because("For extending Gradle Plugin-Publish Plugin functionality")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -107,7 +107,6 @@ gradleTestKitSupport {
 }
 
 dependencies {
-  api(libs.javax.inject)
   api(libs.moshi.core)
   api(libs.moshix.sealed.runtime)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,6 @@ gradleTestKitPlugin = { module = "com.autonomousapps:gradle-testkit-plugin", ver
 grammar = { module = "com.autonomousapps:gradle-script-grammar", version.ref = "grammar" }
 groovy = { module = "org.apache.groovy:groovy", version.ref = "groovy" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
-javax-inject = "javax.inject:javax.inject:1"
 jspecify = { module = "org.jspecify:jspecify", version.ref = "jspecify" }
 junit-api = { module = "org.junit.jupiter:junit-jupiter-api" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }


### PR DESCRIPTION
This is packaged in the Gradle API already and thus the dependency adds duplicated classes to the plugin compilation and runtime classpaths.

I discovered this by running dependency analysis on a Gradle plugin build. It prompted me to add the dependency to `javax.inject`, although I did not have the dependency before. I use it from the Gradle API directly. Other Gradle plugins also do not have this dependency, although they probably all use `@Inject` somewhere.