### PR TITLE
fix: when following a bundle rule, don't drop 'api' dependencies.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/Bundles.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/Bundles.kt
@@ -51,13 +51,13 @@ internal class Bundles private constructor(
     primaryPointers.putIfAbsent(subordinate, primary)
   }
 
-  fun hasParentInBundle(coordinates: Coordinates): Boolean = parentPointers[coordinates] != null
+  fun findParent(coordinates: Coordinates): Coordinates? = parentPointers[coordinates]
 
-  fun findParentInBundle(coordinates: Coordinates): Coordinates? = parentPointers[coordinates]
+  fun hasParent(coordinates: Coordinates): Boolean = findParent(coordinates) != null
 
   /**
    * Requirements for calling this method:
-   * 1. [hasParentInBundle] has already been called and it returns true. Otherwise this method will throw.
+   * 1. [hasParent] has already been called and it returns true. Otherwise this method will throw.
    * 2. [addAdvice] is add-advice. Otherwise this method will throw.
    *
    * Can return either [addAdvice] exactly, or a change-advice. Will do the latter when the following is true:
@@ -80,7 +80,7 @@ internal class Bundles private constructor(
   fun maybeParent(addAdvice: Advice, originalCoordinates: Coordinates): Advice {
     check(addAdvice.isAdd()) { "Must be add-advice. Was '$addAdvice'." }
 
-    val parent = findParentInBundle(originalCoordinates)
+    val parent = findParent(originalCoordinates)
       ?: error("No parent for $originalCoordinates. Check 'hasParentInBundle()' before calling this method.")
     val parentCoordinates = preferredCoordinates(parent, addAdvice)
 
@@ -139,8 +139,10 @@ internal class Bundles private constructor(
           // This means the parent is in the same source set
           else -> addAdvice.toConfiguration
         }
+      } else if (parentDeclaration.configurationName == "implementation") {
+        "api"
       } else {
-        // TODO(tsr): not a KMP project. What can we say?
+        // TODO(tsr): handle any other cases?
         null
       }
 
@@ -176,6 +178,7 @@ internal class Bundles private constructor(
 
   fun maybePrimary(addAdvice: Advice, originalCoordinates: Coordinates): Advice {
     check(addAdvice.isAdd()) { "Must be add-advice" }
+
     return primaryPointers[originalCoordinates]?.let { primary ->
       val preferredCoordinatesNotation = preferredCoordinates(primary, addAdvice)
       addAdvice.copy(coordinates = preferredCoordinatesNotation.withoutDefaultCapability())

--- a/src/main/kotlin/com/autonomousapps/internal/reason/DependencyAdviceExplainer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/reason/DependencyAdviceExplainer.kt
@@ -98,8 +98,9 @@ internal class DependencyAdviceExplainer(
             check(trace is BundleTrace.PrimaryMap) { "Expected a ${BundleTrace.PrimaryMap::class.java.simpleName}" }
 
             "You have been advised to add this dependency to '${a.toConfiguration!!.colorize(Colors.GREEN)}'.\n" +
-              "It matched a $bundle rule: ${printableIdentifier(trace.primary).colorize(Colors.BOLD)} was substituted for " +
-              "${printableIdentifier(trace.subordinate).colorize(Colors.BOLD)}."
+              "It matched a $bundle rule: ${printableIdentifier(trace.primary).colorize(Colors.BOLD)} was substituted for ${
+                printableIdentifier(trace.subordinate).colorize(Colors.BOLD)
+              }."
           } else {
             "You have been advised to add this dependency to '${a.toConfiguration!!.colorize(Colors.GREEN)}'."
           }
@@ -110,8 +111,19 @@ internal class DependencyAdviceExplainer(
         }
 
         a.isChange() || a.isChangeToRuntimeOnly() || a.isCompileOnly() -> {
-          "You have been advised to change this dependency to '${a.toConfiguration!!.colorize(Colors.GREEN)}' " +
-            "from '${a.fromConfiguration!!.colorize(Colors.YELLOW)}'."
+          val base =
+            "You have been advised to change this dependency to '${a.toConfiguration!!.colorize(Colors.GREEN)}' from '${
+              a.fromConfiguration!!.colorize(Colors.YELLOW)
+            }'."
+
+          val trace = findTrace()
+          if (trace != null) {
+            "$base\nIt matched a $bundle rule: ${printableIdentifier(trace.top).colorize(Colors.BOLD)} was substituted for ${
+              printableIdentifier(trace.bottom).colorize(Colors.BOLD)
+            }."
+          } else {
+            base
+          }
         }
 
         else -> error("Unknown advice type: $advice")

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeAdviceTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeAdviceTask.kt
@@ -357,8 +357,8 @@ internal class DependencyAdviceBuilder(
           //  `parentAdvice` case.
           // This can transform add-advice to change-advice. Currently only for KMP projects where the "parent" KMP dep
           // is declared on a commonX configuration, and the "child" -jvm or -android dep needs to be upgraded.
-          advice.isAdd() && bundles.hasParentInBundle(originalCoordinates) -> {
-            val parent = bundles.findParentInBundle(originalCoordinates)!!
+          advice.isAdd() && bundles.hasParent(originalCoordinates) -> {
+            val parent = bundles.findParent(originalCoordinates)!!
 
             val parentAdvice = bundles.maybeParent(advice, originalCoordinates)
             if (parentAdvice != advice) {

--- a/src/test/kotlin/com/autonomousapps/internal/BundlesTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/BundlesTest.kt
@@ -12,6 +12,7 @@ import com.autonomousapps.model.internal.declaration.ConfigurationNames
 import com.autonomousapps.model.internal.declaration.Declaration
 import com.autonomousapps.model.internal.intermediates.Reason
 import com.autonomousapps.model.internal.intermediates.Usage
+import com.autonomousapps.model.source.AndroidSourceKind
 import com.autonomousapps.model.source.JvmSourceKind
 import com.autonomousapps.model.source.KmpSourceKind
 import com.autonomousapps.model.source.SourceKind
@@ -32,6 +33,14 @@ class BundlesTest {
   private val dependenciesHandler = RealDependenciesHandler(objects)
   private val gvi = GradleVariantIdentification.EMPTY
 
+  private val androidConfigurationNames = ConfigurationNames(
+    projectType = ProjectType.ANDROID,
+    supportedSourceSetNames = setOf(
+      "main",
+      "debug",
+      "test",
+    )
+  )
   private val jvmConfigurationNames = ConfigurationNames(ProjectType.JVM, setOf("main", "test"))
   private val kmpConfigurationNames = ConfigurationNames(
     projectType = ProjectType.KMP,
@@ -71,7 +80,7 @@ class BundlesTest {
         ignoreKtx = false
       )
 
-      assertThat(bundles.hasParentInBundle(stdlib)).isTrue()
+      assertThat(bundles.hasParent(stdlib)).isTrue()
       assertThat(bundles.hasUsedChild(stdlibJdk8)).isTrue()
     }
 
@@ -86,7 +95,7 @@ class BundlesTest {
      * ```
      * because okio is the implicit parent of okio-jvm, and in this case okio is declared on commonMainImplementation.
      */
-    @Test fun `transforms add (jvmMainApi) to change (commonMainImplementation to commonMainApi) for kmp (implicit bundles)`() {
+    @Test fun `transforms add (jvmMainApi) to change (commonMainImplementation to commonMainApi) for kmp`() {
       // Given a project that has a dependency graph with three nodes (itself, okio, and okio-jvm)
       val consumer = ProjectCoordinates(":consumer", gvi)
       val okio = ModuleCoordinates("com.squareup.okio:okio", "3.16.4", gvi)
@@ -142,7 +151,7 @@ class BundlesTest {
      * ```
      * because okio is the implicit parent of okio-jvm, and in this case okio is declared on jvmMainImplementation.
      */
-    @Test fun `transforms change (jvmMainImplementation-jvmMainApi) for okio-jvm to okio for kmp (implicit bundles)`() {
+    @Test fun `transforms change (jvmMainImplementation-jvmMainApi) for okio-jvm to okio for kmp`() {
       // Given a project that has a dependency graph with three nodes (itself, okio, and okio-jvm)
       val consumer = ProjectCoordinates(":consumer", gvi)
       val okio = ModuleCoordinates("com.squareup.okio:okio", "3.16.4", gvi)
@@ -194,7 +203,7 @@ class BundlesTest {
      *
      * @see <a href="https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1653">Issue 1653</a>.
      */
-    @Test fun `does not transform change (jvmMainImplementation-jvmMainApi) for metro-runtime for kmp (implicit bundles)`() {
+    @Test fun `does not transform change (jvmMainImplementation-jvmMainApi) for metro-runtime for kmp`() {
       // Given a project that has a dependency graph with three nodes (itself, okio, and okio-jvm)
       val consumer = ProjectCoordinates(":consumer", gvi)
       val metroRuntime = ModuleCoordinates("dev.zacsweers.metro:runtime", "0.10.2", gvi)
@@ -231,6 +240,69 @@ class BundlesTest {
       // Then the advice remains unchanged
       val addAdvice = Advice.ofAdd(metroRuntimeJvm, "jvmMainApi")
       assertThat(bundles.maybeParent(addAdvice, metroRuntimeJvm)).isEqualTo(addAdvice)
+    }
+  }
+
+  @Nested inner class ExplicitBundles {
+    /**
+     * Because of user-supplied bundle, will transform:
+     * ```
+     * add foo-bar to debugApi
+     * ```
+     * to
+     * ```
+     * change foo from implementation to api
+     * ```
+     * because foo-bar is explicitly declared the primary of foo-bar, and in this case foo is declared on
+     * implementation.
+     */
+    @Test fun `transforms change (debugApi-api) for foo-bar to foo for non-KMP user-supplied bundle`() {
+      // Given a project that has a dependency graph with three nodes (itself, okio, and okio-jvm)
+      val consumer = ProjectCoordinates(":consumer", gvi)
+      val foo = ModuleCoordinates("com.foo:foo", "1", gvi)
+      val fooBar = ModuleCoordinates("com.foo:foo-bar", "1", gvi)
+      val graph = newGraphFrom(
+        // :consumer -> foo -> foo-bar
+        listOf(consumer to foo, foo to fooBar),
+        sourceKind = AndroidSourceKind.MAIN,
+      )
+
+      // ...a single declaration: implementation(libs.foo)
+      val declarations = Declaration(
+        identifier = "com.foo:foo",
+        version = "1",
+        configurationName = "implementation",
+        gradleVariantIdentification = gvi,
+      ).intoSet()
+
+      // ...usages of project :consumer
+      val unused = Reason.Unused.intoSet()
+      val abi = Reason.Abi("Uses 1 class: foo.FooBar").intoSet()
+      val fooUsages = foo to usage(Bucket.NONE, AndroidSourceKind.MAIN, reasons = unused).intoSet()
+      val fooBarUsages = fooBar to usage(Bucket.API, AndroidSourceKind.main("debug"), reasons = abi).intoSet()
+      val dependencyUsages = listOf(fooUsages, fooBarUsages).toMap<Coordinates, Set<Usage>>()
+
+      // ...and the explicit bundle
+      dependenciesHandler.bundle("foo") {
+        it.primary("com.foo:foo")
+        it.includeGroup("com.foo")
+      }
+
+      // When we build the thing under test
+      val bundles = Bundles.of(
+        projectPath = ":consumer",
+        dependencyGraph = graph,
+        bundleRules = dependenciesHandler.serializableBundles(),
+        dependencyUsages = dependencyUsages,
+        declarations = declarations,
+        configurationNames = androidConfigurationNames,
+        ignoreKtx = false
+      )
+
+      // Then it mutates the advice as expected
+      val addAdvice = Advice.ofAdd(fooBar, "debugApi")
+      val expectedAdvice = Advice.ofChange(foo, "implementation", "api")
+      assertThat(bundles.maybeParent(addAdvice, fooBar)).isEqualTo(expectedAdvice)
     }
   }
 


### PR DESCRIPTION
Given a parent-child relationship, bundle behavior is to remove the child advice if the parent is already declared. However, if the child advice was to add to 'api' and the parent is only on 'implementation' (literally just this relationship), then mutate the advice to change the parent from 'implementation' to 'api'. No other combinations are currently considered.

Also update 'reason' to indicate this advice comes from a bundle rule.