### PR TITLE
feat: add exception tracking to exploded-jars.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/AnnotationsImplementationSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/AnnotationsImplementationSpec.groovy
@@ -91,8 +91,6 @@ final class AnnotationsImplementationSpec extends AbstractJvmSpec {
 
     when:
     build(gradleVersion, gradleProject.rootDir, 'buildHealth')
-    // TODO(tsr): still need better tests for reason. Before the fix, this output was wrong. Still not fixed really.
-    //, ':consumer:reason', '--id', 'org.jetbrains:annotations')
 
     then:
     assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
@@ -103,7 +101,10 @@ final class AnnotationsImplementationSpec extends AbstractJvmSpec {
 
   private static String kgpVersionFrom(GradleVersion gradleVersion) {
     if (gradleVersion < GradleVersion.version('9.0.0')) {
-      return '2.0.21'
+      // TODO(tsr): causes Kotlin compilation failure. Possibly related to
+      //  https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1671
+//      return '2.0.21'
+      return '2.1.21'
     } else {
       return '2.2.10'
     }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/ExceptionsAreSpecialSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/ExceptionsAreSpecialSpec.groovy
@@ -1,0 +1,31 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.jvm
+
+import com.autonomousapps.jvm.projects.ExceptionsAreSpecialProject
+import com.autonomousapps.utils.Colors
+
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertThat
+
+class ExceptionsAreSpecialSpec extends AbstractJvmSpec {
+
+  @SuppressWarnings('GroovyAssignabilityCheck')
+  def "annotations on public classes are part of the abi (#gradleVersion isBroken=#isBroken)"() {
+    given:
+    def project = new ExceptionsAreSpecialProject(isBroken)
+    gradleProject = project.gradleProject
+
+    when:
+    def result = build(gradleVersion, gradleProject.rootDir, ':buildHealth', ':consumer:reason', '--id', 'org.json:json')
+
+    then:
+    assertThat(project.actualProjectAdvice()).containsExactlyElementsIn(project.expectedProjectAdvice())
+
+    and:
+    assertThat(Colors.decolorize(result.output)).contains(project.expectedReason())
+
+    where:
+    [gradleVersion, isBroken] << multivariableDataPipe(gradleVersions(), [true, false])
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/ExceptionsAreSpecialProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/ExceptionsAreSpecialProject.groovy
@@ -1,0 +1,136 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.gradle.Dependency
+import com.autonomousapps.model.Advice
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.*
+import static com.autonomousapps.kit.gradle.Dependency.compileOnly
+import static com.autonomousapps.kit.gradle.Dependency.implementation
+
+final class ExceptionsAreSpecialProject extends AbstractProject {
+
+  // Should be implementation, but isn't. Consumer advice
+  private static final Dependency JSON_COMPILE_ONLY = compileOnly('org.json:json:20251224')
+  private static final Dependency JSON_IMPL = implementation('org.json:json:20251224')
+
+  private final boolean isBroken
+  final GradleProject gradleProject
+
+  ExceptionsAreSpecialProject(boolean isBroken) {
+    this.isBroken = isBroken
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newGradleProjectBuilder()
+      .withSubproject('consumer') { s ->
+        s.sources = consumerSources()
+        s.withBuildScript { bs ->
+          bs.plugins(javaLibrary)
+          // should be runtimeOnly to account for the bad metadata in ':producer'
+          bs.dependencies(
+            implementation(':producer'),
+            JSON_IMPL,
+          )
+        }
+      }
+    // Here we should assume that ':producer' is actually an external artifact we have no control over.
+      .withSubproject('producer') { s ->
+        s.sources = producerSources()
+        s.withBuildScript { bs ->
+          bs.plugins(javaLibrary)
+          bs.dependencies(isBroken ? JSON_COMPILE_ONLY : JSON_IMPL)
+        }
+      }
+    // TODO(tsr): another module that has `throws JSONException` to check if that should be `api`?
+      .write()
+  }
+
+  private static final List<Source> consumerSources() {
+    return [
+      Source.java(
+        '''\
+          package mutual.aid.consumer;
+          
+          import mutual.aid.producer.Producer;
+          
+          public class Consumer {
+            public void ohno() {
+              Producer producer = new Producer();
+            }
+          }
+        '''.stripIndent()
+      ).build()
+    ]
+  }
+
+  private static final List<Source> producerSources() {
+    return [
+      Source.java(
+        '''\
+          package mutual.aid.producer;
+          
+          import org.json.JSONException;
+          
+          public class Producer {
+            public void ohno() {
+              try {
+                System.out.println("try");
+              } catch(JSONException e) {
+                System.out.println("catch");
+              }
+            }
+          }
+        '''.stripIndent()
+      ).build()
+    ]
+  }
+
+  Set<ProjectAdvice> actualProjectAdvice() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  private final Set<Advice> consumerAdvice() {
+    if (isBroken) {
+      [Advice.ofChange(moduleCoordinates(JSON_IMPL), JSON_IMPL.configuration, 'runtimeOnly')]
+    } else {
+      [Advice.ofRemove(moduleCoordinates(JSON_IMPL), JSON_IMPL.configuration)]
+    }
+
+  }
+
+  // Current behavior of `compileOnly` is we don't advise to change it. Obviously it can be wrong but not sure what we
+  // can realistically do here.
+  private static final Set<Advice> producerAdvice() {
+    return [
+//      Advice.ofChange(moduleCoordinates(JSON_COMPILE_ONLY), JSON_COMPILE_ONLY.configuration, 'implementation')
+    ]
+  }
+
+  Set<ProjectAdvice> expectedProjectAdvice() {
+    return [
+      projectAdviceForDependencies(':consumer', consumerAdvice()),
+      projectAdviceForDependencies(':producer', producerAdvice()),
+    ]
+  }
+
+  String expectedReason() {
+    if (isBroken) {
+      '''\
+      Source: main
+      ------------
+      * Referenced 1 time by another dependency: (1) ':producer': (a) [org.json.JSONException] by class mutual.aid.producer.Producer (implies runtimeOnly).'''.stripIndent()
+    } else {
+      '''\
+      Source: main
+      ------------
+      (no usages)'''.stripIndent()
+    }
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/ExceptionsAreSpecialProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/ExceptionsAreSpecialProject.groovy
@@ -125,7 +125,7 @@ final class ExceptionsAreSpecialProject extends AbstractProject {
       '''\
       Source: main
       ------------
-      * Referenced 1 time by another dependency: (1) ':producer': (a) [org.json.JSONException] by class mutual.aid.producer.Producer (implies runtimeOnly).'''.stripIndent()
+      * Has exceptions referenced 1 time by another dependency: (1) ':producer': (a) [org.json.JSONException] by class mutual.aid.producer.Producer (implies runtimeOnly).'''.stripIndent()
     } else {
       '''\
       Source: main

--- a/src/main/kotlin/com/autonomousapps/internal/BytecodeParsers.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/BytecodeParsers.kt
@@ -109,7 +109,7 @@ private class BytecodeReader(
   private fun Sequence<String>.fixup(classAnalyzer: ClassAnalyzer): Set<String> {
     return this
       // Filter out `java` packages, but not `javax`
-      .filterNot { it.startsWith("java/") }
+      .filterNot(ClassNames::isCoreJava)
       // Filter out a "used class" that is exactly the class under analysis
       .filterNot { it == classAnalyzer.className }
       // More human-readable
@@ -122,7 +122,7 @@ private class BytecodeReader(
   private fun Sequence<Pair<String, String>>.fixup(classAnalyzer: ClassAnalyzer): Map<String, String> {
     return this
       // Filter out `java` packages, but not `javax`
-      .filterNot { it.first.startsWith("java/") }
+      .filterNot { ClassNames.isCoreJava(it.first) }
       // Filter out a "used class" that is exactly the class under analysis
       .filterNot { it.first == classAnalyzer.className }
       // More human-readable
@@ -136,7 +136,7 @@ private class BytecodeReader(
   private fun Map<String, Set<MemberAccess>>.fixup(classAnalyzer: ClassAnalyzer): Map<String, Set<MemberAccess>> {
     return this
       // Filter out `java` packages, but not `javax`
-      .filterKeys { !it.startsWith("java/") }
+      .filterKeys { !ClassNames.isCoreJava(it) }
       // Filter out a "used class" that is exactly the class under analysis
       .filterKeys { it != classAnalyzer.className }
   }

--- a/src/main/kotlin/com/autonomousapps/internal/ClassNames.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/ClassNames.kt
@@ -6,6 +6,8 @@ internal object ClassNames {
 
   fun canonicalize(className: String): String = className.replace('/', '.').intern()
 
+  fun isCoreJava(className: String): Boolean = className.startsWith("java/")
+
   // TODO(tsr): I think I can delete the slashy version but I'm not sure
   fun isEnum(superClassName: String?): Boolean = superClassName == "java.lang.Enum" || superClassName == "java/lang/Enum"
 

--- a/src/main/kotlin/com/autonomousapps/internal/JarExploder.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/JarExploder.kt
@@ -89,11 +89,9 @@ internal class JarExploder(
     }
 
     val analyzedClasses = visitors.map { it.getAnalyzedClass() }
-      .filterNot {
-        // Filter out `java` packages, but not `javax`
-        it.className.startsWith("java.")
-      }
-      .toSortedSet()
+      // Filter out `java` packages, but not `javax`
+      .filterNot { it.className.startsWith("java.") }
+      .toSet()
 
     return ExplodingJar(
       analyzedClasses = analyzedClasses,

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/DependencyAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/DependencyAnalyzer.kt
@@ -258,7 +258,9 @@ internal abstract class AbstractDependencyAnalyzer(
       // Currently only modeling this via Gradle property. TODO(tsr): hoist it to the DSL.
       t.checkBinaryCompat.set(checkBinaryCompat)
 
+      t.buildPath.set(project.buildPath(compileConfigurationName))
       t.graph.set(graphViewTask.flatMap { it.output })
+      t.graphRuntime.set(graphViewTask.flatMap { it.outputRuntime })
       t.declarations.set(findDeclarationsTask.flatMap { it.output })
       t.dependencies.set(synthesizeDependenciesTask.flatMap { it.outputDir })
       t.syntheticProject.set(synthesizeProjectViewTask.flatMap { it.output })

--- a/src/main/kotlin/com/autonomousapps/internal/asm.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/asm.kt
@@ -46,7 +46,7 @@ internal class ClassNameAndAnnotationsVisitor(private val logger: Logger) : Clas
 
   private val localVariableArray = LocalVariableArray()
   private val reflectiveAccesses = mutableSetOf<String>()
-  private val methodAnalyzer = MethodAnalyzer(logger, localVariableArray, reflectiveAccesses)
+  private val methodAnalyzer = MethodAnalyzer(logger, localVariableArray, reflectiveAccesses, exceptions)
 
   internal fun getAnalyzedClass(): AnalyzedClass {
     val className = this.className
@@ -226,6 +226,7 @@ internal class ClassNameAndAnnotationsVisitor(private val logger: Logger) : Clas
     private val logger: Logger,
     private val localVariableArray: LocalVariableArray,
     private val reflectiveAccesses: MutableSet<String>,
+    private val exceptions: MutableSet<String>,
   ) : MethodVisitor(ASM_VERSION) {
 
     private fun log(msgProvider: () -> String) {
@@ -267,6 +268,14 @@ internal class ClassNameAndAnnotationsVisitor(private val logger: Logger) : Clas
       // that parameter.
       if ("$owner.$name" == "java/lang/Class.forName" && lastConstant != null) {
         reflectiveAccesses += lastConstant.value
+      }
+    }
+
+    override fun visitTryCatchBlock(start: Label, end: Label, handler: Label, type: String?) {
+      log { "  - MethodAnalyzer#visitTryCatchBlock: type=$type" }
+
+      if (type != null && !ClassNames.isCoreJava(type)) {
+        exceptions.add(canonicalize(type))
       }
     }
   }

--- a/src/main/kotlin/com/autonomousapps/internal/asm.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/asm.kt
@@ -36,6 +36,7 @@ internal class ClassNameAndAnnotationsVisitor(private val logger: Logger) : Clas
   private val innerClasses = mutableSetOf<String>()
   private val effectivelyPublicFields = mutableSetOf<Member.Field>()
   private val effectivelyPublicMethods = mutableSetOf<Member.Method>()
+  private val exceptions = mutableSetOf<String>()
 
   private var methodCount = 0
   private var fieldCount = 0
@@ -64,6 +65,7 @@ internal class ClassNameAndAnnotationsVisitor(private val logger: Logger) : Clas
       innerClasses = innerClasses.efficient(),
       constants = constants.efficient(),
       reflectiveAccesses = reflectiveAccesses.efficient(),
+      exceptions = exceptions.efficient(),
       effectivelyPublicFields = effectivelyPublicFields.efficient(),
       effectivelyPublicMethods = effectivelyPublicMethods.efficient(),
     )
@@ -109,7 +111,20 @@ internal class ClassNameAndAnnotationsVisitor(private val logger: Logger) : Clas
   override fun visitMethod(
     access: Int, name: String, descriptor: String, signature: String?, exceptions: Array<out String>?
   ): MethodVisitor {
-    log { "- visitMethod: ${AccessFlags(access).getModifierString()} descriptor=$descriptor name=$name signature=$signature" }
+    log {
+      val exceptions = exceptions.orEmpty().joinToString(separator = ",", prefix = "[", postfix = "]")
+      "- visitMethod: ${AccessFlags(access).getModifierString()} descriptor=$descriptor name=$name signature=$signature exceptions=$exceptions"
+    }
+
+    // Exceptions go in the Exceptions table and get verified by the JVM when it loads a class
+    // About how the JVM handles exceptions: https://www.infoworld.com/article/2165977/how-the-java-virtual-machine-handles-exceptions.html
+    this.exceptions.addAll(
+      exceptions
+        .orEmpty()
+        // Filter out `java` packages
+        .filterNot(ClassNames::isCoreJava)
+        .map(::canonicalize)
+    )
 
     if (!("()V" == descriptor && ("<init>" == name || "<clinit>" == name))) {
       // ignore constructors and static initializers

--- a/src/main/kotlin/com/autonomousapps/internal/kotlin/abiDependencies.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/kotlin/abiDependencies.kt
@@ -3,6 +3,7 @@
 package com.autonomousapps.internal.kotlin
 
 import com.autonomousapps.internal.AbiExclusions
+import com.autonomousapps.internal.ClassNames
 import com.autonomousapps.internal.ClassNames.canonicalize
 import com.autonomousapps.internal.utils.DESC_REGEX
 import com.autonomousapps.internal.utils.allItems
@@ -64,7 +65,7 @@ private fun List<ClassBinarySignature>.explodedAbi(
         sourceFile = classSignature.sourceFile,
         exposedClasses = exposedClasses.asSequence()
           // We don't report that the JDK is part of the ABI
-          .filterNot { it.startsWith("java/") }
+          .filterNot(ClassNames::isCoreJava)
           .map { canonicalize(it) }
           .toSortedSet(),
       )

--- a/src/main/kotlin/com/autonomousapps/internal/models.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/models.kt
@@ -12,7 +12,6 @@ import com.autonomousapps.model.internal.intermediates.producer.Constant
 import com.autonomousapps.model.internal.intermediates.producer.Member
 import com.squareup.moshi.JsonClass
 import java.lang.annotation.RetentionPolicy
-import java.util.regex.Pattern
 
 /** Metadata from an Android manifest. */
 internal data class Manifest(
@@ -47,8 +46,9 @@ internal data class AnalyzedClass(
   val innerClasses: Set<String>,
   val constants: Set<Constant>,
   val reflectiveAccesses: Set<String>,
+  val exceptions: Set<String>,
   val binaryClass: BinaryClass,
-) : Comparable<AnalyzedClass> {
+) {
   constructor(
     className: String,
     outerClassName: String?,
@@ -61,6 +61,7 @@ internal data class AnalyzedClass(
     innerClasses: Set<String>,
     constants: Set<Constant>,
     reflectiveAccesses: Set<String>,
+    exceptions: Set<String>,
     effectivelyPublicFields: Set<Member.Field>,
     effectivelyPublicMethods: Set<Member.Method>,
   ) : this(
@@ -73,6 +74,7 @@ internal data class AnalyzedClass(
     innerClasses = innerClasses,
     constants = constants,
     reflectiveAccesses = reflectiveAccesses,
+    exceptions = exceptions,
     binaryClass = BinaryClass(
       className = className.intern(),
       superClassName = superClassName?.intern(),
@@ -92,8 +94,6 @@ internal data class AnalyzedClass(
       else -> null
     }
   }
-
-  override fun compareTo(other: AnalyzedClass): Int = className.compareTo(other.className)
 }
 
 @JsonClass(generateAdapter = false)
@@ -121,7 +121,9 @@ internal data class AbiExclusions(
   private val pathRegexes = pathExclusions.mapToSet(String::toRegex)
 
   fun includeAll() = includeAnnotationRegexes.isEmpty() && includeClassRegexes.isEmpty()
-  fun includesAnnotation(fqcn: String): Boolean = includeAnnotationRegexes.any { it.containsMatchIn(fqcn.binaryToHuman()) }
+  fun includesAnnotation(fqcn: String): Boolean =
+    includeAnnotationRegexes.any { it.containsMatchIn(fqcn.binaryToHuman()) }
+
   fun includesClass(fqcn: String) = includeClassRegexes.any { it.containsMatchIn(fqcn.binaryToHuman()) }
   fun excludesAnnotation(fqcn: String): Boolean = annotationRegexes.any { it.containsMatchIn(fqcn.binaryToHuman()) }
   fun excludesClass(fqcn: String) = classRegexes.any { it.containsMatchIn(fqcn.binaryToHuman()) }

--- a/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
@@ -146,6 +146,18 @@ internal inline fun <T, R : Any> Iterable<T>.mapNotNullToOrderedSet(transform: (
   return mapNotNullTo(TreeSet(), transform)
 }
 
+internal inline fun <T, R : Any, V : Any> Iterable<T>.mapSecondNotNull(transform: (T) -> Pair<R, V?>): List<Pair<R, V>> {
+  return mapNotNull {
+    val pair = transform(it)
+    if (pair.second != null) {
+      @Suppress("UNCHECKED_CAST")
+      pair as Pair<R, V>
+    } else {
+      null
+    }
+  }
+}
+
 /**
  * Sort elements keeping Comparable-equal elements (stable sorting).
  * This method has different semantics with standard toSortedSet(Comparator).

--- a/src/main/kotlin/com/autonomousapps/model/internal/Capability.kt
+++ b/src/main/kotlin/com/autonomousapps/model/internal/Capability.kt
@@ -176,6 +176,24 @@ internal data class ConstantCapability(
   }
 }
 
+@TypeLabel("exception")
+@JsonClass(generateAdapter = false)
+internal data class ExceptionCapability(
+  /** Map of class names to the exceptions they handle. Does not include standard Java exceptions. */
+  val exceptions: Map<String, Set<String>>,
+) : Capability() {
+
+  companion object {
+    fun newInstance(exceptions: Map<String, Set<String>>): ExceptionCapability {
+      return ExceptionCapability(exceptions.toSortedMap().efficient())
+    }
+  }
+
+  override fun merge(other: Capability): Capability {
+    return newInstance(exceptions + (other as ExceptionCapability).exceptions)
+  }
+}
+
 @TypeLabel("inferred")
 @JsonClass(generateAdapter = false)
 internal data class InferredCapability(

--- a/src/main/kotlin/com/autonomousapps/model/internal/intermediates/ExplodingJar.kt
+++ b/src/main/kotlin/com/autonomousapps/model/internal/intermediates/ExplodingJar.kt
@@ -66,22 +66,27 @@ internal class ExplodingJar(
   /** Map of class names to the reflective accesses they make. May be empty. */
   val reflectiveAccesses: Map<String, Set<String>> = analyzedClasses.asSequence()
     .filterNot { it.reflectiveAccesses.isEmpty() }
-    .map { it.className to it.reflectiveAccesses }
-    .toMap()
+    .associate { it.className to it.reflectiveAccesses }
+    .toSortedMap()
+    .efficient()
+
+  /** Map of class names to the exceptions they handle. Does not include standard Java exceptions. May be empty. */
+  val exceptions: Map<String, Set<String>> = analyzedClasses.asSequence()
+    .filterNot { it.exceptions.isEmpty() }
+    .associate { it.className to it.exceptions }
     .toSortedMap()
     .efficient()
 
   /**
    * A jar is a lint jar if it's _only_ for linting.
    *
-   * nb: We're deliberately using `all` here because it is also true if the collection is empty,
-   * which is what we want.
+   * nb: We're deliberately using `all` here because it is also true if the collection is empty, which is what we want.
    */
   val isLintJar: Boolean = analyzedClasses.all { it.hasNoMembers } && androidLintRegistry != null
 
   /**
-   * True if this jar is a candidate for the `compileOnly` configuration, and false otherwise. See
-   * the class-level javadoc for an explanation of the algorithm.
+   * True if this jar is a candidate for the `compileOnly` configuration, and false otherwise. See the class-level
+   * Javadoc for an explanation of the algorithm.
    */
   val isCompileOnlyCandidate: Boolean =
     if (analyzedClasses.isEmpty()) {

--- a/src/main/kotlin/com/autonomousapps/model/internal/intermediates/Reason.kt
+++ b/src/main/kotlin/com/autonomousapps/model/internal/intermediates/Reason.kt
@@ -172,7 +172,7 @@ internal sealed class Reason(open val reason: String) {
   @JsonClass(generateAdapter = false)
   data class Exceptions(override val reason: String) : Reason(reason) {
     constructor(users: Map<Coordinates, Map<String, Set<String>>>) : this(
-      buildReason(asReason(users), "Referenced", Kind.Exception)
+      buildReason(asReason(users), "Has exceptions referenced", Kind.Exception)
     )
 
     override val configurationName: String = "runtimeOnly"

--- a/src/main/kotlin/com/autonomousapps/model/internal/intermediates/Reason.kt
+++ b/src/main/kotlin/com/autonomousapps/model/internal/intermediates/Reason.kt
@@ -4,6 +4,7 @@ package com.autonomousapps.model.internal.intermediates
 
 import com.autonomousapps.internal.strings.slashy
 import com.autonomousapps.internal.utils.capitalizeSafely
+import com.autonomousapps.model.Coordinates
 import com.autonomousapps.model.internal.AndroidResSource
 import com.autonomousapps.model.internal.intermediates.consumer.MemberAccess
 import com.autonomousapps.model.internal.intermediates.producer.BinaryClass
@@ -165,6 +166,37 @@ internal sealed class Reason(open val reason: String) {
     )
 
     override val configurationName: String = "implementation"
+  }
+
+  @TypeLabel("exceptions")
+  @JsonClass(generateAdapter = false)
+  data class Exceptions(override val reason: String) : Reason(reason) {
+    constructor(users: Map<Coordinates, Map<String, Set<String>>>) : this(
+      buildReason(asReason(users), "Referenced", Kind.Exception)
+    )
+
+    override val configurationName: String = "runtimeOnly"
+
+    private companion object {
+      /**
+       * Ends up looking like
+       * ```
+       * * Referenced 1 time by another dependency: (1) ':producer': (a) [org.json.JSONException] by class mutual.aid.producer.Producer (implies runtimeOnly).
+       * ```
+       * See `ExceptionsAreSpecialSpec`.
+       */
+      fun asReason(users: Map<Coordinates, Map<String, Set<String>>>): Collection<String> {
+        return users.entries.mapIndexed { i, user ->
+          val uses = user.value.entries
+            .mapIndexed { j, entry ->
+              "(${'a' + j}) ${entry.value} by class ${entry.key}"
+            }
+            .joinToString(separator = ", ")
+
+          "(${i + 1}) '${user.key.gav()}': $uses"
+        }
+      }
+    }
   }
 
   @TypeLabel("impl")
@@ -419,6 +451,7 @@ private enum class Kind(
   Annotation("annotation", "annotations"),
   Class("class", "classes"),
   Constant("constant", "constants"),
+  Exception("time by another dependency", "times by other dependencies"),
   InlineMember("inline member", "inline members"),
   LintRegistry("lint registry", "lint registries"),
   NativeBinary("native binary", "native binaries"),

--- a/src/main/kotlin/com/autonomousapps/model/internal/intermediates/producer/ExplodedJar.kt
+++ b/src/main/kotlin/com/autonomousapps/model/internal/intermediates/producer/ExplodedJar.kt
@@ -22,31 +22,41 @@ internal data class ExplodedJar(
    * True if this dependency contains only annotations. False otherwise.
    */
   val isAnnotations: Boolean = false,
+
   /**
    * The set of classes that are service providers (they extend [java.security.Provider]). May be
    * empty.
    */
   val securityProviders: Set<String> = emptySet(),
+
   /**
    * Android Lint registry, if there is one. May be null.
    */
   val androidLintRegistry: String? = null,
+
   /**
    * True if this component contains _only_ an Android Lint jar/registry. If this is true,
    * [androidLintRegistry] must be non-null.
    */
   val isLintJar: Boolean = false,
+
   /**
    * The classes (with binary member signatures) provided by this library.
    */
   val binaryClasses: Set<BinaryClass>,
+
   /**
    * A map of each class declared by this library to the set of constants it defines. The latter may
    * be empty for any given declared class.
    */
   val constants: Map<String, Set<Constant>>,
+
   /** Map of class names to the reflective accesses they make (using [Class.forName]). May be empty. */
   val reflectiveAccesses: Map<String, Set<String>>,
+
+  /** Map of class names to the exceptions they handle. Does not include standard Java exceptions. May be empty. */
+  val exceptions: Map<String, Set<String>>,
+
   /**
    * All the "Kt" files within this component.
    */
@@ -65,6 +75,7 @@ internal data class ExplodedJar(
     binaryClasses = exploding.binaryClasses,
     constants = exploding.constants,
     reflectiveAccesses = exploding.reflectiveAccesses,
+    exceptions = exploding.exceptions,
     ktFiles = exploding.ktFiles
   )
 
@@ -78,6 +89,7 @@ internal data class ExplodedJar(
       .thenBy(LexicographicIterableComparator()) { it.ktFiles }
       .thenBy(MapSetComparator()) { it.constants }
       .thenBy(MapSetComparator()) { it.reflectiveAccesses }
+      .thenBy(MapSetComparator()) { it.exceptions }
       .compare(this, other)
   }
 

--- a/src/main/kotlin/com/autonomousapps/model/internal/intermediates/producer/ExplodedJar.kt
+++ b/src/main/kotlin/com/autonomousapps/model/internal/intermediates/producer/ExplodedJar.kt
@@ -104,6 +104,7 @@ internal data class ExplodedJar(
     capabilities += InferredCapability(isAnnotations)
     binaryClasses.ifNotEmpty { capabilities += BinaryClassCapability.newInstance(it) }
     constants.ifNotEmpty { capabilities += ConstantCapability.newInstance(it, ktFiles) }
+    exceptions.ifNotEmpty { capabilities += ExceptionCapability.newInstance(it) }
     securityProviders.ifNotEmpty { capabilities += SecurityProviderCapability.newInstance(it) }
     androidLintRegistry?.let { capabilities += AndroidLinterCapability(it, isLintJar) }
     return capabilities

--- a/src/main/kotlin/com/autonomousapps/model/internal/intermediates/producer/ReflectingDependency.kt
+++ b/src/main/kotlin/com/autonomousapps/model/internal/intermediates/producer/ReflectingDependency.kt
@@ -31,21 +31,19 @@ internal data class ReflectingDependency(
       require(accessingClasses.isNotEmpty())
     }
 
-    fun asReason(): String {
-      return buildString {
-        append(accessor.gav())
-        append(" in class ")
+    fun asReason() = buildString {
+      append(accessor.gav())
+      append(" in class ")
 
-        if (accessingClasses.size == 1) {
-          append(accessingClasses.first())
-        } else {
-          append(accessingClasses)
-          append("*")
-        }
-
-        append(": ")
-        append(accessedClass)
+      if (accessingClasses.size == 1) {
+        append(accessingClasses.first())
+      } else {
+        append(accessingClasses)
+        append("*")
       }
+
+      append(": ")
+      append(accessedClass)
     }
 
     override fun compareTo(other: ReflectiveAccess): Int {

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeUsagesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeUsagesTask.kt
@@ -713,18 +713,31 @@ private class GraphVisitor(
       .filterNot { dependency -> dependency.coordinates == coordinates }
       // If the dependency's runtime graph can reach `this` dependency, then we can skip analysis
       .filterNot { dependency ->
-        context.graphRuntime.graph
-          .reachableNodes(dependency.coordinates)
-          .contains(coordinates)
+        val graph = context.graphRuntime.graph
+        if (dependency.coordinates in graph.nodes()) {
+          graph
+            .reachableNodes(dependency.coordinates)
+            .contains(coordinates)
+        } else {
+          false
+        }
       }
       .mapSecondNotNull { dependency -> dependency.coordinates to dependency.findCapability<ExceptionCapability>() }
       .associate { (coordinates, exceptionCapability) ->
         // The specific exception types this dependency references
         val preferredCoordinates = coordinates.maybeProjectCoordinates(buildPath)
         preferredCoordinates to exceptionCapability.exceptions
-          .map { (className, types) ->
-            val relevantTypes = types.filterToOrderedSet { exceptions.contains(it) }
-            className to relevantTypes
+          .mapNotNull { (className, types) ->
+            val relevantTypes = types.filterToOrderedSet { type -> type in exceptions }
+            if (relevantTypes.isEmpty()) {
+              null
+            } else {
+              className to relevantTypes
+            }
+          }
+          // It only matters if the code of `this` project refers to a class that itself references a relevant type
+          .filter { (className, _) ->
+            codeSource.any { source -> className in source.usedNonAnnotationClasses }
           }
           .toMap()
       }

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeUsagesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeUsagesTask.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.tasks
 
+import com.android.utils.associateNotNull
 import com.autonomousapps.graph.Graphs.parents
 import com.autonomousapps.graph.Graphs.reachableNodes
 import com.autonomousapps.graph.Graphs.root
@@ -707,8 +708,9 @@ private class GraphVisitor(
     // (i.e., `context.project`).
     val exceptions = capability.exceptions.values.flatten().toSet()
 
+    // TODO(tsr): extract this to testable function
     // These are all the dependencies of this project that use the exception types provided by `coordinates`.
-    val users = context.dependencies
+    val users: Map<Coordinates, Map<String, Set<String>>> = context.dependencies
       // The dependency can see all its own exceptions
       .filterNot { dependency -> dependency.coordinates == coordinates }
       // If the dependency's runtime graph can reach `this` dependency, then we can skip analysis
@@ -723,10 +725,8 @@ private class GraphVisitor(
         }
       }
       .mapSecondNotNull { dependency -> dependency.coordinates to dependency.findCapability<ExceptionCapability>() }
-      .associate { (coordinates, exceptionCapability) ->
-        // The specific exception types this dependency references
-        val preferredCoordinates = coordinates.maybeProjectCoordinates(buildPath)
-        preferredCoordinates to exceptionCapability.exceptions
+      .associateNotNull { (coordinates, exceptionCapability) ->
+        val classToExceptionType = exceptionCapability.exceptions
           .mapNotNull { (className, types) ->
             val relevantTypes = types.filterToOrderedSet { type -> type in exceptions }
             if (relevantTypes.isEmpty()) {
@@ -740,6 +740,13 @@ private class GraphVisitor(
             codeSource.any { source -> className in source.usedNonAnnotationClasses }
           }
           .toMap()
+
+        if (classToExceptionType.isNotEmpty()) {
+          // The specific exception types this dependency references
+          coordinates.maybeProjectCoordinates(buildPath) to classToExceptionType
+        } else {
+          null
+        }
       }
 
     return if (users.isNotEmpty()) {

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeUsagesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeUsagesTask.kt
@@ -3,8 +3,10 @@
 package com.autonomousapps.tasks
 
 import com.autonomousapps.graph.Graphs.parents
+import com.autonomousapps.graph.Graphs.reachableNodes
 import com.autonomousapps.graph.Graphs.root
 import com.autonomousapps.internal.binary.BinaryCompatibilityChecker
+import com.autonomousapps.internal.graph.maybeProjectCoordinates
 import com.autonomousapps.internal.graph.supers.SuperNode
 import com.autonomousapps.internal.utils.*
 import com.autonomousapps.model.Coordinates
@@ -46,9 +48,16 @@ public abstract class ComputeUsagesTask @Inject constructor(
   @get:Input
   public abstract val checkBinaryCompat: Property<Boolean>
 
+  @get:Input
+  public abstract val buildPath: Property<String>
+
   @get:PathSensitive(PathSensitivity.NONE)
   @get:InputFile
   public abstract val graph: RegularFileProperty
+
+  @get:PathSensitive(PathSensitivity.NONE)
+  @get:InputFile
+  public abstract val graphRuntime: RegularFileProperty
 
   @get:PathSensitive(PathSensitivity.NONE)
   @get:InputFile
@@ -77,7 +86,9 @@ public abstract class ComputeUsagesTask @Inject constructor(
       it.checkSuperClasses.set(checkSuperClasses)
       it.checkBinaryCompat.set(checkBinaryCompat)
 
+      it.buildPath.set(buildPath)
       it.graph.set(graph)
+      it.graph.set(graphRuntime)
       it.declarations.set(declarations)
       it.dependencies.set(dependencies)
       it.syntheticProject.set(syntheticProject)
@@ -91,7 +102,9 @@ public abstract class ComputeUsagesTask @Inject constructor(
     public val checkSuperClasses: Property<Boolean>
     public val checkBinaryCompat: Property<Boolean>
 
+    public val buildPath: Property<String>
     public val graph: RegularFileProperty
+    public val graphRuntime: RegularFileProperty
     public val declarations: RegularFileProperty
     public val dependencies: DirectoryProperty
     public val syntheticProject: RegularFileProperty
@@ -102,14 +115,16 @@ public abstract class ComputeUsagesTask @Inject constructor(
 
   public abstract class ComputeUsagesAction : WorkAction<ComputeUsagesParameters> {
 
+    private val buildPath = parameters.buildPath.get()
     private val graph = parameters.graph.fromJson<DependencyGraphView>()
+    private val graphRuntime = parameters.graph.fromJson<DependencyGraphView>()
     private val declarations = parameters.declarations.fromJsonSet<Declaration>()
     private val project = parameters.syntheticProject.fromJson<ProjectVariant>()
     private val dependencies = project.dependencies(parameters.dependencies.get())
-    private val duplicateClasses = parameters.duplicateClassesReports.get().asSequence()
-      .map { it.fromJsonSet<DuplicateClass>() }
-      .flatten()
-      .toSortedSet()
+    private val duplicateClasses =
+      parameters.duplicateClassesReports.get().asSequence()
+        .flatMap { it.fromJsonSet<DuplicateClass>() }
+        .toSortedSet()
 
     override fun execute() {
       val output = parameters.output.getAndDelete()
@@ -118,11 +133,13 @@ public abstract class ComputeUsagesTask @Inject constructor(
         project = project,
         dependencies = dependencies,
         graph = graph,
+        graphRuntime = graphRuntime,
         declarations = declarations,
         duplicateClasses = duplicateClasses,
       )
       val visitor = GraphVisitor(
         project = project,
+        buildPath = buildPath,
         kapt = parameters.kapt.get(),
         checkSuperClasses = parameters.checkSuperClasses.get(),
         checkBinaryCompat = parameters.checkBinaryCompat.get(),
@@ -136,6 +153,7 @@ public abstract class ComputeUsagesTask @Inject constructor(
 
 private class GraphVisitor(
   project: ProjectVariant,
+  private val buildPath: String,
   private val kapt: Boolean,
   private val checkSuperClasses: Boolean,
   private val checkBinaryCompat: Boolean,
@@ -173,6 +191,7 @@ private class GraphVisitor(
     var isCompileOnlyCandidate = false
     var isAnnotationCandidate = false
     var isRuntimeAndroid = false
+    var hasReferencedExceptionType = false
     var usesTestInstrumentationRunner = false
     var usesResBySource = false
     var usesResByResCompileTime = false
@@ -242,6 +261,10 @@ private class GraphVisitor(
           // only if necessary.
           usesConstant = usesConstantByBytecode(dependencyCoordinates, capability, context)
           usesConstant = usesConstant || usesConstantByImport(dependencyCoordinates, capability, context)
+        }
+
+        is ExceptionCapability -> {
+          hasReferencedExceptionType = isForMissingRuntimeException(dependencyCoordinates, capability, context)
         }
 
         is InferredCapability -> {
@@ -323,6 +346,9 @@ private class GraphVisitor(
       isUnusedCandidate = false
       reportBuilder[dependencyCoordinates, Kind.DEPENDENCY] = Bucket.COMPILE_ONLY
     } else if (isAccessedByReflection) {
+      reportBuilder[dependencyCoordinates, Kind.DEPENDENCY] = Bucket.RUNTIME_ONLY
+    } else if (hasReferencedExceptionType) {
+      isUnusedCandidate = false
       reportBuilder[dependencyCoordinates, Kind.DEPENDENCY] = Bucket.RUNTIME_ONLY
     } else if (noRealCapabilities(dependency)) {
       isUnusedCandidate = true
@@ -660,6 +686,51 @@ private class GraphVisitor(
 
     return if (imports.isNotEmpty()) {
       reportBuilder[coordinates, Kind.DEPENDENCY] = Reason.ConstantImport(imports)
+      true
+    } else {
+      false
+    }
+  }
+
+  private fun isForMissingRuntimeException(
+    coordinates: Coordinates,
+    capability: ExceptionCapability,
+    context: GraphViewVisitor.Context,
+  ): Boolean {
+    val codeSource = context.project.codeSource
+    if (codeSource.isEmpty()) {
+      // nothing to do here
+      return false
+    }
+
+    // These are all the exception types referenced by `coordinates`, which is a specific dependency of `this` project
+    // (i.e., `context.project`).
+    val exceptions = capability.exceptions.values.flatten().toSet()
+
+    // These are all the dependencies of this project that use the exception types provided by `coordinates`.
+    val users = context.dependencies
+      // The dependency can see all its own exceptions
+      .filterNot { dependency -> dependency.coordinates == coordinates }
+      // If the dependency's runtime graph can reach `this` dependency, then we can skip analysis
+      .filterNot { dependency ->
+        context.graphRuntime.graph
+          .reachableNodes(dependency.coordinates)
+          .contains(coordinates)
+      }
+      .mapSecondNotNull { dependency -> dependency.coordinates to dependency.findCapability<ExceptionCapability>() }
+      .associate { (coordinates, exceptionCapability) ->
+        // The specific exception types this dependency references
+        val preferredCoordinates = coordinates.maybeProjectCoordinates(buildPath)
+        preferredCoordinates to exceptionCapability.exceptions
+          .map { (className, types) ->
+            val relevantTypes = types.filterToOrderedSet { exceptions.contains(it) }
+            className to relevantTypes
+          }
+          .toMap()
+      }
+
+    return if (users.isNotEmpty()) {
+      reportBuilder[coordinates, Kind.DEPENDENCY] = Reason.Exceptions(users)
       true
     } else {
       false

--- a/src/main/kotlin/com/autonomousapps/visitor/GraphViewReader.kt
+++ b/src/main/kotlin/com/autonomousapps/visitor/GraphViewReader.kt
@@ -16,12 +16,13 @@ internal class GraphViewReader(
   private val project: ProjectVariant,
   private val dependencies: Set<Dependency>,
   private val graph: DependencyGraphView,
+  private val graphRuntime: DependencyGraphView,
   private val declarations: Set<Declaration>,
   private val duplicateClasses: Set<DuplicateClass>,
 ) {
 
   fun accept(visitor: GraphViewVisitor) {
-    val context = DefaultContext(project, dependencies, graph, declarations, duplicateClasses)
+    val context = DefaultContext(project, dependencies, graph, graphRuntime, declarations, duplicateClasses)
     project.excludedIdentifiers.forEach { excludedIdentifier ->
       visitor.visit(excludedIdentifier)
     }
@@ -35,6 +36,7 @@ internal class DefaultContext(
   override val project: ProjectVariant,
   override val dependencies: Set<Dependency>,
   override val graph: DependencyGraphView,
+  override val graphRuntime: DependencyGraphView,
   override val declarations: Set<Declaration>,
   override val duplicateClasses: Set<DuplicateClass>,
 ) : GraphViewVisitor.Context {

--- a/src/main/kotlin/com/autonomousapps/visitor/GraphViewVisitor.kt
+++ b/src/main/kotlin/com/autonomousapps/visitor/GraphViewVisitor.kt
@@ -19,6 +19,7 @@ internal interface GraphViewVisitor {
     val project: ProjectVariant
     val dependencies: Set<Dependency>
     val graph: DependencyGraphView
+    val graphRuntime: DependencyGraphView
     val declarations: Set<Declaration>
     val duplicateClasses: Set<DuplicateClass>
 


### PR DESCRIPTION
Exceptions get verified early by the JVM and so if a dependency is missing an exception's type from the runtime classpath, that can cause failures in the consumer at runtime. This is the first step in adding support for this use-case.

- [x] Squash commits and fixup message.