### PR TITLE
test: android libs don't need a manifest.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AdviceFilterProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AdviceFilterProject.groovy
@@ -61,7 +61,7 @@ final class AdviceFilterProject extends AbstractAndroidProject {
           bs.additions = appAdditions
         }
       }
-      .withAndroidLibProject('lib_android', 'com.example.lib') { lib ->
+      .withAndroidLibProject('lib_android') { lib ->
         lib.sources = libAndroidSources
         lib.withBuildScript { bs ->
           bs.plugins = androidLibPlugins()

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidAssetMutationProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidAssetMutationProject.groovy
@@ -37,7 +37,7 @@ final class AndroidAssetMutationProject extends AbstractAndroidProject {
 
   private GradleProject build() {
     return newAndroidGradleProjectBuilder(agpVersion)
-      .withAndroidLibProject('lib', 'com.example.lib') { lib ->
+      .withAndroidLibProject('lib') { lib ->
         lib.manifest = libraryManifest('com.example.lib')
         lib.withBuildScript { bs ->
           bs.plugins(androidLib())
@@ -50,7 +50,7 @@ final class AndroidAssetMutationProject extends AbstractAndroidProject {
         }
         lib.sources = sources
       }
-      .withAndroidLibProject('assets', 'com.example.lib.assets') { assets ->
+      .withAndroidLibProject('assets') { assets ->
         assets.withBuildScript { bs ->
           bs.plugins(androidLib(false))
           bs.android = defaultAndroidLibBlock(false, 'com.example.lib.assets')

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidAssetsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidAssetsProject.groovy
@@ -42,7 +42,7 @@ final class AndroidAssetsProject extends AbstractAndroidProject {
         app.styles = AndroidStyleRes.DEFAULT
         app.colors = AndroidColorRes.DEFAULT
       }
-      .withAndroidLibProject('lib', 'com.example.lib') { lib ->
+      .withAndroidLibProject('lib') { lib ->
         lib.manifest = libraryManifest('com.example.lib')
         lib.withBuildScript { bs ->
           bs.plugins = [Plugins.androidLib, Plugins.dependencyAnalysisNoVersion]
@@ -52,7 +52,7 @@ final class AndroidAssetsProject extends AbstractAndroidProject {
           ]
         }
       }
-      .withAndroidLibProject('assets', 'com.example.lib.assets') { assets ->
+      .withAndroidLibProject('assets') { assets ->
         assets.withBuildScript { bs ->
           bs.plugins = [Plugins.androidLib, Plugins.dependencyAnalysisNoVersion]
           bs.android = defaultAndroidLibBlock(false, 'com.example.lib.assets')

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidFileMutationProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidFileMutationProject.groovy
@@ -65,8 +65,9 @@ final class AndroidFileMutationProject extends AbstractAndroidProject {
 
   private GradleProject build() {
     return newAndroidGradleProjectBuilder(agpVersion)
+      // TODO(tsr): use withAndroidLibProject() instead
       .withAndroidSubproject('lib') { l ->
-        l.manifest = AndroidManifest.defaultLib()
+        l.manifest = null
         l.withBuildScript { bs ->
           bs.plugins(androidLib())
           bs.android = defaultAndroidLibBlock()

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidKotlinInlineProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidKotlinInlineProject.groovy
@@ -27,8 +27,9 @@ final class AndroidKotlinInlineProject extends AbstractAndroidProject {
 
   private GradleProject build() {
     return newAndroidGradleProjectBuilder(agpVersion)
+      // TODO(tsr): use withAndroidLibProject() instead
       .withAndroidSubproject('lib') { l ->
-        l.manifest = AndroidManifest.defaultLib()
+        l.manifest = null
         l.withBuildScript { bs ->
           bs.plugins(androidLib())
           bs.android = defaultAndroidLibBlock()

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidMenuProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidMenuProject.groovy
@@ -28,13 +28,14 @@ final class AndroidMenuProject extends AbstractAndroidProject {
 
   private GradleProject build() {
     return newAndroidGradleProjectBuilder(agpVersion)
+      // TODO(tsr): use withAndroidLibProject() instead
       .withAndroidSubproject('consumer') { consumer ->
         consumer.withBuildScript { bs ->
           bs.plugins = [Plugins.androidLib, Plugins.dependencyAnalysisNoVersion]
           bs.android = defaultAndroidLibBlock(false, 'com.example.consumer')
           bs.dependencies = [project('implementation', ':producer')]
         }
-        consumer.manifest = AndroidManifest.defaultLib()
+        consumer.manifest = null
         consumer.withFile('src/main/res/menu/a_menu.xml', """\
         <?xml version="1.0" encoding="utf-8"?>
         <menu xmlns:android="http://schemas.android.com/apk/res/android">
@@ -45,12 +46,13 @@ final class AndroidMenuProject extends AbstractAndroidProject {
         </menu>""".stripIndent()
         )
       }
+      // TODO(tsr): use withAndroidLibProject() instead
       .withAndroidSubproject('producer') { producer ->
         producer.withBuildScript { bs ->
           bs.plugins = [Plugins.androidLib, Plugins.dependencyAnalysisNoVersion]
           bs.android = defaultAndroidLibBlock(false, 'com.example.producer')
         }
-        producer.manifest = AndroidManifest.defaultLib()
+        producer.manifest = null
         producer.withFile('src/main/res/drawable/drawable_from_other_module.xml', """\
         <?xml version="1.0" encoding="utf-8"?>
         <vector xmlns:android="http://schemas.android.com/apk/res/android"

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidResMutationProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidResMutationProject.groovy
@@ -68,7 +68,7 @@ final class AndroidResMutationProject extends AbstractAndroidProject {
 
   private GradleProject build() {
     return newAndroidGradleProjectBuilder(agpVersion)
-      .withAndroidLibProject('lib', 'com.example.lib') { lib ->
+      .withAndroidLibProject('lib') { lib ->
         lib.manifest = libraryManifest('com.example.lib')
         lib.withBuildScript { bs ->
           bs.plugins(androidLib())
@@ -81,7 +81,7 @@ final class AndroidResMutationProject extends AbstractAndroidProject {
         }
         lib.sources = sources
       }
-      .withAndroidLibProject('res', 'com.example.lib.res') { res ->
+      .withAndroidLibProject('res') { res ->
         res.withBuildScript { bs ->
           bs.plugins(androidLib(false))
           bs.android = defaultAndroidLibBlock(false, 'com.example.lib.res')
@@ -89,7 +89,7 @@ final class AndroidResMutationProject extends AbstractAndroidProject {
         res.manifest = libraryManifest('com.example.lib.res')
         res.strings = AndroidStringRes.DEFAULT
       }
-      .withAndroidLibProject('layouts', 'com.example.lib.layouts') { res ->
+      .withAndroidLibProject('layouts') { res ->
         res.withBuildScript { bs ->
           bs.plugins(androidLib(false))
           bs.android = defaultAndroidLibBlock(false, 'com.example.lib.layouts')

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidTestDependenciesProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidTestDependenciesProject.groovy
@@ -41,9 +41,10 @@ abstract class AndroidTestDependenciesProject extends AbstractAndroidProject {
 
     private GradleProject build() {
       return newAndroidGradleProjectBuilder(agpVersion)
+      // TODO(tsr): use withAndroidLibProject() instead
         .withAndroidSubproject('proj') { s ->
           s.sources = sources
-          s.manifest = AndroidManifest.defaultLib()
+          s.manifest = null
           s.withBuildScript { bs ->
             bs.plugins = androidLib(false)
             bs.android = defaultAndroidLibBlock(false, 'com.example.proj')
@@ -110,10 +111,11 @@ abstract class AndroidTestDependenciesProject extends AbstractAndroidProject {
 
     private GradleProject build() {
       return newAndroidGradleProjectBuilder(agpVersion)
+      // TODO(tsr): use withAndroidLibProject() instead
         .withAndroidSubproject('proj') { s ->
           s.sources = sources
           s.colors = AndroidColorRes.DEFAULT
-          s.manifest = AndroidManifest.defaultLib()
+          s.manifest = null
           s.withBuildScript { bs ->
             bs.plugins = androidLib(false)
             bs.android = defaultAndroidLibBlock(false, 'com.example.proj')
@@ -178,9 +180,10 @@ abstract class AndroidTestDependenciesProject extends AbstractAndroidProject {
 
     private GradleProject build() {
       return newAndroidGradleProjectBuilder(agpVersion)
+      // TODO(tsr): use withAndroidLibProject() instead
         .withAndroidSubproject('proj') { s ->
           s.sources = sources
-          s.manifest = AndroidManifest.defaultLib()
+          s.manifest = null
           s.withBuildScript { bs ->
             bs.plugins = androidLib(false)
             bs.android = defaultAndroidLibBlock(false, 'com.example.proj')

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidTestSmokeProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidTestSmokeProject.groovy
@@ -45,9 +45,10 @@ final class AndroidTestSmokeProject extends AbstractAndroidProject {
           )
         }
       }
+    // TODO(tsr): use withAndroidLibProject() instead
       .withAndroidSubproject('benchmark') { test ->
         test.sources = androidBenchmarkSources
-        test.manifest = AndroidManifest.defaultLib()
+        test.manifest = null
 
         test.withBuildScript { buildScript ->
           buildScript.plugins(androidTest())

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidTestSourceProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidTestSourceProject.groovy
@@ -48,9 +48,10 @@ final class AndroidTestSourceProject extends AbstractAndroidProject {
           buildScript.dependencies(appDependencies())
         }
       }
+    // TODO(tsr): use withAndroidLibProject() instead
       .withAndroidSubproject('lib') { subproject ->
         subproject.sources = androidLibSources
-        subproject.manifest = AndroidManifest.defaultLib()
+        subproject.manifest = null
         subproject.withBuildScript { buildScript ->
           buildScript.plugins(androidLib())
           buildScript.android = defaultAndroidLibBlock(true, 'my.android.lib')

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidTestsAreIgnorableProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidTestsAreIgnorableProject.groovy
@@ -37,8 +37,9 @@ final class AndroidTestsAreIgnorableProject extends AbstractAndroidProject {
           )
         }
       }
+    // TODO(tsr): use withAndroidLibProject() instead
       .withAndroidSubproject('lib') { lib ->
-        lib.manifest = AndroidManifest.defaultLib()
+        lib.manifest = null
         lib.withBuildScript { bs ->
           bs.plugins = [Plugins.androidLib, Plugins.dependencyAnalysisNoVersion]
           bs.android = defaultAndroidLibBlock(false, 'my.android.lib')

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidThemeActivityProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidThemeActivityProject.groovy
@@ -65,13 +65,14 @@ final class AndroidThemeActivityProject extends AbstractAndroidProject {
           )
         ]
       }
+    // TODO(tsr): use withAndroidLibProject() instead
       .withAndroidSubproject('producer') { producer ->
         producer.withBuildScript { bs ->
           bs.plugins = androidLib(false)
           bs.android = defaultAndroidLibBlock(false, 'com.example.producer')
           bs.dependencies(appcompat('implementation'))
         }
-        producer.manifest = AndroidManifest.defaultLib()
+        producer.manifest = null
         producer.styles = AndroidStyleRes.of(
           '''\
           <?xml version="1.0" encoding="utf-8"?>

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidThemeProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidThemeProject.groovy
@@ -48,6 +48,7 @@ final class AndroidThemeProject extends AbstractAndroidProject {
           </manifest>'''.stripIndent()
         )
       }
+    // TODO(tsr): use withAndroidLibProject() instead
       .withAndroidSubproject('producer') { producer ->
         producer.withBuildScript { bs ->
           bs.plugins = androidLib(false)
@@ -56,7 +57,7 @@ final class AndroidThemeProject extends AbstractAndroidProject {
             appcompat('implementation'),
           ]
         }
-        producer.manifest = AndroidManifest.defaultLib()
+        producer.manifest = null
         producer.styles = AndroidStyleRes.of(
           '''\
           <?xml version="1.0" encoding="utf-8"?>

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidToJvmInlineProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidToJvmInlineProject.groovy
@@ -26,7 +26,7 @@ final class AndroidToJvmInlineProject extends AbstractAndroidProject {
 
   private GradleProject build() {
     return newAndroidGradleProjectBuilder(agpVersion)
-      .withAndroidLibProject('consumer', 'com.example.consumer') { l ->
+      .withAndroidLibProject('consumer') { l ->
         l.withBuildScript { bs ->
           bs.plugins = androidLib(true)
           bs.android = defaultAndroidLibBlock(true, 'com.example.consumer')

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AttrResProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AttrResProject.groovy
@@ -30,6 +30,7 @@ final class AttrResProject extends AbstractAndroidProject {
 
   private GradleProject build() {
     return newAndroidGradleProjectBuilder(agpVersion)
+    // TODO(tsr): use withAndroidLibProject() instead
       .withAndroidSubproject('consumer') { consumer ->
         consumer.withBuildScript { bs ->
           bs.plugins = androidLib(false)
@@ -41,7 +42,7 @@ final class AttrResProject extends AbstractAndroidProject {
             APPCOMPAT,
           ]
         }
-        consumer.manifest = AndroidManifest.defaultLib()
+        consumer.manifest = null
         consumer.withFile('src/main/res/drawable/ic_pin.xml', """\
         <?xml version="1.0" encoding="utf-8"?>
         <vector xmlns:android="http://schemas.android.com/apk/res/android"
@@ -66,6 +67,7 @@ final class AttrResProject extends AbstractAndroidProject {
         </resources>""".stripIndent()
         )
       }
+    // TODO(tsr): use withAndroidLibProject() instead
       .withAndroidSubproject('producer') { producer ->
         producer.withBuildScript { bs ->
           bs.plugins = androidLib(false)
@@ -75,7 +77,7 @@ final class AttrResProject extends AbstractAndroidProject {
             APPCOMPAT,
           ]
         }
-        producer.manifest = AndroidManifest.defaultLib()
+        producer.manifest = null
         producer.withFile('src/main/res/values/resources.xml', """\
         <resources>
           <attr name="themeColor" format="color" />

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AttrResWithNullProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AttrResWithNullProject.groovy
@@ -28,6 +28,7 @@ final class AttrResWithNullProject extends AbstractAndroidProject {
 
   private GradleProject build() {
     return newAndroidGradleProjectBuilder(agpVersion)
+    // TODO(tsr): use withAndroidLibProject() instead
       .withAndroidSubproject('consumer') { consumer ->
         consumer.withBuildScript { bs ->
           bs.plugins = androidLib(false)
@@ -37,7 +38,7 @@ final class AttrResWithNullProject extends AbstractAndroidProject {
             ANDROIDX_ANNOTATION,
           ]
         }
-        consumer.manifest = AndroidManifest.defaultLib()
+        consumer.manifest = null
         consumer.withFile('src/main/res/drawable/ic_pin.xml', """\
         <?xml version="1.0" encoding="utf-8"?>
         <vector xmlns:android="http://schemas.android.com/apk/res/android"
@@ -55,6 +56,7 @@ final class AttrResWithNullProject extends AbstractAndroidProject {
         </vector>""".stripIndent()
         )
       }
+    // TODO(tsr): use withAndroidLibProject() instead
       .withAndroidSubproject('producer') { producer ->
         producer.withBuildScript { bs ->
           bs.plugins = androidLib(false)
@@ -64,7 +66,7 @@ final class AttrResWithNullProject extends AbstractAndroidProject {
             APPCOMPAT,
           ]
         }
-        producer.manifest = AndroidManifest.defaultLib()
+        producer.manifest = null
         producer.withFile('src/main/res/values/resources.xml', """\
         <resources>
           <attr name="themeColor" format="color" />

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/CompileOnlyProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/CompileOnlyProject.groovy
@@ -25,7 +25,7 @@ final class CompileOnlyProject extends AbstractAndroidProject {
 
   private GradleProject build() {
     return newAndroidGradleProjectBuilder(agpVersion)
-      .withAndroidLibProject('lib', 'com.example.lib') { lib ->
+      .withAndroidLibProject('lib') { lib ->
         lib.manifest = libraryManifest()
         lib.withBuildScript { bs ->
           bs.plugins = androidLib(false)

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/CompileOnlyTransitiveProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/CompileOnlyTransitiveProject.groovy
@@ -24,7 +24,7 @@ final class CompileOnlyTransitiveProject extends AbstractAndroidProject {
 
   private GradleProject build() {
     return newAndroidGradleProjectBuilder(agpVersion)
-      .withAndroidLibProject('consumer', 'com.example.consumer') { p ->
+      .withAndroidLibProject('consumer') { p ->
         p.manifest = libraryManifest()
         p.sources = consumerSources
         p.withBuildScript { bs ->

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/ConstantsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/ConstantsProject.groovy
@@ -45,7 +45,7 @@ final class ConstantsProject extends AbstractAndroidProject {
         app.styles = AndroidStyleRes.DEFAULT
         app.colors = AndroidColorRes.DEFAULT
       }
-      .withAndroidLibProject('lib', 'mutual.aid.lib') { lib ->
+      .withAndroidLibProject('lib') { lib ->
         lib.withBuildScript { bs ->
           bs.plugins(androidLib())
           bs.android = defaultAndroidLibBlock(true, 'mutual.aid.lib')
@@ -53,7 +53,7 @@ final class ConstantsProject extends AbstractAndroidProject {
         }
         lib.sources = libSource
       }
-      .withAndroidLibProject('lib2', 'mutual.aid.lib2') { lib ->
+      .withAndroidLibProject('lib2') { lib ->
         lib.withBuildScript { bs ->
           bs.plugins(androidLib())
           bs.android = defaultAndroidLibBlock(true, 'mutual.aid.lib2')
@@ -61,7 +61,7 @@ final class ConstantsProject extends AbstractAndroidProject {
         }
         lib.sources = lib2Source
       }
-      .withAndroidLibProject('libstar', 'mutual.aid.libstar') { lib ->
+      .withAndroidLibProject('libstar') { lib ->
         lib.withBuildScript { bs ->
           bs.plugins(androidLib())
           bs.android = defaultAndroidLibBlock(true, 'mutual.aid.libstar')

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/CouldBeAndroidProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/CouldBeAndroidProject.groovy
@@ -82,7 +82,7 @@ final class CouldBeAndroidProject extends AbstractAndroidProject {
         app.styles = AndroidStyleRes.DEFAULT
         app.colors = AndroidColorRes.DEFAULT
       }
-      .withAndroidLibProject('assets', 'com.example.lib.assets') { assets ->
+      .withAndroidLibProject('assets') { assets ->
         assets.withBuildScript { bs ->
           bs.plugins = androidLib(false)
           bs.android = defaultAndroidLibBlock(false, 'com.example.lib.assets')
@@ -93,7 +93,7 @@ final class CouldBeAndroidProject extends AbstractAndroidProject {
         )
         assets.strings = AndroidStringRes.DEFAULT
       }
-      .withAndroidLibProject('lib-android-java-deps', 'com.example.lib') { lib ->
+      .withAndroidLibProject('lib-android-java-deps') { lib ->
         lib.withBuildScript { bs ->
           bs.plugins = androidLib(false)
           bs.android = defaultAndroidLibBlock(false, 'com.example.lib')
@@ -103,7 +103,7 @@ final class CouldBeAndroidProject extends AbstractAndroidProject {
           ]
         }
       }
-      .withAndroidLibProject('lib-android-android-deps', 'com.example.lib') { lib ->
+      .withAndroidLibProject('lib-android-android-deps') { lib ->
         lib.withBuildScript { bs ->
           bs.plugins = androidLib(false)
           bs.android = defaultAndroidLibBlock(false, 'com.example.lib')

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/DaggerProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/DaggerProject.groovy
@@ -33,8 +33,9 @@ final class DaggerProject extends AbstractAndroidProject {
           bs.plugins += rootKapt
         }
       }
+    // TODO(tsr): use withAndroidLibProject() instead
       .withAndroidSubproject(projectName) { s ->
-        s.manifest = AndroidManifest.defaultLib()
+        s.manifest = null
         s.sources = sources
         s.withBuildScript { bs ->
           bs.android = defaultAndroidLibBlock(true)

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/DataBindingUsagesExclusionsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/DataBindingUsagesExclusionsProject.groovy
@@ -57,7 +57,7 @@ final class DataBindingUsagesExclusionsProject extends AbstractAndroidProject {
         app.manifest = AndroidManifest.appEmpty()
         app.sources = appSources
       }
-      .withAndroidLibProject('lib', 'com.example.lib') { lib ->
+      .withAndroidLibProject('lib') { lib ->
         lib.withBuildScript { bs ->
           bs.plugins(androidLib() + kapt())
           bs.android = defaultAndroidLibBlock(true, 'com.example.lib')

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/DataBindingUsagesExclusionsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/DataBindingUsagesExclusionsProject.groovy
@@ -49,17 +49,17 @@ final class DataBindingUsagesExclusionsProject extends AbstractAndroidProject {
       }
       .withAndroidSubproject('app') { app ->
         app.withBuildScript { bs ->
-          bs.plugins = androidApp()
+          bs.plugins(androidApp())
           bs.android = defaultAndroidAppBlock(true, 'com.example.app')
-          bs.dependencies = appDependencies
+          bs.dependencies(appDependencies)
           bs.withGroovy('android.buildFeatures.dataBinding true')
         }
-        app.manifest = AndroidManifest.defaultLib()
+        app.manifest = AndroidManifest.appEmpty()
         app.sources = appSources
       }
       .withAndroidLibProject('lib', 'com.example.lib') { lib ->
         lib.withBuildScript { bs ->
-          bs.plugins = androidLib() + kapt()
+          bs.plugins(androidLib() + kapt())
           bs.android = defaultAndroidLibBlock(true, 'com.example.lib')
           bs.withGroovy('android.buildFeatures.dataBinding true')
         }

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/DominanceTreeProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/DominanceTreeProject.groovy
@@ -31,7 +31,7 @@ final class DominanceTreeProject extends AbstractAndroidProject {
           ]
         }
       }
-      .withAndroidLibProject('lib', 'com.example.lib') { lib ->
+      .withAndroidLibProject('lib') { lib ->
         lib.withBuildScript { bs ->
           bs.plugins = androidLib(false)
           bs.android = defaultAndroidLibBlock(false, 'com.example.lib')

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/DuplicateDependencyVersionsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/DuplicateDependencyVersionsProject.groovy
@@ -35,7 +35,7 @@ final class DuplicateDependencyVersionsProject extends AbstractAndroidProject {
           ]
         }
       }
-      .withAndroidLibProject('lib1', 'com.example.lib1') { lib ->
+      .withAndroidLibProject('lib1') { lib ->
         lib.withBuildScript { bs ->
           bs.plugins = androidLib(false)
           bs.android = defaultAndroidLibBlock(false, 'com.example.lib1')
@@ -44,7 +44,7 @@ final class DuplicateDependencyVersionsProject extends AbstractAndroidProject {
           ]
         }
       }
-      .withAndroidLibProject('lib2', 'com.example.lib2') { lib ->
+      .withAndroidLibProject('lib2') { lib ->
         lib.withBuildScript { bs ->
           bs.plugins = androidLib(false)
           bs.android = defaultAndroidLibBlock(false, 'com.example.lib2')

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/ExternalApplicationProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/ExternalApplicationProject.groovy
@@ -42,7 +42,7 @@ final class ExternalApplicationProject extends AbstractAndroidProject {
         app.colors = AndroidColorRes.DEFAULT
         app.manifest = AndroidManifest.app('com.example.lib.ExternalApp')
       }
-      .withAndroidLibProject('lib', 'com.example.lib') { lib ->
+      .withAndroidLibProject('lib') { lib ->
         lib.withBuildScript { bs ->
           bs.plugins = androidLib(false)
           bs.android = defaultAndroidLibBlock(false)

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/MixedSourceProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/MixedSourceProject.groovy
@@ -26,7 +26,7 @@ final class MixedSourceProject extends AbstractAndroidProject {
 
   private GradleProject build() {
     return newAndroidGradleProjectBuilder(agpVersion)
-      .withAndroidLibProject('consumer', 'com.example.consumer') { lib ->
+      .withAndroidLibProject('consumer') { lib ->
         lib.withBuildScript { bs ->
           bs.plugins = androidLib(false)
           bs.android = defaultAndroidLibBlock(false, 'com.example.consumer')

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/NativeLibProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/NativeLibProject.groovy
@@ -25,7 +25,7 @@ final class NativeLibProject extends AbstractAndroidProject {
 
   private GradleProject build() {
     return newAndroidGradleProjectBuilder(agpVersion)
-      .withAndroidLibProject('lib', 'com.example.lib') { lib ->
+      .withAndroidLibProject('lib') { lib ->
         lib.withBuildScript { bs ->
           bs.plugins = androidLib(false)
           bs.android = defaultAndroidLibBlock(false, 'com.example.lib')

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/ResDuplicateAttrProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/ResDuplicateAttrProject.groovy
@@ -28,7 +28,7 @@ final class ResDuplicateAttrProject extends AbstractAndroidProject {
 
   private GradleProject build() {
     return newAndroidGradleProjectBuilder(agpVersion)
-      .withAndroidLibProject('lib-a', 'com.example.lib_a') { lib ->
+      .withAndroidLibProject('lib-a') { lib ->
         lib.withBuildScript { bs ->
           bs.plugins = androidLib(false)
           bs.android = defaultAndroidLibBlock(false, 'com.example.lib_a')
@@ -68,13 +68,12 @@ final class ResDuplicateAttrProject extends AbstractAndroidProject {
           )
         ]
       }
-      .withAndroidLibProject('lib-b', 'com.example.lib_b') { lib ->
+      .withAndroidLibProject('lib-b') { lib ->
         lib.withBuildScript { bs ->
           bs.plugins = androidLib(false)
           bs.android = defaultAndroidLibBlock(false, 'com.example.lib_b')
           bs.dependencies(recyclerView('api'))
         }
-        lib.manifest = AndroidManifest.defaultLib()
         lib.sources = libBSources
       }
       .write()

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/ResProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/ResProject.groovy
@@ -60,7 +60,7 @@ final class ResProject extends AbstractAndroidProject {
         </com.example.app.MessageLayout>'''.stripIndent()
         )
       }
-      .withAndroidLibProject('lib', 'com.example.lib') { lib ->
+      .withAndroidLibProject('lib') { lib ->
         lib.withBuildScript { bs ->
           bs.plugins(androidLib(false))
           bs.android = defaultAndroidLibBlock(false, 'com.example.lib')
@@ -68,12 +68,11 @@ final class ResProject extends AbstractAndroidProject {
         lib.colors = AndroidColorRes.DEFAULT
         lib.manifest = libraryManifest('com.example.lib')
       }
-      .withAndroidLibProject('lib2', 'com.example.lib2') { lib2 ->
+      .withAndroidLibProject('lib2') { lib2 ->
         lib2.withBuildScript { bs ->
           bs.plugins(androidLib(false))
           bs.android = defaultAndroidLibBlock(false, 'com.example.lib2')
         }
-        lib2.manifest = AndroidManifest.defaultLib()
         lib2.withFile('src/main/res/values/resources.xml', '''\
         <resources>
           <item name="message_layout" type="id"/>

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/SettingsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/SettingsProject.groovy
@@ -62,7 +62,7 @@ abstract class SettingsProject {
         </com.example.app.MessageLayout>'''.stripIndent()
           )
         }
-        .withAndroidLibProject('lib', 'com.example.lib') { lib ->
+        .withAndroidLibProject('lib') { lib ->
           lib.withBuildScript { bs ->
             bs.plugins = [plugins.androidLibNoVersion]
             bs.android = defaultAndroidLibBlock(false, 'com.example.lib')
@@ -70,12 +70,11 @@ abstract class SettingsProject {
           lib.colors = AndroidColorRes.DEFAULT
           lib.manifest = libraryManifest('com.example.lib')
         }
-        .withAndroidLibProject('lib2', 'com.example.lib2') { lib2 ->
+        .withAndroidLibProject('lib2') { lib2 ->
           lib2.withBuildScript { bs ->
             bs.plugins = [plugins.androidLibNoVersion]
             bs.android = defaultAndroidLibBlock(false, 'com.example.lib2')
           }
-          lib2.manifest = AndroidManifest.defaultLib()
           lib2.withFile('src/main/res/values/resources.xml', '''\
         <resources>
           <item name="message_layout" type="id"/>

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/TestFixturesDuplicatedWithMainProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/TestFixturesDuplicatedWithMainProject.groovy
@@ -31,38 +31,38 @@ final class TestFixturesDuplicatedWithMainProject extends AbstractAndroidProject
         r.gradleProperties = GradleProperties.minimalAndroidProperties() +
           "android.experimental.enableTestFixturesKotlinSupport=true"
       }
-      .withSubproject('lib-test-utils') { s ->
-        s.sources = libTestUtilsSources
+      .withAndroidSubproject('app') { s ->
+        s.sources = sourcesWithTestFixtures
+        s.manifest = AndroidManifest.appEmpty()
         s.withBuildScript { bs ->
-          bs.plugins = kotlin
+          bs.plugins(androidApp(true))
+          bs.android = defaultAndroidAppBlock(true,"com.example.app").tap {
+            testFixturesOptions = TestFixturesOptions.enabled()
+          }
+          bs.dependencies(
+            project("implementation", ":lib-test-utils"),
+            project("testFixturesImplementation", ":lib-test-utils"),
+          )
         }
       }
       .withAndroidSubproject('lib') { s ->
         s.sources = sourcesWithTestFixtures
         s.manifest = libraryManifest('lib.with.fixtures')
         s.withBuildScript { bs ->
-          bs.plugins = androidLib(true)
+          bs.plugins(androidLib(true))
           bs.android = defaultAndroidLibBlock(true).tap {
-            testFixturesOptions = new TestFixturesOptions(true)
+            testFixturesOptions = TestFixturesOptions.enabled()
           }
-          bs.dependencies = [
+          bs.dependencies(
             project("implementation", ":lib-test-utils"),
-            project("testFixturesImplementation", ":lib-test-utils")
-          ]
+            project("testFixturesImplementation", ":lib-test-utils"),
+          )
         }
       }
-      .withAndroidSubproject('app') { s ->
-        s.sources = sourcesWithTestFixtures
-        s.manifest = AndroidManifest.defaultLib()
+      .withSubproject('lib-test-utils') { s ->
+        s.sources = libTestUtilsSources
         s.withBuildScript { bs ->
-          bs.plugins = androidApp(true)
-          bs.android = defaultAndroidAppBlock(true,"com.example.app").tap {
-            testFixturesOptions = new TestFixturesOptions(true)
-          }
-          bs.dependencies = [
-            project("implementation", ":lib-test-utils"),
-            project("testFixturesImplementation", ":lib-test-utils")
-          ]
+          bs.plugins(kotlin)
         }
       }
       .write()

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/TestInstrumentationRunnerProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/TestInstrumentationRunnerProject.groovy
@@ -40,7 +40,7 @@ final class TestInstrumentationRunnerProject extends AbstractAndroidProject {
           bs.dependencies(testRunner)
         }
       }
-      .withAndroidLibProject('test_runner', 'com.test.testrunner') { lib ->
+      .withAndroidLibProject('test_runner') { lib ->
         lib.sources = sourcesTestRunner
         lib.withBuildScript { bs ->
           bs.plugins(androidLib(false))

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/TestSourceProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/TestSourceProject.groovy
@@ -43,9 +43,10 @@ final class TestSourceProject extends AbstractAndroidProject {
           ]
         }
       }
+    // TODO(tsr): use withAndroidLibProject() instead
       .withAndroidSubproject('lib') { subproject ->
         subproject.sources = androidLibSources
-        subproject.manifest = AndroidManifest.defaultLib()
+        subproject.manifest = null
         subproject.withBuildScript { bs ->
           bs.plugins = androidLib(true)
           bs.android = defaultAndroidLibBlock(true, 'my.android.lib')

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/TransitiveRuntimeProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/TransitiveRuntimeProject.groovy
@@ -27,7 +27,7 @@ final class TransitiveRuntimeProject extends AbstractAndroidProject {
 
   private GradleProject build() {
     return newAndroidGradleProjectBuilder(agpVersion)
-      .withAndroidLibProject('consumer', 'com.example.consumer') { s ->
+      .withAndroidLibProject('consumer') { s ->
         s.manifest = libraryManifest()
         s.withBuildScript { bs ->
           bs.plugins(androidLib(false))
@@ -38,7 +38,7 @@ final class TransitiveRuntimeProject extends AbstractAndroidProject {
           )
         }
       }
-      .withAndroidLibProject('unused', 'com.example.unused') { s ->
+      .withAndroidLibProject('unused') { s ->
         s.manifest = libraryManifest()
         s.withBuildScript { bs ->
           bs.plugins(androidLib(false))

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/TransitiveVariantRuntimeProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/TransitiveVariantRuntimeProject.groovy
@@ -26,7 +26,7 @@ final class TransitiveVariantRuntimeProject extends AbstractAndroidProject {
 
   private GradleProject build() {
     return newAndroidGradleProjectBuilder(agpVersion)
-      .withAndroidLibProject('consumer', 'com.example.consumer') { s ->
+      .withAndroidLibProject('consumer') { s ->
         s.manifest = libraryManifest()
         s.withBuildScript { bs ->
           bs.plugins(androidLib(false))
@@ -34,7 +34,7 @@ final class TransitiveVariantRuntimeProject extends AbstractAndroidProject {
           bs.dependencies(unused)
         }
       }
-      .withAndroidLibProject('unused', 'com.example.unused') { s ->
+      .withAndroidLibProject('unused') { s ->
         s.manifest = libraryManifest()
         s.withBuildScript { bs ->
           bs.plugins(androidLib(false))

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/GradleProject.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/GradleProject.kt
@@ -281,14 +281,13 @@ public class GradleProject(
 
     public fun withAndroidLibProject(
       name: String,
-      packageName: String,
       block: AndroidSubproject.Builder.() -> Unit,
     ): Builder {
       // If a builder with this name already exists, returning it for building-upon
       val builder = androidSubprojectMap[name] ?: AndroidSubproject.Builder()
       builder.apply {
         this.name = name
-        this.manifest = AndroidManifest.defaultLib()
+        this.manifest = null
         this.styles = AndroidStyleRes.EMPTY
         this.colors = AndroidColorRes.EMPTY
         this.strings = null

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/android/AndroidManifest.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/android/AndroidManifest.kt
@@ -92,15 +92,5 @@ public class AndroidManifest(public val content: String) {
 
     @JvmField
     public val DEFAULT_APP: AndroidManifest = app(null)
-
-    @JvmStatic
-    public fun defaultLib(): AndroidManifest? = null
-//    @JvmStatic
-//    public fun defaultLib(): AndroidManifest = AndroidManifest(
-//      """
-//      |<?xml version="1.0" encoding="utf-8"?>
-//      |<manifest xmlns:android="http://schemas.android.com/apk/res/android" />
-//      """.trimMargin()
-//    )
   }
 }

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/android/AndroidManifest.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/android/AndroidManifest.kt
@@ -94,11 +94,13 @@ public class AndroidManifest(public val content: String) {
     public val DEFAULT_APP: AndroidManifest = app(null)
 
     @JvmStatic
-    public fun defaultLib(): AndroidManifest = AndroidManifest(
-      """
-      |<?xml version="1.0" encoding="utf-8"?>
-      |<manifest xmlns:android="http://schemas.android.com/apk/res/android" />
-      """.trimMargin()
-    )
+    public fun defaultLib(): AndroidManifest? = null
+//    @JvmStatic
+//    public fun defaultLib(): AndroidManifest = AndroidManifest(
+//      """
+//      |<?xml version="1.0" encoding="utf-8"?>
+//      |<manifest xmlns:android="http://schemas.android.com/apk/res/android" />
+//      """.trimMargin()
+//    )
   }
 }

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/android/TestFixturesOptions.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/android/TestFixturesOptions.kt
@@ -16,4 +16,9 @@ public class TestFixturesOptions(
   }
 
   override val name: String = "testFixtures"
+
+  public companion object {
+    @JvmStatic
+    public fun enabled(): TestFixturesOptions = TestFixturesOptions(true)
+  }
 }


### PR DESCRIPTION
Followup on all the:
- [ ] `// TODO(tsr): use withAndroidLibProject() instead`