### PR TITLE
feat: Expose useParenthesesForGroovy configuration for Groovy DSL syntax.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/extension/DependenciesHandler.kt
+++ b/src/main/kotlin/com/autonomousapps/extension/DependenciesHandler.kt
@@ -37,6 +37,9 @@ import javax.inject.Inject
  *     // Set to true to instruct the plugin to not suggest replacing -ktx dependencies with non-ktx dependencies.
  *     ignoreKtx(<true|false>) // default: false
  *
+ *     // Set to true to use parentheses syntax for Groovy build script dependencies.
+ *     useParenthesesForGroovy(<true|false>) // default: false
+ *
  *     bundle("kotlin-stdlib") {
  *       // 1: include all in group as a single logical dependency
  *       includeGroup("org.jetbrains.kotlin")
@@ -132,6 +135,16 @@ public abstract class DependenciesHandler @Inject constructor(objects: ObjectFac
   public fun ignoreKtx(ignore: Boolean) {
     ignoreKtx.set(ignore)
     ignoreKtx.disallowChanges()
+  }
+
+  internal val useParenthesesForGroovy = objects.property(Boolean::class.java).also {
+    it.convention(false)
+  }
+
+  @Suppress("unused") // public API
+  public fun useParenthesesForGroovy(use: Boolean) {
+    useParenthesesForGroovy.set(use)
+    useParenthesesForGroovy.disallowChanges()
   }
 
   public fun bundle(name: String, action: Action<BundleHandler>) {

--- a/src/main/kotlin/com/autonomousapps/internal/advice/ProjectHealthConsoleReportBuilder.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/advice/ProjectHealthConsoleReportBuilder.kt
@@ -20,6 +20,7 @@ internal class ProjectHealthConsoleReportBuilder(
   /** Customize how dependencies are printed. */
   dependencyMap: ((String) -> String?)? = null,
   useTypesafeProjectAccessors: Boolean,
+  useParenthesesForGroovy: Boolean = false,
 ) {
 
   val text: String
@@ -31,6 +32,7 @@ internal class ProjectHealthConsoleReportBuilder(
     projectType = projectMetadata.projectType,
     dependencyMap = dependencyMap,
     useTypesafeProjectAccessors = useTypesafeProjectAccessors,
+    useParenthesesForGroovy = useParenthesesForGroovy,
   )
   private var shouldPrintNewLine = false
 

--- a/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
@@ -1098,6 +1098,7 @@ internal class ProjectPlugin(private val project: Project) {
         t.dslKind.set(DslKind.from(buildFile))
         t.dependencyMap.set(dagpExtension.dependenciesHandler.map)
         t.useTypesafeProjectAccessors.set(dagpExtension.useTypesafeProjectAccessors)
+        t.useParenthesesForGroovy.set(dagpExtension.dependenciesHandler.useParenthesesForGroovy)
         t.output.set(paths.consoleReportPath)
       }
 
@@ -1124,6 +1125,7 @@ internal class ProjectPlugin(private val project: Project) {
       t.projectMetadata.set(writeProjectMetadata.flatMap { it.output })
       t.dependencyMap.set(dagpExtension.dependenciesHandler.map)
       t.useTypesafeProjectAccessors.set(dagpExtension.useTypesafeProjectAccessors)
+      t.useParenthesesForGroovy.set(dagpExtension.dependenciesHandler.useParenthesesForGroovy)
     }
 
     resolveExternalDependenciesTask = tasks.register("resolveExternalDependencies")

--- a/src/main/kotlin/com/autonomousapps/subplugin/RootPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/RootPlugin.kt
@@ -116,6 +116,7 @@ internal class RootPlugin(private val project: Project) {
       t.dslKind.set(DslKind.from(buildFile))
       t.dependencyMap.set(dagpExtension.dependenciesHandler.map)
       t.useTypesafeProjectAccessors.set(dagpExtension.useTypesafeProjectAccessors)
+      t.useParenthesesForGroovy.set(dagpExtension.dependenciesHandler.useParenthesesForGroovy)
 
       t.output.set(paths.buildHealthPath)
       t.consoleOutput.set(paths.consoleReportPath)

--- a/src/main/kotlin/com/autonomousapps/tasks/GenerateBuildHealthTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/GenerateBuildHealthTask.kt
@@ -57,6 +57,9 @@ public abstract class GenerateBuildHealthTask : DefaultTask() {
   @get:Input
   public abstract val useTypesafeProjectAccessors: Property<Boolean>
 
+  @get:Input
+  public abstract val useParenthesesForGroovy: Property<Boolean>
+
   @get:OutputFile
   public abstract val output: RegularFileProperty
 
@@ -119,6 +122,7 @@ public abstract class GenerateBuildHealthTask : DefaultTask() {
             dslKind = dslKind.get(),
             dependencyMap = dependencyMap.get().toLambda(),
             useTypesafeProjectAccessors = useTypesafeProjectAccessors.get(),
+            useParenthesesForGroovy = useParenthesesForGroovy.get(),
           ).text
           val projectPath = if (projectAdvice.projectPath == ":") "root project" else projectAdvice.projectPath
           consoleOutput.appendText("Advice for ${projectPath}\n$report")

--- a/src/main/kotlin/com/autonomousapps/tasks/GenerateProjectHealthReportTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/GenerateProjectHealthReportTask.kt
@@ -53,6 +53,9 @@ public abstract class GenerateProjectHealthReportTask @Inject constructor(
   @get:Input
   public abstract val useTypesafeProjectAccessors: Property<Boolean>
 
+  @get:Input
+  public abstract val useParenthesesForGroovy: Property<Boolean>
+
   @get:OutputFile
   public abstract val output: RegularFileProperty
 
@@ -64,6 +67,7 @@ public abstract class GenerateProjectHealthReportTask @Inject constructor(
       it.dslKind.set(dslKind)
       it.dependencyMap.set(dependencyMap)
       it.useTypesafeProjectAccessors.set(useTypesafeProjectAccessors)
+      it.useParenthesesForGroovy.set(useParenthesesForGroovy)
       it.output.set(output)
     }
   }
@@ -75,6 +79,7 @@ public abstract class GenerateProjectHealthReportTask @Inject constructor(
     public val dslKind: Property<DslKind>
     public val dependencyMap: MapProperty<String, String>
     public val useTypesafeProjectAccessors: Property<Boolean>
+    public val useParenthesesForGroovy: Property<Boolean>
     public val output: RegularFileProperty
   }
 
@@ -93,6 +98,7 @@ public abstract class GenerateProjectHealthReportTask @Inject constructor(
         dslKind = parameters.dslKind.get(),
         dependencyMap = parameters.dependencyMap.get().toLambda(),
         useTypesafeProjectAccessors = parameters.useTypesafeProjectAccessors.get(),
+        useParenthesesForGroovy = parameters.useParenthesesForGroovy.get(),
       ).text
 
       output.writeText(consoleText)

--- a/src/main/kotlin/com/autonomousapps/tasks/RewriteTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/RewriteTask.kt
@@ -48,6 +48,9 @@ public abstract class RewriteTask : DefaultTask() {
   @get:Input
   public abstract val useTypesafeProjectAccessors: Property<Boolean>
 
+  @get:Input
+  public abstract val useParenthesesForGroovy: Property<Boolean>
+
   @get:Optional
   @get:Input
   @get:Option(
@@ -80,6 +83,7 @@ public abstract class RewriteTask : DefaultTask() {
         projectType = projectMetadata.projectType,
         dependencyMap = map.toLambda(),
         useTypesafeProjectAccessors = useTypesafeProjectAccessors.get(),
+        useParenthesesForGroovy = useParenthesesForGroovy.get(),
       ),
       reversedDependencyMap = createReversedDependencyMap(map, useTypesafeProjectAccessors.get())
     )


### PR DESCRIPTION
## Problem
In https://github.com/autonomousapps/dependency-analysis-gradle-plugin/pull/1522 `useParenthesesForGroovy` param was added to `AdvicePrinter` to support parentheses syntax in Groovy build scripts. 
From 1522 PR description: 
```
// Space syntax (default)
implementation projects.myModule   
api projects.common.viewmodels  

// Parentheses syntax (when useParenthesesForGroovy = true)
implementation(projects.myModule) 
api(projects.common.viewmodels) 
```

The parameter existed in the code but it was never exposed as a configurable option - it always defaulted to false. 
For proof, here's a search in repository: https://github.com/search?q=repo%3Aautonomousapps%2Fdependency-analysis-gradle-plugin%20useParenthesesForGroovy&type=code

This meant that even if a project consistently used parentheses syntax in Groovy build scripts:
```
dependencies {
  implementation(libs.core)
  api(projects.myModule)
}
```

The plugin's advice output (projectHealth, buildHealth) and build script rewriting (fixDependencies) would always produce space: 
```
implementation libs.core
api projects.myModule
```

## How I propose to configure

`useParenthesesForGroovy` flag is now configurable via the `structure {}` DSL block.

Configure in settings.gradle[.kts] or root build.gradle[.kts]:
```
dependencyAnalysis {
  structure {
    useParenthesesForGroovy(true)
  }
}
```