### PR TITLE
feat(testkit-support): DependencyResolutionManagement can specify repositoriesMode and versionCatalogs.

### DIFF
--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/RootProject.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/RootProject.kt
@@ -98,6 +98,7 @@ public class RootProject(
      */
     public fun withVersionCatalog(file: File) {
       withFile(file)
+      // TODO(tsr): wire this file into DependencyResolutionManagement.versionCatalogs directly
     }
 
     public fun withFile(path: String, content: String) {

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/DependencyResolutionManagement.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/DependencyResolutionManagement.kt
@@ -5,14 +5,59 @@ package com.autonomousapps.kit.gradle
 import com.autonomousapps.kit.render.Element
 import com.autonomousapps.kit.render.Scribe
 
-public class DependencyResolutionManagement(
-  private val repositories: Repositories,
+public class DependencyResolutionManagement @JvmOverloads constructor(
+  private val repositories: Repositories?,
+  private val repositoriesMode: RepositoriesMode? = null,
+  private val versionCatalogs: VersionCatalogs? = null,
 ) : Element.Block {
+
+  public enum class RepositoriesMode : Element.Line {
+    PREFER_PROJECT,
+    PREFER_SETTINGS,
+    FAIL_ON_PROJECT_REPOS,
+    ;
+
+    override fun render(scribe: Scribe): String = scribe.line {
+      it.append("repositoriesMode = RepositoriesMode.")
+      it.append(name)
+    }
+  }
 
   override val name: String = "dependencyResolutionManagement"
 
   override fun render(scribe: Scribe): String = scribe.block(this) { s ->
-    repositories.render(s)
+    repositoriesMode?.render(s)
+    repositories?.render(s)
+    versionCatalogs?.render(s)
+  }
+
+  public class Builder {
+    public var repositories: Repositories = Repositories.DEFAULT_DEPENDENCIES
+    public var repositoriesMode: RepositoriesMode? = null
+    public var versionCatalogs: VersionCatalogs? = null
+
+    public fun withRepositories(repositories: Repositories): Builder {
+      this.repositories = repositories
+      return this
+    }
+
+    public fun withRepositoriesMode(repositoriesMode: RepositoriesMode): Builder {
+      this.repositoriesMode = repositoriesMode
+      return this
+    }
+
+    public fun withVersionCatalogs(versionCatalogs: VersionCatalogs): Builder {
+      this.versionCatalogs = versionCatalogs
+      return this
+    }
+
+    public fun build(): DependencyResolutionManagement {
+      return DependencyResolutionManagement(
+        repositories = repositories,
+        repositoriesMode = repositoriesMode,
+        versionCatalogs = versionCatalogs,
+      )
+    }
   }
 
   public companion object {

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/VersionCatalog.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/VersionCatalog.kt
@@ -1,0 +1,36 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.kit.gradle
+
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.render.Element
+import com.autonomousapps.kit.render.Scribe
+
+public class VersionCatalog(
+  private val catalogName: String,
+  private val fromFiles: String,
+) : Element.Block {
+
+  override val name: String = catalogName
+
+  override fun render(scribe: Scribe): String = when (scribe.dslKind) {
+    GradleProject.DslKind.GROOVY -> renderGroovy(scribe)
+    GradleProject.DslKind.KOTLIN -> renderKotlin(scribe)
+  }
+
+  private fun renderGroovy(scribe: Scribe): String = scribe.block(this) { s ->
+    s.line {
+      it.append("from(files(\"")
+      it.append(fromFiles)
+      it.append("\"))")
+    }
+  }
+
+  private fun renderKotlin(scribe: Scribe): String = scribe.block("create(\"$catalogName\")") { s ->
+    s.line {
+      it.append("from(files(\"")
+      it.append(fromFiles)
+      it.append("\"))")
+    }
+  }
+}

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/VersionCatalogFile.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/VersionCatalogFile.kt
@@ -9,7 +9,7 @@ import org.intellij.lang.annotations.Language
  * [version catalog file](https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format).
  */
 public class VersionCatalogFile(
-  @Language("toml") public var content: String,
+  @param:Language("toml") public var content: String,
 ) {
 
   public companion object {

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/VersionCatalogs.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/VersionCatalogs.kt
@@ -1,0 +1,35 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.kit.gradle
+
+import com.autonomousapps.kit.render.Element
+import com.autonomousapps.kit.render.Scribe
+
+/**
+ * dependencyResolutionManagement {
+ *   versionCatalogs {
+ *     create("libs") {
+ *       from(files("..."))
+ *     }
+ *   }
+ * }
+ */
+public class VersionCatalogs(
+  public val versionCatalogs: List<VersionCatalog>
+) : Element.Block {
+
+  override val name: String = "versionCatalogs"
+
+  override fun render(scribe: Scribe): String = scribe.block(this) { s ->
+    versionCatalogs.forEach { catalog ->
+      catalog.render(s)
+    }
+  }
+
+  public companion object {
+    @JvmStatic
+    public fun of(vararg versionCatalogs: VersionCatalog): VersionCatalogs {
+      return VersionCatalogs(versionCatalogs.toList())
+    }
+  }
+}

--- a/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestGroovy.kt
+++ b/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestGroovy.kt
@@ -60,7 +60,11 @@ internal class ScribeTestGroovy {
     @Test fun `can render dependencyResolutionManagement block`() {
       // Given
       val repositories = Repositories(Repository.GOOGLE, Repository.MAVEN_CENTRAL)
-      val dependencyResolutionManagement = DependencyResolutionManagement(repositories)
+      val dependencyResolutionManagement = DependencyResolutionManagement.Builder()
+        .withRepositories(repositories)
+        .withRepositoriesMode(DependencyResolutionManagement.RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+        .withVersionCatalogs(VersionCatalogs.of(VersionCatalog("myLibs", "my-libs.versions.toml")))
+        .build()
 
       // When
       val text = dependencyResolutionManagement.render(scribe)
@@ -68,14 +72,20 @@ internal class ScribeTestGroovy {
       // Then
       assertThat(text).isEqualTo(
         """
-        dependencyResolutionManagement {
-          repositories {
-            google()
-            mavenCentral()
-          }
-        }
-        
-      """.trimIndent()
+          |dependencyResolutionManagement {
+          |  repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
+          |  repositories {
+          |    google()
+          |    mavenCentral()
+          |  }
+          |  versionCatalogs {
+          |    myLibs {
+          |      from(files("my-libs.versions.toml"))
+          |    }
+          |  }
+          |}
+          |
+        """.trimMargin()
       )
     }
 

--- a/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestKotlin.kt
+++ b/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestKotlin.kt
@@ -60,7 +60,11 @@ internal class ScribeTestKotlin {
     @Test fun `can render dependencyResolutionManagement block`() {
       // Given
       val repositories = Repositories(Repository.GOOGLE, Repository.MAVEN_CENTRAL)
-      val dependencyResolutionManagement = DependencyResolutionManagement(repositories)
+      val dependencyResolutionManagement = DependencyResolutionManagement.Builder()
+        .withRepositories(repositories)
+        .withRepositoriesMode(DependencyResolutionManagement.RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+        .withVersionCatalogs(VersionCatalogs.of(VersionCatalog("my-libs", "my-libs.versions.toml")))
+        .build()
 
       // When
       val text = dependencyResolutionManagement.render(scribe)
@@ -68,14 +72,20 @@ internal class ScribeTestKotlin {
       // Then
       assertThat(text).isEqualTo(
         """
-        dependencyResolutionManagement {
-          repositories {
-            google()
-            mavenCentral()
-          }
-        }
-        
-      """.trimIndent()
+          |dependencyResolutionManagement {
+          |  repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
+          |  repositories {
+          |    google()
+          |    mavenCentral()
+          |  }
+          |  versionCatalogs {
+          |    create("my-libs") {
+          |      from(files("my-libs.versions.toml"))
+          |    }
+          |  }
+          |}
+          |
+        """.trimMargin()
       )
     }
 


### PR DESCRIPTION
Next step is to wire in RootProject.withVersionCatalog() to automatically update DependencyResolutionManagement.versionCatalogs.