### PR TITLE
chore: disable sign tasks when publishing snapshots.

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/autonomousapps/convention/BaseConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/autonomousapps/convention/BaseConventionPlugin.kt
@@ -79,35 +79,44 @@ internal class BaseConventionPlugin(private val project: Project) {
       .orElse("false")
       .map { it.toBoolean() }
 
-    val taskGraph = gradle.taskGraph
-    val isFunctionalTest: Provider<Boolean> = providers.provider { taskGraph.hasTask(":functionalTest") }
+    // Both these values are static and safe to get during configuration
+    val shouldSign = !isCi.get() && !isSnapshot.get()
 
     tasks.withType(Sign::class.java).configureEach { t ->
+      // Disabling this task is better than configuring it with `onlyIf()`. The latter is evaluated at execution time,
+      // so the task still has to get serialized during the CC store phase, which takes a very long time when Sign task
+      // inputs must be serialized. Apparently the task is "some of the worst code in Gradle in terms of laziness"
+      // (personal communication).
+      t.enabled = shouldSign
+
       with(t) {
         inputs.property("version", publishedVersion)
-        inputs.property("is-snapshot", isSnapshot)
-        inputs.property("is-ci", isCi)
-        inputs.property("is-functional-test", isFunctionalTest)
-
-        // Don't sign snapshots
-        onlyIf("Not a snapshot") {
-          !(inputs.properties["is-snapshot"] as Boolean)
-        }
-        // We currently don't support publishing from CI
-        onlyIf("release environment") {
-          !(inputs.properties["is-ci"] as Boolean)
-        }
-        // Don't sign when running functional tests
-        onlyIf("not running functional tests") {
-          !(inputs.properties["is-functional-test"] as Boolean)
-        }
-
+//        inputs.property("is-snapshot", isSnapshot)
+//        inputs.property("is-ci", isCi)
+//        inputs.property("is-functional-test", isFunctionalTest)
+//
+//        // Don't sign snapshots
+//        onlyIf("Not a snapshot") {
+//          !(inputs.properties["is-snapshot"] as Boolean)
+//        }
+//        // We currently don't support publishing from CI
+//        onlyIf("release environment") {
+//          !(inputs.properties["is-ci"] as Boolean)
+//        }
+//        // Don't sign when running functional tests
+//        onlyIf("not running functional tests") {
+//          !(inputs.properties["is-functional-test"] as Boolean)
+//        }
+//
         doFirst {
           val version = inputs.properties["version"] as String
           logger.quiet("Signing v$version")
         }
       }
     }
+
+    val taskGraph = gradle.taskGraph
+    val isFunctionalTest: Provider<Boolean> = providers.provider { taskGraph.hasTask(":functionalTest") }
 
     tasks.withType(DokkaGeneratePublicationTask::class.java).configureEach { t ->
       val key = "is-functional-test"

--- a/build-logic/convention/src/main/kotlin/com/autonomousapps/convention/DagpExtension.kt
+++ b/build-logic/convention/src/main/kotlin/com/autonomousapps/convention/DagpExtension.kt
@@ -83,10 +83,6 @@ public abstract class DagpExtension(
         }
       }
     }
-
-    // TODO(tsr): update URL
-    //val releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-    //val snapshotsRepoUrl = "https://central.sonatype.com/repository/maven-snapshots/"
   }
 
   internal companion object {


### PR DESCRIPTION
Serializing Sign inputs during CC store is extremely slow. This will make certain flows much faster.