### PR TITLE
fix: don't attempt to suggest upgrading an undeclared 'parent' dependency of a KMP dependency.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/Bundles.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/Bundles.kt
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.internal
 
-import com.autonomousapps.model.internal.ProjectType
 import com.autonomousapps.extension.DependenciesHandler.SerializableBundles
 import com.autonomousapps.graph.Graphs.children
 import com.autonomousapps.graph.Graphs.reachableNodes
@@ -10,6 +9,7 @@ import com.autonomousapps.internal.utils.filterToOrderedSet
 import com.autonomousapps.model.*
 import com.autonomousapps.model.Coordinates.Companion.copy
 import com.autonomousapps.model.internal.DependencyGraphView
+import com.autonomousapps.model.internal.ProjectType
 import com.autonomousapps.model.internal.declaration.Bucket
 import com.autonomousapps.model.internal.declaration.ConfigurationNames
 import com.autonomousapps.model.internal.declaration.Declaration
@@ -78,7 +78,7 @@ internal class Bundles private constructor(
    * @see [maybePrimary]
    */
   fun maybeParent(addAdvice: Advice, originalCoordinates: Coordinates): Advice {
-    check(addAdvice.isAdd()) { "Must be add-advice" }
+    check(addAdvice.isAdd()) { "Must be add-advice. Was '$addAdvice'." }
 
     val parent = findParentInBundle(originalCoordinates)
       ?: error("No parent for $originalCoordinates. Check 'hasParentInBundle()' before calling this method.")
@@ -91,6 +91,13 @@ internal class Bundles private constructor(
 
     // Find all declarations for this dependency. E.g., ["commonMainImplementation", "jvmMainImplementation"].
     val parentDeclarations = declarations.filterToOrderedSet { decl -> decl.identifier == parentCoordinates.identifier }
+
+    // This can happen when the parent dependency is added by a plugin (no declarations). We can't do anything here.
+    // See https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1653.
+    if (parentDeclarations.isEmpty()) {
+      // nb: the only caller of this method (at time of writing!) will throw away the advice if it is unchanged.
+      return addAdvice
+    }
 
     // Pick the "highest" one (api > implementation > everything else)
     val declarationSelector: (Declaration) -> Int = { declaration ->

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeAdviceTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeAdviceTask.kt
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.tasks
 
-import com.autonomousapps.model.internal.ProjectType
 import com.autonomousapps.extension.DependenciesHandler
 import com.autonomousapps.internal.Bundles
 import com.autonomousapps.internal.UsageContainer
@@ -11,6 +10,7 @@ import com.autonomousapps.internal.transform.StandardTransform
 import com.autonomousapps.internal.utils.*
 import com.autonomousapps.model.*
 import com.autonomousapps.model.internal.DependencyGraphView
+import com.autonomousapps.model.internal.ProjectType
 import com.autonomousapps.model.internal.declaration.Bucket
 import com.autonomousapps.model.internal.declaration.ConfigurationNames
 import com.autonomousapps.model.internal.declaration.Declaration
@@ -209,7 +209,6 @@ public abstract class ComputeAdviceTask @Inject constructor(
         annotationProcessorUsages = annotationProcessorUsages,
         declarations = declarations,
         dependencyGraph = dependencyGraph,
-        supportedSourceSets = supportedSourceSets,
         explicitSourceSets = explicitSourceSets,
         projectType = projectType,
         configurationNames = configurationNames,
@@ -294,7 +293,6 @@ internal class DependencyAdviceBuilder(
   private val annotationProcessorUsages: Map<Coordinates, Set<Usage>>,
   private val declarations: Set<Declaration>,
   private val dependencyGraph: Map<String, DependencyGraphView>,
-  private val supportedSourceSets: Set<String>,
   private val explicitSourceSets: Set<String>,
   private val projectType: ProjectType,
   private val configurationNames: ConfigurationNames,
@@ -361,10 +359,10 @@ internal class DependencyAdviceBuilder(
           // is declared on a commonX configuration, and the "child" -jvm or -android dep needs to be upgraded.
           advice.isAdd() && bundles.hasParentInBundle(originalCoordinates) -> {
             val parent = bundles.findParentInBundle(originalCoordinates)!!
-            bundledTraces.add(BundleTrace.DeclaredParent(parent = parent, child = originalCoordinates))
 
             val parentAdvice = bundles.maybeParent(advice, originalCoordinates)
             if (parentAdvice != advice) {
+              bundledTraces.add(BundleTrace.DeclaredParent(parent = parent, child = originalCoordinates))
               parentAdvice
             } else {
               null

--- a/src/test/kotlin/com/autonomousapps/internal/BundlesTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/BundlesTest.kt
@@ -186,6 +186,52 @@ class BundlesTest {
       val expectedAdvice = Advice.ofChange(okio, "jvmMainImplementation", "jvmMainApi")
       assertThat(bundles.maybeParent(addAdvice, okioJvm)).isEqualTo(expectedAdvice)
     }
+
+    /**
+     * Metro (and other plugins) can add dependencies, meaning those dependencies are undeclared. When this happens, we
+     * can't recommend upgrading the _parent_ of a -jvm (etc.) dependency because the user has no control over that.
+     * This test validates that `bundles.maybeParent(addAdvice)` returns that same `addAdvice` in this scenario.
+     *
+     * @see <a href="https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1653">Issue 1653</a>.
+     */
+    @Test fun `does not transform change (jvmMainImplementation-jvmMainApi) for metro-runtime for kmp (implicit bundles)`() {
+      // Given a project that has a dependency graph with three nodes (itself, okio, and okio-jvm)
+      val consumer = ProjectCoordinates(":consumer", gvi)
+      val metroRuntime = ModuleCoordinates("dev.zacsweers.metro:runtime", "0.10.2", gvi)
+      val metroRuntimeJvm = ModuleCoordinates("dev.zacsweers.metro:runtime-jvm", "0.10.2", gvi)
+      val graph = newGraphFrom(
+        // :consumer -> metroRuntime -> metroRuntimeJvm
+        listOf(consumer to metroRuntime, metroRuntime to metroRuntimeJvm),
+        sourceKind = KmpSourceKind.JVM_MAIN,
+        configurationName = "jvmCompileClasspath",
+        graphKey = "jvmMain,CUSTOM_JVM,jvmCompileClasspath",
+      )
+
+      // no declarations (the dep is provided by a plugin!)
+      val declarations = emptySet<Declaration>()
+
+      // ...usages of project :consumer
+      val unused = Reason.Unused.intoSet()
+      val abi = Reason.Abi("Imports 1 class: dev.zacsweers.metro.ContributesTo").intoSet()
+      val metroRuntimeUsages = metroRuntime to usage(Bucket.NONE, KmpSourceKind.JVM_MAIN, reasons = unused).intoSet()
+      val metroRuntimeJvmUsages = metroRuntimeJvm to usage(Bucket.API, KmpSourceKind.JVM_MAIN, reasons = abi).intoSet()
+      val dependencyUsages = listOf(metroRuntimeUsages, metroRuntimeJvmUsages).toMap<Coordinates, Set<Usage>>()
+
+      // When we build the thing under test
+      val bundles = Bundles.of(
+        projectPath = ":consumer",
+        dependencyGraph = graph,
+        bundleRules = dependenciesHandler.serializableBundles(),
+        dependencyUsages = dependencyUsages,
+        declarations = declarations,
+        configurationNames = kmpConfigurationNames,
+        ignoreKtx = false
+      )
+
+      // Then the advice remains unchanged
+      val addAdvice = Advice.ofAdd(metroRuntimeJvm, "jvmMainApi")
+      assertThat(bundles.maybeParent(addAdvice, metroRuntimeJvm)).isEqualTo(addAdvice)
+    }
   }
 
   @Nested inner class Primary {


### PR DESCRIPTION
Resolves https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1653