### PR TITLE
feat: remove unused 'file' property.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/utils/comparators.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/comparators.kt
@@ -63,3 +63,37 @@ internal class MapSetComparator<K : Comparable<K>, V : Comparable<V>> : Comparat
     return 0
   }
 }
+internal class MapComparator<K : Comparable<K>, V : Comparable<V>> : Comparator<Map<K, V>> {
+  override fun compare(left: Map<K, V>?, right: Map<K, V>?): Int {
+    if (left === right) return 0
+    if (left == null || right == null) return if (left == null) -1 else 1
+
+    if (left.size > right.size) return 1
+    if (right.size > left.size) return -1
+
+    val leftIterator = left.iterator()
+    val rightIterator = right.iterator()
+
+    while (leftIterator.hasNext() && rightIterator.hasNext()) {
+      val leftEntry = leftIterator.next()
+      val rightEntry = rightIterator.next()
+
+      // Compare keys first
+      val keyCompareResult = leftEntry.key.compareTo(rightEntry.key)
+      if (keyCompareResult != 0) {
+        return keyCompareResult
+      }
+
+      // If keys match, compare values
+      val valueCompareResult = leftEntry.value.compareTo(rightEntry.value)
+      if (valueCompareResult != 0) {
+        return valueCompareResult
+      }
+    }
+
+    if (leftIterator.hasNext()) return 1
+    if (rightIterator.hasNext()) return -1
+
+    return 0
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/model/internal/Dependency.kt
+++ b/src/main/kotlin/com/autonomousapps/model/internal/Dependency.kt
@@ -2,24 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.model.internal
 
-import com.autonomousapps.model.Coordinates
-import com.autonomousapps.model.FlatCoordinates
-import com.autonomousapps.model.IncludedBuildCoordinates
-import com.autonomousapps.model.ModuleCoordinates
-import com.autonomousapps.model.ProjectCoordinates
+import com.autonomousapps.internal.utils.MapComparator
+import com.autonomousapps.model.*
 import com.squareup.moshi.JsonClass
 import dev.zacsweers.moshix.sealed.annotations.TypeLabel
-import java.io.File
 
 @JsonClass(generateAdapter = false, generator = "sealed:type")
 internal sealed class Dependency(
   open val coordinates: Coordinates,
   open val capabilities: Map<String, Capability>,
-  // Can be empty because we don't get file for annotation processor dependencies.
-  // This property is also unused and was only added speculatively, so maybe it doesn't matter
-  open val files: Set<File>
 ) : Comparable<Dependency> {
-  override fun compareTo(other: Dependency): Int = coordinates.compareTo(other.coordinates)
+
+  override fun compareTo(other: Dependency): Int {
+    return compareBy(Dependency::coordinates)
+      .thenBy(MapComparator()) { it.capabilities }
+      .compare(this, other)
+  }
 
   inline fun <reified T : Capability> findCapability(): T? {
     return capabilities[T::class.java.canonicalName] as? T?
@@ -32,29 +30,25 @@ internal data class ProjectDependency(
   override val coordinates: ProjectCoordinates,
   /** Map of [Capability] canonicalName to the capability. */
   override val capabilities: Map<String, Capability>,
-  override val files: Set<File>
-) : Dependency(coordinates, capabilities, files)
+) : Dependency(coordinates, capabilities)
 
 @TypeLabel("module")
 @JsonClass(generateAdapter = false)
 internal data class ModuleDependency(
   override val coordinates: ModuleCoordinates,
   override val capabilities: Map<String, Capability>,
-  override val files: Set<File>
-) : Dependency(coordinates, capabilities, files)
+) : Dependency(coordinates, capabilities)
 
 @TypeLabel("flat")
 @JsonClass(generateAdapter = false)
 internal data class FlatDependency(
   override val coordinates: FlatCoordinates,
   override val capabilities: Map<String, Capability>,
-  override val files: Set<File>
-) : Dependency(coordinates, capabilities, files)
+) : Dependency(coordinates, capabilities)
 
 @TypeLabel("included_build")
 @JsonClass(generateAdapter = false)
 internal data class IncludedBuildDependency(
   override val coordinates: IncludedBuildCoordinates,
   override val capabilities: Map<String, Capability>,
-  override val files: Set<File>
-) : Dependency(coordinates, capabilities, files)
+) : Dependency(coordinates, capabilities)

--- a/src/main/kotlin/com/autonomousapps/model/internal/PhysicalArtifact.kt
+++ b/src/main/kotlin/com/autonomousapps/model/internal/PhysicalArtifact.kt
@@ -12,7 +12,10 @@ import java.io.File
 @JsonClass(generateAdapter = false)
 internal data class PhysicalArtifact(
   val coordinates: Coordinates,
-  /** Physical artifact on disk; a jar file or directory pointing to class files. */
+  /**
+   * Physical artifact on disk; a jar file or directory pointing to class files. This file has an absolute path.
+   * nb: attempts to make this file relative have thus far been doomed to fail. Please stop trying.
+   */
   val file: File,
 ) : Comparable<PhysicalArtifact> {
 

--- a/src/main/kotlin/com/autonomousapps/model/internal/intermediates/producer/ExplodedJar.kt
+++ b/src/main/kotlin/com/autonomousapps/model/internal/intermediates/producer/ExplodedJar.kt
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.model.internal.intermediates.producer
 
+import com.autonomousapps.internal.utils.LexicographicIterableComparator
+import com.autonomousapps.internal.utils.MapSetComparator
 import com.autonomousapps.internal.utils.ifNotEmpty
 import com.autonomousapps.model.Coordinates
 import com.autonomousapps.model.internal.*
 import com.autonomousapps.model.internal.intermediates.ExplodingJar
 import com.squareup.moshi.JsonClass
-import java.io.File
 
 /**
  * A library or project, along with the set of classes declared by, and other information contained within, this
@@ -16,7 +17,6 @@ import java.io.File
 @JsonClass(generateAdapter = false)
 internal data class ExplodedJar(
   override val coordinates: Coordinates,
-  val jarFile: File,
 
   /**
    * True if this dependency contains only annotations. False otherwise.
@@ -58,7 +58,6 @@ internal data class ExplodedJar(
     exploding: ExplodingJar,
   ) : this(
     coordinates = artifact.coordinates,
-    jarFile = artifact.file,
     isAnnotations = exploding.isCompileOnlyCandidate,
     securityProviders = exploding.securityProviders,
     androidLintRegistry = exploding.androidLintRegistry,
@@ -70,9 +69,16 @@ internal data class ExplodedJar(
   )
 
   override fun compareTo(other: ExplodedJar): Int {
-    return coordinates.compareTo(other.coordinates).let {
-      if (it == 0) jarFile.compareTo(other.jarFile) else it
-    }
+    return compareBy(ExplodedJar::coordinates)
+      .thenBy(ExplodedJar::isAnnotations)
+      .thenComparing(compareBy<ExplodedJar, String?>(nullsFirst()) { it.androidLintRegistry })
+      .thenBy(ExplodedJar::isLintJar)
+      .thenBy(LexicographicIterableComparator()) { it.securityProviders }
+      .thenBy(LexicographicIterableComparator()) { it.binaryClasses }
+      .thenBy(LexicographicIterableComparator()) { it.ktFiles }
+      .thenBy(MapSetComparator()) { it.constants }
+      .thenBy(MapSetComparator()) { it.reflectiveAccesses }
+      .compare(this, other)
   }
 
   init {

--- a/src/main/kotlin/com/autonomousapps/tasks/ArtifactsReportTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ArtifactsReportTask.kt
@@ -18,6 +18,7 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.*
 
@@ -46,19 +47,23 @@ public abstract class ArtifactsReportTask : DefaultTask() {
    * jars really does matter here. Using [Classpath] is an error, as it looks only at content and
    * not name or path, and we really do need to know the actual path to the artifact, even if its
    * contents haven't changed.
+   *
+   * Attempts to make this path non-absolute have thus far failed. Please stop trying.
    */
   @PathSensitive(PathSensitivity.ABSOLUTE)
-  @InputFiles // TODO(tsr): can I avoid using `get()`?
-  public fun getClasspathArtifactFiles(): FileCollection = artifacts.get().artifactFiles
+  @InputFiles
+  public fun getClasspathArtifactFiles(): Provider<FileCollection> {
+    return artifacts.map { it.artifactFiles }
+  }
 
   /** @see [getClasspathArtifactFiles] */
   @PathSensitive(PathSensitivity.ABSOLUTE)
-  @InputFiles // TODO(tsr): can I avoid using `get()`?
-  public fun getClasspathOpaqueArtifactFiles(): FileCollection = opaqueArtifacts.get().artifactFiles
+  @InputFiles
+  public fun getClasspathOpaqueArtifactFiles(): Provider<FileCollection> {
+    return opaqueArtifacts.map { it.artifactFiles }
+  }
 
-  /**
-   * This artifact collection is the result of resolving the compile or runtime classpath.
-   */
+  /** This artifact collection is the result of resolving the compile or runtime classpath for jar artifacts. */
   public fun setConfiguration(
     configuration: NamedDomainObjectProvider<Configuration>,
     action: (Configuration) -> ArtifactCollection,
@@ -67,6 +72,10 @@ public abstract class ArtifactsReportTask : DefaultTask() {
     artifacts.set(configuration.map { c -> action(c) })
   }
 
+  /**
+   * This artifact collection is the result of resolving the compile or runtime classpath for
+   * [OpaqueComponentArtifactIdentifiers][org.gradle.internal.component.local.model.OpaqueComponentArtifactIdentifier].
+   */
   public fun setOpaqueConfiguration(
     configuration: NamedDomainObjectProvider<Configuration>,
     action: (Configuration) -> ArtifactCollection,

--- a/src/main/kotlin/com/autonomousapps/tasks/SynthesizeDependenciesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/SynthesizeDependenciesTask.kt
@@ -5,17 +5,7 @@ package com.autonomousapps.tasks
 import com.autonomousapps.internal.utils.*
 import com.autonomousapps.model.*
 import com.autonomousapps.model.internal.*
-import com.autonomousapps.model.internal.intermediates.producer.AndroidAssetDependency
-import com.autonomousapps.model.internal.intermediates.producer.AndroidManifestDependency
-import com.autonomousapps.model.internal.intermediates.producer.AndroidResDependency
-import com.autonomousapps.model.internal.intermediates.producer.AnnotationProcessorDependency
-import com.autonomousapps.model.internal.intermediates.producer.DependencyView
-import com.autonomousapps.model.internal.intermediates.producer.ExplodedJar
-import com.autonomousapps.model.internal.intermediates.producer.InlineMemberDependency
-import com.autonomousapps.model.internal.intermediates.producer.NativeLibDependency
-import com.autonomousapps.model.internal.intermediates.producer.ReflectingDependency
-import com.autonomousapps.model.internal.intermediates.producer.ServiceLoaderDependency
-import com.autonomousapps.model.internal.intermediates.producer.TypealiasDependency
+import com.autonomousapps.model.internal.intermediates.producer.*
 import com.autonomousapps.services.InMemoryCache
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
@@ -25,7 +15,6 @@ import org.gradle.api.tasks.*
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 import org.gradle.workers.WorkerExecutor
-import java.io.File
 import javax.inject.Inject
 
 @CacheableTask
@@ -156,10 +145,12 @@ public abstract class SynthesizeDependenciesTask @Inject constructor(
       val androidRes = parameters.androidRes.fromNullableJsonSet<AndroidResDependency>()
       val androidAssets = parameters.androidAssets.fromNullableJsonSet<AndroidAssetDependency>()
 
+      // TODO(tsr): I wonder if we don't need this anymore. If not, we can remove this as a task input which would help
+      //  cacheability (since `PhysicalArtifact` has a reference to an absolute `File`).
       physicalArtifacts.forEach { artifact ->
         builders.merge(
           artifact.coordinates,
-          DependencyBuilder(artifact.coordinates).apply { files.add(artifact.file) },
+          DependencyBuilder(artifact.coordinates),
           DependencyBuilder::concat
         )
       }
@@ -254,10 +245,8 @@ public abstract class SynthesizeDependenciesTask @Inject constructor(
   private class DependencyBuilder(val coordinates: Coordinates) {
 
     val capabilities: MutableList<Capability> = mutableListOf()
-    val files: MutableSet<File> = sortedSetOf()
 
     fun concat(other: DependencyBuilder): DependencyBuilder {
-      files.addAll(other.files)
       other.capabilities.forEach { otherCapability ->
         val existing = capabilities.find { it.javaClass.canonicalName == otherCapability.javaClass.canonicalName }
         if (existing != null) {
@@ -274,10 +263,10 @@ public abstract class SynthesizeDependenciesTask @Inject constructor(
     fun build(): Dependency {
       val capabilities: Map<String, Capability> = capabilities.associateBy { it.javaClass.canonicalName }.toSortedMap()
       return when (coordinates) {
-        is ProjectCoordinates -> ProjectDependency(coordinates, capabilities, files)
-        is ModuleCoordinates -> ModuleDependency(coordinates, capabilities, files)
-        is FlatCoordinates -> FlatDependency(coordinates, capabilities, files)
-        is IncludedBuildCoordinates -> IncludedBuildDependency(coordinates, capabilities, files)
+        is ProjectCoordinates -> ProjectDependency(coordinates, capabilities)
+        is ModuleCoordinates -> ModuleDependency(coordinates, capabilities)
+        is FlatCoordinates -> FlatDependency(coordinates, capabilities)
+        is IncludedBuildCoordinates -> IncludedBuildDependency(coordinates, capabilities)
       }
     }
   }


### PR DESCRIPTION
This removes some instances of absolute file paths (not all, however). This should help a bit with cache relocatability.