### PR TITLE
feat: record lambda in binaryClassAccesses

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/asm.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/asm.kt
@@ -463,6 +463,24 @@ private class MethodAnalyzer(
   ) {
     log { "- MethodAnalyzer#visitInvokeDynamicInsn: $name $descriptor" }
     addClass(descriptor, ClassRef.Kind.NOT_ANNOTATION)
+
+    // Bootstrap arguments may contain Handle instances pointing to the actual implementation
+    // method (e.g. a static method reference compiled to INVOKEDYNAMIC). Record each such Handle
+    // as a MemberAccess so callers appear in binaryClassAccesses.
+    for (arg in bootstrapMethodArguments) {
+      if (arg is Handle) {
+        log { "  - MethodAnalyzer#visitInvokeDynamicInsn bootstrap Handle: ${arg.owner}.${arg.name} ${arg.desc}" }
+        addClass(if (arg.owner.startsWith("[")) arg.owner else "L${arg.owner};", ClassRef.Kind.NOT_ANNOTATION)
+        val method = MemberAccess.Method(
+          owner = arg.owner,
+          name = arg.name,
+          descriptor = arg.desc,
+        )
+        binaryClasses.merge(arg.owner, sortedSetOf(method)) { acc, inc ->
+          acc.apply { addAll(inc) }
+        }
+      }
+    }
   }
 
   override fun visitLocalVariable(

--- a/src/test/java/com/autonomousapps/internal/fixtures/ClassUsedInLambda.java
+++ b/src/test/java/com/autonomousapps/internal/fixtures/ClassUsedInLambda.java
@@ -1,0 +1,9 @@
+// Copyright (c) 2025. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.internal.fixtures;
+
+public class ClassUsedInLambda {
+
+  public void someMethod() {
+  }
+}

--- a/src/test/java/com/autonomousapps/internal/fixtures/LambdaUsage.java
+++ b/src/test/java/com/autonomousapps/internal/fixtures/LambdaUsage.java
@@ -1,0 +1,12 @@
+// Copyright (c) 2025. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.internal.fixtures;
+
+public class LambdaUsage {
+
+  public void run() {
+    var classUsedInLambda = new ClassUsedInLambda();
+    Runnable r = classUsedInLambda::someMethod;
+    r.run();
+  }
+}

--- a/src/test/kotlin/com/autonomousapps/internal/ClassAnalyzerTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/ClassAnalyzerTest.kt
@@ -1,0 +1,38 @@
+// Copyright (c) 2025. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.internal
+
+import com.autonomousapps.internal.asm.ClassReader
+import com.autonomousapps.internal.fixtures.LambdaUsage
+import com.autonomousapps.model.internal.intermediates.consumer.MemberAccess
+import com.google.common.truth.Truth.assertThat
+import org.gradle.api.logging.Logging
+import org.junit.jupiter.api.Test
+
+class ClassAnalyzerTest {
+
+  private val logger = Logging.getLogger(ClassAnalyzerTest::class.java)
+
+  @Test fun `records lambda usage in binaryClassAccesses`() {
+    val classAnalyzer = ClassAnalyzer(logger).also { analyzer ->
+      ClassReader(LambdaUsage::class.java.name).accept(analyzer, 0)
+    }
+
+    val binaryClassAccesses: Map<String, Set<MemberAccess>> = classAnalyzer.getBinaryClasses()
+
+    val methodOwner = "com/autonomousapps/internal/fixtures/ClassUsedInLambda"
+    assertThat(binaryClassAccesses).containsKey(methodOwner)
+    assertThat(binaryClassAccesses[methodOwner]).containsExactly(
+      MemberAccess.Method(
+        owner = methodOwner,
+        name = "<init>",
+        descriptor = "()V",
+      ),
+      MemberAccess.Method(
+        owner = methodOwner,
+        name = "someMethod",
+        descriptor = "()V",
+      )
+    )
+  }
+}


### PR DESCRIPTION
We are using the exploding-bytecode.json to get a method usage diff and thereby determine if a method has become unused.
We noticed that lambda usages are not added to binaryClassAccesses giving us false positives.

The dependency analyze Plugin works correctly even without this change but maybe you are willing to merge it anyways.
This is also why I was unable to add a functionalTest showing the issue, hope you are fine with the unit-test in this case.