### PR TITLE
feat: new ":publicTypeUsage" task.

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -369,13 +369,13 @@ major releases should be treated as non-events. For these users, the "API" is ju
 
 The following is a list of articles / blog posts that have been published discussing this plugin:
 
-1. https://blog.gradle.org/detect-maven-hijack-risks-in-gradle-with-plugin[Detecting Maven-Hijack-style risks in Gradle builds with the Dependency Analysis Gradle Plugin
-]
-2. https://dev.to/autonomousapps/the-proper-care-and-feeding-of-your-gradle-build-d8g[The proper care and feeding of your Gradle build]
-3. https://dev.to/autonomousapps/dependency-analysis-gradle-plugin-using-bytecode-analysis-to-find-unused-dependencies-509n[Dependency Analysis Gradle Plugin: Using bytecode analysis to find unused dependencies]
-4. https://dev.to/autonomousapps/dependency-analysis-gradle-plugin-what-s-an-abi-3l2h[Dependency Analysis Gradle Plugin: What's an ABI?]
-5. https://dev.to/autonomousapps/reducing-my-gradle-plugin-s-impact-on-configuration-time-a-journey-32h2[Reducing my Gradle plugin's impact on configuration time: A journey]
-6. https://dev.to/autonomousapps/one-click-dependencies-fix-191p[One-click dependencies fix]
+1. https://medium.com/@emartynov/from-spaghetti-to-strict-cleaning-up-gradle-dependencies-in-a-large-android-codebase-47b72662109d[From Spaghetti to Strict: Cleaning Up Gradle Dependencies in a large Android codebase]
+2. https://blog.gradle.org/detect-maven-hijack-risks-in-gradle-with-plugin[Detecting Maven-Hijack-style risks in Gradle builds with the Dependency Analysis Gradle Plugin]
+3. https://dev.to/autonomousapps/the-proper-care-and-feeding-of-your-gradle-build-d8g[The proper care and feeding of your Gradle build]
+4. https://dev.to/autonomousapps/dependency-analysis-gradle-plugin-using-bytecode-analysis-to-find-unused-dependencies-509n[Dependency Analysis Gradle Plugin: Using bytecode analysis to find unused dependencies]
+5. https://dev.to/autonomousapps/dependency-analysis-gradle-plugin-what-s-an-abi-3l2h[Dependency Analysis Gradle Plugin: What's an ABI?]
+6. https://dev.to/autonomousapps/reducing-my-gradle-plugin-s-impact-on-configuration-time-a-journey-32h2[Reducing my Gradle plugin's impact on configuration time: A journey]
+7. https://dev.to/autonomousapps/one-click-dependencies-fix-191p[One-click dependencies fix]
 
 This plugin has also been featured in these newsletters:
 

--- a/src/functionalTest/groovy/com/autonomousapps/android/PublicTypeUsageSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/PublicTypeUsageSpec.groovy
@@ -1,0 +1,44 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.android
+
+import com.autonomousapps.android.projects.PublicTypeUsageProject
+import com.autonomousapps.internal.android.AgpVersion
+
+import static com.autonomousapps.kit.GradleBuilder.build
+import static com.google.common.truth.Truth.assertThat
+
+@SuppressWarnings('GroovyAssignabilityCheck')
+class PublicTypeUsageSpec extends AbstractAndroidSpec {
+
+  def "type usage can be configured and computed globally (#gradleVersion AGP #agpVersion)"() {
+    given:
+    def project = new PublicTypeUsageProject(agpVersion)
+    gradleProject = project.gradleProject
+
+    when:
+    def result = build(gradleVersion, gradleProject.rootDir, ':publicTypeUsage')
+
+    then:
+    assertThat(project.actualPublicTypeUsage()).isEqualTo(project.expectedPublicTypeUsage)
+
+    and:
+    assertThat(result.output).contains(
+      '''\
+        These projects have public types (classes, interfaces) that have no external accessors. Those types' visibilities could be restricted (e.g., made `internal`).
+        
+        :java-lib (2 types)
+        - com.example.javalib.AnotherPublicUnusedClass
+        - com.example.javalib.PublicUnusedClass
+
+        :module-fire (1 type)
+        - com.example.module.RealMagic
+        
+        :module-water (1 type)
+        - com.example.module.RealMagic'''.stripIndent()
+    )
+
+    where: 'Requires at least AGP 9.1.0 due to Dagger incompatibility with earlier versions'
+    [gradleVersion, agpVersion] << gradleAgpMatrix(AgpVersion.AGP_MAX)
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AbstractAndroidProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AbstractAndroidProject.groovy
@@ -69,6 +69,10 @@ abstract class AbstractAndroidProject extends AbstractProject {
     return isAtLeastAgp9 ? Plugins.androidLegacyKaptNoVersion : Plugins.kotlinKaptNoVersion
   }
 
+  protected List<Plugin> hilt() {
+    [plugins.hiltNoVersion, plugins.kspNoVersion]
+  }
+
   AbstractAndroidProject(String kotlinVersion, String agpVersion) {
     super(kotlinVersion, agpVersion)
 
@@ -115,7 +119,7 @@ abstract class AbstractAndroidProject extends AbstractProject {
       .withRootProject { root ->
         root.gradleProperties += GradleProperties.minimalAndroidProperties()
         root.withBuildScript { bs ->
-          bs.buildscript = BuildscriptBlock.defaultAndroidBuildscriptBlock(agpVersion)
+          bs.plugins += plugins.androidAppNoApply
         }
       }
   }

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/PublicTypeUsageProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/PublicTypeUsageProject.groovy
@@ -1,0 +1,466 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.android.projects
+
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.android.AndroidManifest
+import com.autonomousapps.kit.android.AndroidSubproject
+import com.autonomousapps.kit.gradle.Dependency
+import com.autonomousapps.kit.gradle.Java
+import com.autonomousapps.kit.gradle.kotlin.Kotlin
+import com.autonomousapps.model.internal.PublicTypeUsage
+
+import static com.autonomousapps.internal.OutputPathsKt.getPublicTypeUsagePath
+import static com.autonomousapps.internal.utils.MoshiUtils.MOSHI
+import static com.autonomousapps.kit.gradle.Dependency.implementation
+import static com.autonomousapps.kit.gradle.dependencies.Dependencies.*
+
+final class PublicTypeUsageProject extends AbstractAndroidProject {
+
+  final GradleProject gradleProject
+  private final String agpVersion
+
+  PublicTypeUsageProject(String agpVersion) {
+    super(agpVersion)
+    this.agpVersion = agpVersion
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newAndroidGradleProjectBuilder(agpVersion)
+      .withRootProject { r ->
+        r.withBuildScript { bs ->
+          bs.plugins += [plugins.kspNoApply, plugins.hiltNoApply]
+          bs.additions = '''\
+          dependencyAnalysis {
+            abi {
+              exclusions {
+                ignoreGeneratedCode()
+                ignoreSubPackage("hilt_aggregated_deps")
+                excludeClasses(
+                  "^.*\\\\.Hilt_.*\\$",
+                  // e.g., AutoBindRealThingSingletonModule
+                  "^.*\\\\.AutoBind\\\\w+Module\\$",
+                )
+              }
+            }
+          }
+          '''.stripIndent()
+        }
+      }
+      .withAndroidSubproject('app') { app ->
+        app.withBuildScript { bs ->
+          bs.plugins(androidApp() + hilt())
+          bs.android = defaultAndroidAppBlock()
+          bs.kotlin = Kotlin.DEFAULT
+          bs.additions = appFlavors() + '\n' + excludeTypes()
+          bs.dependencies(
+            implementation(':annotation'),
+            implementation(':inline'),
+            implementation(':java-lib'),
+            fireImplementation(':module-fire'),
+            waterImplementation(':module-water'),
+            hiltAndroid('implementation'),
+            hiltAndroidCompiler('ksp'),
+          )
+        }
+        app.sources = appSources()
+        app.manifest = AndroidManifest.appWithoutStyle('com.example.app.HiltApplication')
+      }
+      .withAndroidLibProject('module-fire') { module ->
+        module.withBuildScript { bs ->
+          bs.plugins(androidLib() + hilt())
+          bs.android = defaultAndroidLibBlock(true, "com.example.${packageOf(module)}")
+          bs.dependencies(moduleDependencies())
+          bs.additions = excludeTypes()
+        }
+        module.sources = moduleSources() + fireService()
+        module.manifest = AndroidManifest.of(
+          """\
+            <manifest xmlns:android="http://schemas.android.com/apk/res/android">            
+            <application>
+              <service android:name=".FireService" />
+            </application>
+            </manifest>
+          """.stripIndent()
+        )
+      }
+      .withAndroidLibProject('module-water') { module ->
+        module.withBuildScript { bs ->
+          bs.plugins(androidLib() + hilt())
+          bs.android = defaultAndroidLibBlock(true, "com.example.${packageOf(module)}")
+          bs.dependencies(moduleDependencies())
+        }
+        module.sources = moduleSources()
+      }
+      .withSubproject('inline') { inline ->
+        inline.withBuildScript { bs ->
+          bs.plugins(kotlin)
+          bs.kotlin = Kotlin.DEFAULT
+          bs.java = Java.of(8)
+        }
+        inline.sources = inlineSources()
+      }
+      .withSubproject('annotation') { annotation ->
+        annotation.withBuildScript { bs ->
+          bs.plugins(kotlin)
+          bs.kotlin = Kotlin.DEFAULT
+          bs.java = Java.of(8)
+        }
+        annotation.sources = annotationSources()
+      }
+      .withSubproject('java-lib') { javaLib ->
+        javaLib.withBuildScript { bs ->
+          bs.plugins(javaLibrary)
+          bs.java = Java.of(8)
+        }
+        javaLib.sources = javaLibSources()
+      }
+      .write()
+  }
+
+  private static Dependency fireImplementation(String dependency) {
+    new Dependency('fireImplementation', dependency)
+  }
+
+  private static Dependency waterImplementation(String dependency) {
+    new Dependency('waterImplementation', dependency)
+  }
+
+  private static List<Dependency> moduleDependencies() {
+    [
+      autoDaggerApi('implementation'),
+      autoDaggerCompiler('ksp'),
+      hiltAndroid('implementation'),
+      hiltAndroidCompiler('ksp'),
+    ]
+  }
+
+  private static String packageOf(AndroidSubproject.Builder module) {
+    return module.name.replace('-', '.')
+  }
+
+  private static String appFlavors() {
+    '''\
+    android {
+      flavorDimensions += "element"
+      productFlavors {
+        create("fire") {
+          dimension = "element"
+        }
+        create("water") {
+          dimension = "element"
+        }
+      }
+    }
+    '''.stripIndent()
+  }
+
+  // TODO(tsr): this isn't global yet
+  private static String excludeTypes() {
+    '''\
+      dependencyAnalysis {
+        typeUsage {
+          excludeRegex(
+            "^.*_GeneratedInjector\\$",
+            "^.*_ProvidesMagicFactory\\$",
+            "^hilt_aggregated_deps.*\\$",
+          )
+        }
+      }'''.stripIndent()
+  }
+
+  private static List<Source> appSources() {
+    [
+      Source.kotlin(
+        '''\
+        package com.example.app
+
+        import android.app.Application
+        import com.example.annotation.BinaryRetainedAnnotation
+        import com.example.annotation.SourceRetainedAnnotation
+        import com.example.inlinefun.soMuchFun
+        import com.example.javalib.PublicUsedClass
+        import com.example.module.Magic
+        import com.example.module.Thing
+        import dagger.hilt.android.HiltAndroidApp
+        import javax.inject.Inject
+
+        @BinaryRetainedAnnotation
+        @SourceRetainedAnnotation
+        @HiltAndroidApp
+        class HiltApplication : Application() {
+          @Inject lateinit var magic: Magic
+          @Inject lateinit var thing: Thing
+          
+          private fun usesInlineFun() {
+            soMuchFun()
+          }
+          
+          private fun usesJavaLib() {
+            PublicUsedClass()
+          }
+        }
+        '''.stripIndent()
+      ).build()
+    ]
+  }
+
+  private static List<Source> moduleSources() {
+    [
+      Source.kotlin(
+        '''\
+        package com.example.module
+
+        import dagger.Module
+        import dagger.Provides
+        import dagger.hilt.InstallIn
+        import dagger.hilt.components.SingletonComponent
+
+        @Module
+        @InstallIn(SingletonComponent::class)
+        class MagicModule {
+          @Provides fun providesMagic(): Magic = RealMagic()
+        }
+        '''.stripIndent()
+      ).build(),
+      Source.kotlin(
+        '''\
+        package com.example.module
+
+        interface Magic {
+          fun magic(): Int
+        }
+        '''.stripIndent()
+      ).build(),
+      Source.kotlin(
+        '''\
+        package com.example.module
+
+        import javax.inject.Singleton
+
+        @Singleton
+        class RealMagic : Magic {
+          override fun magic(): Int = 42
+        }
+        '''.stripIndent()
+      ).build(),
+
+      // AutoDagger
+      Source.kotlin(
+        '''\
+        package com.example.module
+        
+        import javax.inject.Inject
+        import se.ansman.dagger.auto.AutoBind
+        
+        @AutoBind
+        class RealThing @Inject constructor() : Thing
+      '''.stripIndent()
+      ).build(),
+      Source.kotlin(
+        '''\
+        package com.example.module
+        
+        interface Thing
+      '''.stripIndent()
+      ).build(),
+    ]
+  }
+
+  private static Source fireService() {
+    Source.kotlin(
+      '''\
+        package com.example.module
+
+        import android.app.Service
+        import android.content.Intent
+        import android.os.IBinder
+        import dagger.hilt.android.AndroidEntryPoint
+
+        @AndroidEntryPoint
+        class FireService : Service() {        
+          override fun onBind(intent: Intent): IBinder? = null
+        }
+      '''.stripIndent()
+    ).build()
+  }
+
+  private static List<Source> inlineSources() {
+    [
+      Source.kotlin(
+        '''\
+        package com.example.inlinefun
+        
+        inline fun soMuchFun() {
+          println("I'm an inline function!")
+        }
+        '''.stripIndent()
+      )
+        .withPath('com.example.inlinefun', 'InlineFuns')
+        .build()
+    ]
+  }
+
+  private static List<Source> annotationSources() {
+    [
+      Source.kotlin(
+        '''\
+        package com.example.annotation
+        
+        @Retention(AnnotationRetention.BINARY)
+        annotation class BinaryRetainedAnnotation
+        '''.stripIndent()
+      ).build(),
+      Source.kotlin(
+        '''\
+        package com.example.annotation
+        
+        @Retention(AnnotationRetention.SOURCE)
+        annotation class SourceRetainedAnnotation
+        '''.stripIndent()
+      ).build(),
+    ]
+  }
+
+  private static List<Source> javaLibSources() {
+    [
+      Source.java(
+        '''\
+        package com.example.javalib;
+        
+        public class PublicUsedClass {}
+        '''.stripIndent()
+      ).build(),
+      Source.java(
+        '''\
+        package com.example.javalib;
+        
+        public class PublicUnusedClass {}
+        '''.stripIndent()
+      ).build(),
+      Source.java(
+        '''\
+        package com.example.javalib;
+        
+        public class AnotherPublicUnusedClass {}
+        '''.stripIndent()
+      ).build(),
+      Source.java(
+        '''\
+        package com.example.javalib;
+        
+        class PackagePrivateClass {}
+        '''.stripIndent()
+      ).build(),
+    ]
+  }
+
+  PublicTypeUsage actualPublicTypeUsage() {
+    def publicTypeUsage = gradleProject.singleArtifact(':', getPublicTypeUsagePath())
+    def adapter = MOSHI.adapter(PublicTypeUsage)
+    return adapter.fromJson(publicTypeUsage.asPath.text)
+  }
+
+  // TODO(tsr): make it easier to create these instances
+  PublicTypeUsage expectedPublicTypeUsage = new PublicTypeUsage(
+    [
+      new PublicTypeUsage.Report(
+        ':annotation',
+        [
+          new PublicTypeUsage.Accesses(
+            'com.example.annotation.BinaryRetainedAnnotation',
+            [':app'] as Set<String>
+          ),
+          new PublicTypeUsage.Accesses(
+            'com.example.annotation.SourceRetainedAnnotation',
+            [':app'] as Set<String>
+          ),
+        ] as Set<PublicTypeUsage.Accesses>,
+        [] as Set<String>
+      ),
+
+      new PublicTypeUsage.Report(
+        ':app',
+        [] as Set<PublicTypeUsage.Accesses>,
+        [] as Set<String>
+      ),
+
+      new PublicTypeUsage.Report(
+        ':inline',
+        [
+          new PublicTypeUsage.Accesses(
+            'com.example.inlinefun.InlineFunsKt',
+            [':app'] as Set<String>
+          ),
+        ] as Set<PublicTypeUsage.Accesses>,
+        [] as Set<String>
+      ),
+
+      new PublicTypeUsage.Report(
+        ':java-lib',
+        [
+          new PublicTypeUsage.Accesses(
+            'com.example.javalib.PublicUsedClass',
+            [':app'] as Set<String>
+          )
+        ] as Set<PublicTypeUsage.Accesses>,
+        [
+          'com.example.javalib.AnotherPublicUnusedClass',
+          'com.example.javalib.PublicUnusedClass',
+        ] as Set<String>
+      ),
+
+      new PublicTypeUsage.Report(
+        ':module-fire',
+        [
+          new PublicTypeUsage.Accesses(
+            'com.example.module.FireService',
+            [':app'] as Set<String>
+          ),
+          new PublicTypeUsage.Accesses(
+            'com.example.module.Magic',
+            [':app'] as Set<String>
+          ),
+          new PublicTypeUsage.Accesses(
+            'com.example.module.MagicModule',
+            [':app'] as Set<String>
+          ),
+          new PublicTypeUsage.Accesses(
+            'com.example.module.RealThing',
+            [':app'] as Set<String>
+          ),
+          new PublicTypeUsage.Accesses(
+            'com.example.module.Thing',
+            [':app'] as Set<String>
+          ),
+        ] as Set<PublicTypeUsage.Accesses>,
+        ['com.example.module.RealMagic'] as Set<String>
+      ),
+
+      new PublicTypeUsage.Report(
+        ':module-water',
+        [
+          new PublicTypeUsage.Accesses(
+            'com.example.module.Magic',
+            [':app'] as Set<String>
+          ),
+          new PublicTypeUsage.Accesses(
+            'com.example.module.MagicModule',
+            [':app'] as Set<String>
+          ),
+          new PublicTypeUsage.Accesses(
+            'com.example.module.RealThing',
+            [':app'] as Set<String>
+          ),
+          new PublicTypeUsage.Accesses(
+            'com.example.module.Thing',
+            [':app'] as Set<String>
+          ),
+        ] as Set<PublicTypeUsage.Accesses>,
+        ['com.example.module.RealMagic'] as Set<String>
+      ),
+    ] as Set<PublicTypeUsage.Report>
+  )
+}

--- a/src/functionalTest/kotlin/com/autonomousapps/kit/gradle/dependencies/Dependencies.kt
+++ b/src/functionalTest/kotlin/com/autonomousapps/kit/gradle/dependencies/Dependencies.kt
@@ -77,6 +77,32 @@ object Dependencies {
   }
 
   @JvmStatic
+  fun autoDagger(configuration: String): Dependency {
+    return provider.autoDagger(configuration)
+  }
+
+  @JvmStatic
+  fun autoDaggerApi(configuration: String): Dependency {
+    return provider.autoDaggerApi(configuration)
+  }
+
+  @JvmStatic
+  fun autoDaggerCompiler(configuration: String): Dependency {
+    return provider.autoDaggerCompiler(configuration)
+  }
+
+  @JvmStatic
+  fun hiltAndroid(configuration: String): Dependency {
+    return provider.hiltAndroid(configuration)
+  }
+
+  @JvmStatic
+  fun hiltAndroidCompiler(configuration: String): Dependency {
+    return provider.hiltAndroidCompiler(configuration)
+  }
+
+
+  @JvmStatic
   fun kotestAssertions(configuration: String): Dependency {
     return provider.kotestAssertions(configuration)
   }

--- a/src/functionalTest/kotlin/com/autonomousapps/kit/gradle/dependencies/DependencyProvider.kt
+++ b/src/functionalTest/kotlin/com/autonomousapps/kit/gradle/dependencies/DependencyProvider.kt
@@ -66,6 +66,26 @@ class DependencyProvider(
     return Dependency(configuration, "org.conscrypt:conscrypt-openjdk-uber:2.4.0")
   }
 
+  fun autoDagger(configuration: String): Dependency {
+    return Dependency(configuration, "se.ansman.dagger.auto:android:2.1.0")
+  }
+
+  fun autoDaggerApi(configuration: String): Dependency {
+    return Dependency(configuration, "se.ansman.dagger.auto:android-api:2.1.0")
+  }
+
+  fun autoDaggerCompiler(configuration: String): Dependency {
+    return Dependency(configuration, "se.ansman.dagger.auto:compiler:2.1.0")
+  }
+
+  fun hiltAndroid(configuration: String): Dependency {
+    return Dependency(configuration, "com.google.dagger:hilt-android:2.59.2")
+  }
+
+  fun hiltAndroidCompiler(configuration: String): Dependency {
+    return Dependency(configuration, "com.google.dagger:hilt-android-compiler:2.59.2")
+  }
+
   fun kotestAssertions(configuration: String): Dependency {
     return Dependency(configuration, "io.kotest:kotest-assertions-core:4.6.0")
   }

--- a/src/functionalTest/kotlin/com/autonomousapps/kit/gradle/dependencies/PluginProvider.kt
+++ b/src/functionalTest/kotlin/com/autonomousapps/kit/gradle/dependencies/PluginProvider.kt
@@ -26,6 +26,7 @@ class PluginProvider(
   val androidLibId: String = "com.android.library"
   val androidTestId: String = "com.android.test"
   val androidLegacyKaptId: String = "com.android.legacy-kapt"
+  val androidAppNoApply: Plugin = Plugin(androidAppId, androidVersion, false)
   val androidApp: Plugin = Plugin(androidAppId, androidVersion)
   val androidAppNoVersion: Plugin = Plugin(androidAppId)
   val androidLibNoVersion: Plugin = Plugin(androidLibId)
@@ -37,6 +38,12 @@ class PluginProvider(
 
   /** Use this in subprojects. */
   val androidKmpLibNoVersion: Plugin = Plugin("com.android.kotlin.multiplatform.library")
+
+  val hiltNoApply: Plugin = Plugin("com.google.dagger.hilt.android", "2.59.2", false)
+  val hiltNoVersion: Plugin = Plugin("com.google.dagger.hilt.android")
+
+  val kspNoApply: Plugin = Plugin("com.google.devtools.ksp", "2.3.7", false)
+  val kspNoVersion: Plugin = Plugin("com.google.devtools.ksp")
 
   val kotlinJvm: Plugin = Plugin("org.jetbrains.kotlin.jvm", kotlinVersion)
   val kotlinJvmNoApply: Plugin = Plugin("org.jetbrains.kotlin.jvm", kotlinVersion, false)

--- a/src/functionalTest/kotlin/com/autonomousapps/kit/gradle/dependencies/Plugins.kt
+++ b/src/functionalTest/kotlin/com/autonomousapps/kit/gradle/dependencies/Plugins.kt
@@ -26,6 +26,12 @@ object Plugins {
   @JvmStatic val androidKmpLibNoVersion: Plugin = provider.androidKmpLibNoVersion
   @JvmStatic val androidTest: Plugin = provider.androidTestNoVersion
 
+  @JvmStatic val hiltNoApply: Plugin = provider.hiltNoApply
+  @JvmStatic val hiltNoVersion: Plugin = provider.hiltNoVersion
+
+  @JvmStatic val kspNoApply: Plugin = provider.kspNoApply
+  @JvmStatic val kspNoVersion: Plugin = provider.kspNoVersion
+
   @JvmStatic val javaTestFixtures: Plugin = provider.javaTestFixtures
 
   @JvmStatic val kotlinJvm: Plugin = provider.kotlinJvm

--- a/src/main/kotlin/com/autonomousapps/extension/AbiHandler.kt
+++ b/src/main/kotlin/com/autonomousapps/extension/AbiHandler.kt
@@ -90,13 +90,13 @@ public abstract class ExclusionsHandler @Inject constructor(objects: ObjectFacto
   }
 
   /**
-   * Best-effort attempts to ignore generated code by ignoring any bytecode in classes annotated
-   * with an annotation ending in `Generated`. It's important to note that the standard
-   * `javax.annotation.Generated` (or its JDK9+ successor) does _not_ work with this due to it
-   * using `SOURCE` retention. It's recommended to use your own `Generated` annotation.
+   * Best-effort attempts to ignore generated code by ignoring any bytecode in classes annotated with an annotation
+   * containing `Generated`. It's important to note that the standard `javax.annotation.Generated` (or its JDK9+
+   * successor) does _not_ work with this due to it using `SOURCE` retention. It's recommended to use your own
+   * `Generated` annotation.
    */
   public fun ignoreGeneratedCode() {
-    excludeAnnotations(".*Generated")
+    excludeAnnotations(".*Generated.*")
   }
 
   /**

--- a/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
@@ -86,6 +86,8 @@ internal class NoVariantOutputPaths(private val project: Project) {
   val resolvedDepsPath = file("$ROOT_DIR/resolved-dependencies-report.txt")
   val resolvedAllLibsVersionsTomlPath = file("$ROOT_DIR/resolvedAllLibs.versions.toml")
   val mergedProjectGraphPath = file("$ROOT_DIR/merged-project-graph.json")
+  val aggregateTypeUsagePath = file("$ROOT_DIR/type-usage.json")
+  val publicTypesPath = file("$ROOT_DIR/public-types.json")
 
   /*
    * Advice-related tasks.
@@ -114,6 +116,8 @@ internal class RootOutputPaths(private val project: Project) {
   val allLibsVersionsTomlPath = file("$ROOT_DIR/allLibs.versions.toml")
   val shouldFailPath = file("$ROOT_DIR/should-fail.txt")
 
+  val publicTypeUsagePath = file("$ROOT_DIR/public-type-usage-report.json")
+  val publicTypeUsageConsolePath = file("$ROOT_DIR/public-type-usage-report.txt")
   val workPlanDir = dir("$ROOT_DIR/work-plan")
 }
 
@@ -141,3 +145,4 @@ public fun getAllLibsVersionsTomlPath(): String = "$ROOT_DIR/allLibs.versions.to
 public fun getResolvedDependenciesReport(): String = "$ROOT_DIR/resolved-dependencies-report.txt"
 public fun getResolvedVersionsTomlPath(): String = "$ROOT_DIR/resolvedAllLibs.versions.toml"
 public fun getTypeUsagePath(variantName: String = "main"): String = "$ROOT_DIR/$variantName/type-usage.json"
+public fun getPublicTypeUsagePath(): String = "$ROOT_DIR/public-type-usage-report.json"

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/DependencyAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/DependencyAnalyzer.kt
@@ -95,6 +95,7 @@ internal interface DependencyAnalyzer {
   fun registerComputeTypeUsageTask(
     synthesizeProjectViewTask: TaskProvider<SynthesizeProjectViewTask>,
     explodeJarTask: TaskProvider<ExplodeJarTask>,
+    synthesizeDependenciesTask: TaskProvider<SynthesizeDependenciesTask>,
     dagpExtension: AbstractExtension,
   ): TaskProvider<ComputeTypeUsageTask>
 
@@ -279,12 +280,14 @@ internal abstract class AbstractDependencyAnalyzer(
   final override fun registerComputeTypeUsageTask(
     synthesizeProjectViewTask: TaskProvider<SynthesizeProjectViewTask>,
     explodeJarTask: TaskProvider<ExplodeJarTask>,
+    synthesizeDependenciesTask: TaskProvider<SynthesizeDependenciesTask>,
     dagpExtension: AbstractExtension,
   ): TaskProvider<ComputeTypeUsageTask> {
     return project.tasks.register("computeTypeUsage$taskNameSuffix", ComputeTypeUsageTask::class.java) { t ->
       t.buildPath.set(project.buildPath(compileConfigurationName))
       t.syntheticProject.set(synthesizeProjectViewTask.flatMap { it.output })
       t.explodedJars.set(explodeJarTask.flatMap { it.output })
+      t.dependencies.set(synthesizeDependenciesTask.flatMap { it.outputDir })
 
       // Configuration from extension
       t.excludedPackages.set(dagpExtension.typeUsageHandler.excludedPackages)

--- a/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
@@ -12,8 +12,8 @@ internal class AgpVersion private constructor(val version: String) : Comparable<
 
   companion object {
 
-    @JvmStatic val AGP_MIN = version("8.10.0")
-    @JvmStatic val AGP_MAX = version("9.1.0")
+    @JvmField val AGP_MIN = version("8.10.0")
+    @JvmField val AGP_MAX = version("9.1.0")
 
     @JvmStatic fun current(): AgpVersion = AgpVersion(agpVersion())
     @JvmStatic fun version(version: String): AgpVersion = AgpVersion(version)

--- a/src/main/kotlin/com/autonomousapps/internal/artifacts/DagpArtifacts.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/artifacts/DagpArtifacts.kt
@@ -16,9 +16,11 @@ internal interface DagpArtifacts : Named {
 
   enum class Kind : ArtifactDescription<DagpArtifacts> {
     COMBINED_GRAPH,
+    PUBLIC_CLASSES,
     PROJECT_HEALTH,
     PROJECT_METADATA,
     RESOLVED_DEPS,
+    TYPE_USAGE,
     ;
 
     override val attribute: Attribute<DagpArtifacts> = DAGP_ARTIFACTS_ATTRIBUTE

--- a/src/main/kotlin/com/autonomousapps/internal/kotlin/PublicApiDump.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/kotlin/PublicApiDump.kt
@@ -66,10 +66,10 @@ internal fun getBinaryAPI(
       with(clazz) {
         val metadata = kotlinMetadata
 
-        val kmFunctions = when (val md = metadata) {
-          is KotlinClassMetadata.Class -> md.kmClass.functions
-          is KotlinClassMetadata.FileFacade -> md.kmPackage.functions
-          is KotlinClassMetadata.MultiFileClassPart -> md.kmPackage.functions
+        val kmFunctions = when (metadata) {
+          is KotlinClassMetadata.Class -> metadata.kmClass.functions
+          is KotlinClassMetadata.FileFacade -> metadata.kmPackage.functions
+          is KotlinClassMetadata.MultiFileClassPart -> metadata.kmPackage.functions
           else -> null
         }.orEmpty()
         val jvmFunctionMap = kmFunctions.filter { it.signature != null }.associateBy { it.signature!! }

--- a/src/main/kotlin/com/autonomousapps/internal/parse/SourceListener.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/parse/SourceListener.kt
@@ -11,11 +11,18 @@ import com.autonomousapps.internal.grammar.SimpleParser
 import java.io.File
 import java.io.FileInputStream
 
+// nb: the "cannot access..." IDE error is incorrect. It's failing at something to do with shaded packages yet again.
 internal class SourceListener : SimpleBaseListener() {
 
+  private var packageDeclaration: String? = null
   private val imports = mutableSetOf<String>()
 
+  fun packageDeclaration(): String? = packageDeclaration
   fun imports(): Set<String> = imports
+
+  override fun enterPackageDeclaration(ctx: SimpleParser.PackageDeclarationContext?) {
+    packageDeclaration = ctx?.qualifiedName()?.text
+  }
 
   override fun enterImportDeclaration(ctx: SimpleParser.ImportDeclarationContext) {
     val qualifiedName = ctx.qualifiedName().text
@@ -29,10 +36,15 @@ internal class SourceListener : SimpleBaseListener() {
   }
 
   internal companion object {
+    fun parseSourceFile(file: File): SourceListener {
+      val parser = newSimpleParser(file)
+      return walkTree(parser)
+    }
+
     fun parseSourceFileForImports(file: File): Set<String> {
       val parser = newSimpleParser(file)
-      val importListener = walkTree(parser)
-      return importListener.imports()
+      val sourceListener = walkTree(parser)
+      return sourceListener.imports()
     }
 
     private fun newSimpleParser(file: File): SimpleParser {

--- a/src/main/kotlin/com/autonomousapps/internal/utils/utils.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/utils.kt
@@ -32,61 +32,52 @@ internal fun DirectoryProperty.delete(): DirectoryProperty {
   return this
 }
 
-/**
- * Resolves the file from the property and deletes its contents, then returns the file.
- */
+/** Resolves the file from the property and deletes its contents, then returns the file. */
 internal fun RegularFileProperty.getAndDelete(): File {
   val file = get().asFile
   file.delete()
   return file
 }
 
-/**
- * Resolves the file from the provider and deletes its contents, then returns the file.
- */
+/** Resolves the file from the provider and deletes its contents, then returns the file. */
 internal fun Provider<RegularFile>.getAndDelete(): File {
   val file = get().asFile
   file.delete()
   return file
 }
 
-/**
- * Buffer reads of the nullable RegularFileProperty from disk to the set.
- */
+/** Buffer reads of the nullable RegularFileProperty from disk to the set. */
 internal inline fun <reified T> RegularFileProperty.fromNullableJsonSet(): Set<T> {
   return orNull?.fromJsonSet() ?: emptySet()
 }
 
-/**
- * Buffers reads of the RegularFileProperty from disk to the set.
- */
+/** Buffers reads of the RegularFileProperty from disk to the set. */
 internal inline fun <reified T> RegularFileProperty.fromJsonSet(
   compressed: Boolean = false,
 ): Set<T> = get().fromJsonSet(compressed)
 
-/**
- * Buffers reads of the RegularFile from disk to the set.
- */
+/** Buffers reads of the RegularFile from disk to the set. */
 internal inline fun <reified T> RegularFile.fromJsonSet(
+  compressed: Boolean = false,
+): Set<T> = asFile.fromJsonSet(compressed)
+
+/** Buffers reads of the RegularFile from disk to the set. */
+internal inline fun <reified T> File.fromJsonSet(
   compressed: Boolean = false,
 ): Set<T> {
   val source = if (compressed) {
-    GzipSource(asFile.source()).buffer()
+    GzipSource(source()).buffer()
   } else {
-    asFile.bufferRead()
+    bufferRead()
   }
 
   return source.use { getJsonSetAdapter<T>().fromJson(it)!! }
 }
 
-/**
- * Buffers reads of the RegularFileProperty from disk to the set.
- */
+/** Buffers reads of the RegularFileProperty from disk to the set. */
 internal inline fun <reified T> RegularFileProperty.fromJsonList(): List<T> = get().fromJsonList()
 
-/**
- * Buffers reads of the RegularFile from disk to the set.
- */
+/** Buffers reads of the RegularFile from disk to the set. */
 internal inline fun <reified T> RegularFile.fromJsonList(): List<T> {
   return asFile.bufferRead().use { reader ->
     getJsonListAdapter<T>().fromJson(reader)!!
@@ -117,38 +108,26 @@ internal inline fun <reified K, reified V> File.fromJsonMapSet(): Map<K, Set<V>>
   return bufferRead().fromJsonMapSet()
 }
 
-/**
- * Buffers reads of the RegularFileProperty from disk to the set.
- */
+/** Buffers reads of the RegularFileProperty from disk to the set. */
 internal inline fun <reified K, reified V> RegularFileProperty.fromJsonMap(): Map<K, V> = get().fromJsonMap()
 
-/**
- * Buffers reads of the RegularFile from disk to the set.
- */
+/** Buffers reads of the RegularFile from disk to the set. */
 internal inline fun <reified K, reified V> RegularFile.fromJsonMap(): Map<K, V> = asFile.fromJsonMap()
 
-/**
- * Buffers reads of the File from disk to the set.
- */
+/** Buffers reads of the File from disk to the set. */
 internal inline fun <reified K, reified V> File.fromJsonMap(): Map<K, V> {
   return bufferRead().use { reader ->
     getJsonMapAdapter<K, V>().fromJson(reader)!!
   }
 }
 
-/**
- * Buffer reads of the RegularFileProperty from disk to the set.
- */
+/** Buffer reads of the RegularFileProperty from disk to the set. */
 internal inline fun <reified T> RegularFileProperty.fromJson(): T = get().fromJson()
 
-/**
- * Buffer reads of the RegularFile from disk to the set.
- */
+/** Buffer reads of the RegularFile from disk to the set. */
 internal inline fun <reified T> RegularFile.fromJson(): T = asFile.fromJson()
 
-/**
- * Buffer reads of the File from disk to the set.
- */
+/** Buffer reads of the File from disk to the set. */
 internal inline fun <reified T> File.fromJson(): T {
   return bufferRead().use { reader ->
     getJsonAdapter<T>().fromJson(reader)!!

--- a/src/main/kotlin/com/autonomousapps/model/ProjectTypeUsage.kt
+++ b/src/main/kotlin/com/autonomousapps/model/ProjectTypeUsage.kt
@@ -5,10 +5,14 @@ package com.autonomousapps.model
 import com.squareup.moshi.JsonClass
 
 /**
- * Type usage information for a single project.
+ * Type usage information for a single source set/variant of a single project.
  *
  * This report shows which types (classes/interfaces) are used from each dependency,
  * enabling coupling analysis and complexity metrics.
+ *
+ * TODO(tsr): I think we should consider adding Android res usages here as well.
+ *
+ * @see [com.autonomousapps.model.internal.AggregateTypeUsageReport]
  */
 @JsonClass(generateAdapter = false)
 public data class ProjectTypeUsage(
@@ -34,15 +38,10 @@ public data class ProjectTypeUsage(
   /**
    * Returns true if there are no usages tracked.
    */
-  public fun isEmpty(): Boolean =
-    internal.isEmpty() &&
-    projectDependencies.isEmpty() &&
-    libraryDependencies.isEmpty()
+  public fun isEmpty(): Boolean = internal.isEmpty() && projectDependencies.isEmpty() && libraryDependencies.isEmpty()
 }
 
-/**
- * Summary statistics about type usage in a project.
- */
+/** Summary statistics about type usage in a project. */
 @JsonClass(generateAdapter = false)
 public data class TypeUsageSummary(
   /** Total number of unique types used (internal + external). */

--- a/src/main/kotlin/com/autonomousapps/model/internal/AggregateTypeUsageReport.kt
+++ b/src/main/kotlin/com/autonomousapps/model/internal/AggregateTypeUsageReport.kt
@@ -1,0 +1,68 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.model.internal
+
+import com.autonomousapps.internal.utils.LexicographicIterableComparator
+import com.autonomousapps.internal.utils.MapSetComparator
+import com.squareup.moshi.JsonClass
+import java.util.*
+
+/**
+ * Simplified type usage information for a single project, aggregated across all variants / source sets.
+ *
+ * This report shows which types (classes/interfaces) are used from each dependency, enabling coupling analysis and
+ * complexity metrics.
+ *
+ * TODO(tsr): consider adding Android res usages here as well.
+ * TODO(tsr): consider making this public.
+ *
+ * @see [com.autonomousapps.model.ProjectTypeUsage]
+ * @see [PublicTypeUsage]
+ */
+@JsonClass(generateAdapter = false)
+internal data class AggregateTypeUsageReport(
+  /** The project path (e.g., ":app", ":feature-home"). */
+  val projectPath: String,
+
+  /** Types defined in this project that are used by itself. */
+  val internal: Set<String>,
+
+  /** Types used from project dependencies (other modules). Map: dependencyIdentifier -> classNames. */
+  val projectDependencies: Map<String, Set<String>>,
+
+  /** Types used from external library dependencies. Map: dependencyIdentifier -> classNames. */
+  val libraryDependencies: Map<String, Set<String>>,
+
+  /** Types used that could not be resolved to any dependency. */
+  val unknownDependencies: Set<String> = emptySet(),
+) : Comparable<AggregateTypeUsageReport> {
+
+  override fun compareTo(other: AggregateTypeUsageReport): Int {
+    return compareBy(AggregateTypeUsageReport::projectPath)
+      .thenBy(LexicographicIterableComparator()) { it.internal }
+      .thenBy(MapSetComparator()) { it.projectDependencies }
+      .thenBy(MapSetComparator()) { it.libraryDependencies }
+      .thenBy(LexicographicIterableComparator()) { it.unknownDependencies }
+      .compare(this, other)
+  }
+
+  fun isEmpty(): Boolean = internal.isEmpty() && projectDependencies.isEmpty() && libraryDependencies.isEmpty()
+
+  internal class Builder {
+    var projectPath: String? = null
+    val internal = sortedSetOf<String>()
+    val projectDependencies = sortedMapOf<String, SortedSet<String>>()
+    val libraryDependencies = sortedMapOf<String, SortedSet<String>>()
+    val unknownDependencies = sortedSetOf<String>()
+
+    fun build(): AggregateTypeUsageReport {
+      return AggregateTypeUsageReport(
+        projectPath = requireNotNull(projectPath),
+        internal = internal,
+        projectDependencies = projectDependencies,
+        libraryDependencies = libraryDependencies,
+        unknownDependencies = unknownDependencies,
+      )
+    }
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/model/internal/Capability.kt
+++ b/src/main/kotlin/com/autonomousapps/model/internal/Capability.kt
@@ -226,17 +226,39 @@ internal data class InlineMemberCapability(
 
   @JsonClass(generateAdapter = false)
   data class InlineMember(
+    val className: String,
     val packageName: String,
     val inlineMembers: Set<String>,
   ) : Comparable<InlineMember> {
 
     companion object {
-      fun newInstance(packageName: String, inlineMembers: Set<String>): InlineMember {
-        return InlineMember(packageName, inlineMembers.toSortedSet().efficient())
+      fun newInstance(className: String, packageName: String, inlineMembers: Set<String>): InlineMember {
+        return InlineMember(
+          className = className,
+          packageName = packageName,
+          inlineMembers = inlineMembers.toSortedSet().efficient(),
+        )
       }
     }
 
-    override fun compareTo(other: InlineMember): Int = compareBy(InlineMember::packageName)
+    /**
+     * Returns the set of import statements most likely to reference the inline functions related to this instance.
+     * ```
+     * // 1
+     * import com.foo.myCoolFunction
+     *
+     * // 2
+     * import com.foo.*
+     * ```
+     */
+    fun candidateImports(): Set<String> {
+      // we like sorted sets because they're easier to debug
+      val candidateImports = sortedSetOf("$packageName.*")
+      return inlineMembers.mapTo(candidateImports) { name -> "$packageName.$name" }
+    }
+
+    override fun compareTo(other: InlineMember): Int = compareBy(InlineMember::className)
+      .thenBy(InlineMember::packageName)
       .thenBy(LexicographicIterableComparator()) { it.inlineMembers }
       .compare(this, other)
   }

--- a/src/main/kotlin/com/autonomousapps/model/internal/ProjectVariant.kt
+++ b/src/main/kotlin/com/autonomousapps/model/internal/ProjectVariant.kt
@@ -116,15 +116,15 @@ internal data class ProjectVariant(
     codeSource.flatMapToOrderedSet { it.imports }
   }
 
-   /**
-    * Every member access from this project to classes in another module. cf [usedClasses], which is a flat set of
-    * referenced class names.
-    */
-   val memberAccesses: Set<MemberAccess> by unsafeLazy {
-     codeSource.flatMapToOrderedSet { src ->
-       src.binaryClassAccesses.entries.flatMap { entry -> entry.value }
-     }
-   }
+  /**
+   * Every member access from this project to classes in another module. cf [usedClasses], which is a flat set of
+   * referenced class names.
+   */
+  val memberAccesses: Set<MemberAccess> by unsafeLazy {
+    codeSource.flatMapToOrderedSet { src ->
+      src.binaryClassAccesses.entries.flatMap { entry -> entry.value }
+    }
+  }
 
   val javaImports: Set<String> by unsafeLazy {
     codeSource.filter { it.kind == Kind.JAVA }

--- a/src/main/kotlin/com/autonomousapps/model/internal/PublicTypeUsage.kt
+++ b/src/main/kotlin/com/autonomousapps/model/internal/PublicTypeUsage.kt
@@ -1,0 +1,60 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.model.internal
+
+import com.autonomousapps.internal.utils.LexicographicIterableComparator
+import com.squareup.moshi.JsonClass
+
+/**
+ * A global report of public type usage. A public type that has no external accessors could have its visibility reduced.
+ *
+ * TODO(tsr): this is a candidate to be public
+ *
+ * @see [PublicTypes]
+ */
+@JsonClass(generateAdapter = false)
+internal data class PublicTypeUsage(
+  val reports: Set<Report>,
+) {
+
+  @JsonClass(generateAdapter = false)
+  data class Report(
+    /** The project that owns the public types being accessed (see [accesses]). */
+    val owningProject: String,
+
+    /** Each accessed public type, along with the accessing projects. May be empty. */
+    val accesses: Set<Accesses>,
+
+    /** Public types that are not accessed outside. May be empty. */
+    val unaccessedTypes: Set<String>,
+  ) : Comparable<Report> {
+    override fun compareTo(other: Report): Int {
+      return compareBy(Report::owningProject)
+        .thenBy(LexicographicIterableComparator()) { it.accesses }
+        .thenBy(LexicographicIterableComparator()) { it.unaccessedTypes }
+        .compare(this, other)
+    }
+  }
+
+  /** Contains all [accessors][accessingProjects] of [typeName]. [accessingProjects] cannot be empty. */
+  @JsonClass(generateAdapter = false)
+  data class Accesses(
+    /** The fully-qualified type being accessed. */
+    val typeName: String,
+    /** Guaranteed to be non-empty. */
+    val accessingProjects: Set<String>,
+  ) : Comparable<Accesses> {
+
+    init {
+      require(accessingProjects.isNotEmpty()) {
+        "Accessing projects must not be empty. Was empty for '$typeName'."
+      }
+    }
+
+    override fun compareTo(other: Accesses): Int {
+      return compareBy(Accesses::typeName)
+        .thenBy(LexicographicIterableComparator()) { it.accessingProjects }
+        .compare(this, other)
+    }
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/model/internal/PublicTypes.kt
+++ b/src/main/kotlin/com/autonomousapps/model/internal/PublicTypes.kt
@@ -1,0 +1,29 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.model.internal
+
+import com.autonomousapps.internal.utils.LexicographicIterableComparator
+import com.squareup.moshi.JsonClass
+
+/**
+ * The set of all public types provided by this project.
+ *
+ * TODO(tsr): consider making this public.
+ *
+ * @see [PublicTypeUsage]
+ */
+@JsonClass(generateAdapter = false)
+internal data class PublicTypes(
+  /** The path of the owning project, e.g., `":feature:home"`. */
+  val projectPath: String,
+
+  /** Types that have public visibility. */
+  val types: Set<String>,
+) : Comparable<PublicTypes> {
+
+  override fun compareTo(other: PublicTypes): Int {
+    return compareBy(PublicTypes::projectPath)
+      .thenBy(LexicographicIterableComparator()) { it.types }
+      .compare(this, other)
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
@@ -100,8 +100,10 @@ internal class ProjectPlugin(private val project: Project) {
   /** We only want to register the aggregation tasks if the by-variants tasks are registered. */
   private val aggregatorsRegistered = AtomicBoolean(false)
 
-  private val computeAdviceTask: TaskProvider<ComputeAdviceTask> =
-    project.tasks.register("computeAdvice", ComputeAdviceTask::class.java)
+  private val computeAdviceTask = project.tasks.register("computeAdvice", ComputeAdviceTask::class.java)
+  private val aggregateTypeUsageTask = project.tasks.register("aggregateTypeUsage", AggregateTypeUsageTask::class.java)
+  private val aggregatePublicTypesTask =
+    project.tasks.register("aggregatePublicTypes", AggregatePublicTypesTask::class.java)
 
   private lateinit var filterAdviceTask: TaskProvider<FilterAdviceTask>
   private lateinit var computeResolvedDependenciesTask: TaskProvider<ComputeResolvedDependenciesTask>
@@ -118,6 +120,10 @@ internal class ProjectPlugin(private val project: Project) {
   private var isAndroidProject = false
   private var isKmpProject = false
 
+  private val combinedGraphPublisher = interProjectPublisher(
+    project = project,
+    artifactDescription = DagpArtifacts.Kind.COMBINED_GRAPH,
+  )
   private val projectHealthPublisher = interProjectPublisher(
     project = project,
     artifactDescription = DagpArtifacts.Kind.PROJECT_HEALTH,
@@ -126,14 +132,19 @@ internal class ProjectPlugin(private val project: Project) {
     project = project,
     artifactDescription = DagpArtifacts.Kind.PROJECT_METADATA,
   )
+  private val publicClassesPublisher = interProjectPublisher(
+    project = project,
+    artifactDescription = DagpArtifacts.Kind.PUBLIC_CLASSES,
+  )
   private val resolvedDependenciesPublisher = interProjectPublisher(
     project = project,
     artifactDescription = DagpArtifacts.Kind.RESOLVED_DEPS,
   )
-  private val combinedGraphPublisher = interProjectPublisher(
+  private val typeUsagesPublisher = interProjectPublisher(
     project = project,
-    artifactDescription = DagpArtifacts.Kind.COMBINED_GRAPH,
+    artifactDescription = DagpArtifacts.Kind.TYPE_USAGE,
   )
+
 
   private val dslService = GlobalDslService.of(project)
 
@@ -975,6 +986,11 @@ internal class ProjectPlugin(private val project: Project) {
         ).toJson()
       }
     })
+    abiAnalysisTask?.let { task ->
+      aggregatePublicTypesTask.configure { t ->
+        t.abiReports.from(task.flatMap { it.output })
+      }
+    }
 
     val usagesExclusionsProvider = provider {
       with(dagpExtension.usageHandler.exclusionsHandler) {
@@ -1029,9 +1045,13 @@ internal class ProjectPlugin(private val project: Project) {
     val computeTypeUsageTask = dependencyAnalyzer.registerComputeTypeUsageTask(
       synthesizeProjectViewTask = synthesizeProjectViewTask,
       explodeJarTask = explodeJarTask,
+      synthesizeDependenciesTask = synthesizeDependenciesTask,
       dagpExtension = dagpExtension,
     )
     storeTypeUsageOutput(dependencyAnalyzer.taskNameSuffix, computeTypeUsageTask.flatMap { it.output })
+    aggregateTypeUsageTask.configure { t ->
+      t.typeUsageReports.from(computeTypeUsageTask.flatMap { it.output })
+    }
 
     // Null for JVM projects
     val androidScoreTask = dependencyAnalyzer.registerAndroidScoreTask(
@@ -1071,6 +1091,7 @@ internal class ProjectPlugin(private val project: Project) {
         outputPaths = paths
       )
     }
+
     computeAdviceTask.configure { t ->
       t.projectPath.set(theProjectPath)
       t.declarations.set(findDeclarationsTask.flatMap { it.output })
@@ -1086,6 +1107,15 @@ internal class ProjectPlugin(private val project: Project) {
       t.dependencyUsages.set(paths.dependencyUsagesPath)
       t.annotationProcessorUsages.set(paths.annotationProcessorUsagesPath)
       t.bundledTraces.set(paths.bundledTracesPath)
+    }
+
+    aggregateTypeUsageTask.configure { t ->
+      t.output.set(paths.aggregateTypeUsagePath)
+    }
+
+    aggregatePublicTypesTask.configure { t ->
+      t.projectPath.set(theProjectPath)
+      t.output.set(paths.publicTypesPath)
     }
 
     filterAdviceTask = tasks.register("filterAdvice", FilterAdviceTask::class.java) { t ->
@@ -1182,7 +1212,9 @@ internal class ProjectPlugin(private val project: Project) {
     combinedGraphPublisher.publish(mergeProjectGraphsTask.flatMap { it.output })
     projectHealthPublisher.publish(filterAdviceTask.flatMap { it.output })
     projectMetadataPublisher.publish(writeProjectMetadata.flatMap { it.output })
+    publicClassesPublisher.publish(aggregatePublicTypesTask.flatMap { it.output })
     resolvedDependenciesPublisher.publish(computeResolvedDependenciesTask.flatMap { it.output })
+    typeUsagesPublisher.publish(aggregateTypeUsageTask.flatMap { it.output })
   }
 
   private fun Project.isKaptApplied() = providers.provider { plugins.hasPlugin("org.jetbrains.kotlin.kapt") }

--- a/src/main/kotlin/com/autonomousapps/subplugin/RootPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/RootPlugin.kt
@@ -39,21 +39,30 @@ internal class RootPlugin(private val project: Project) {
     }
   }
 
+
   private val adviceResolver = interProjectResolver(
     project = project,
     artifactDescription = DagpArtifacts.Kind.PROJECT_HEALTH,
-  )
-  private val projectMetadataResolver = interProjectResolver(
-    project = project,
-    artifactDescription = DagpArtifacts.Kind.PROJECT_METADATA,
   )
   private val combinedGraphResolver = interProjectResolver(
     project = project,
     artifactDescription = DagpArtifacts.Kind.COMBINED_GRAPH,
   )
+  private val projectMetadataResolver = interProjectResolver(
+    project = project,
+    artifactDescription = DagpArtifacts.Kind.PROJECT_METADATA,
+  )
+  private val publicClassesResolver = interProjectResolver(
+    project = project,
+    artifactDescription = DagpArtifacts.Kind.PUBLIC_CLASSES,
+  )
   private val resolvedDepsResolver = interProjectResolver(
     project = project,
     artifactDescription = DagpArtifacts.Kind.RESOLVED_DEPS,
+  )
+  private val typeUsagesResolver = interProjectResolver(
+    project = project,
+    artifactDescription = DagpArtifacts.Kind.TYPE_USAGE,
   )
 
   fun apply() = project.run {
@@ -94,18 +103,19 @@ internal class RootPlugin(private val project: Project) {
   private fun Project.configureRootProject() {
     val paths = RootOutputPaths(this)
 
-    val computeDuplicatesTask = tasks.register("computeDuplicateDependencies", ComputeDuplicateDependenciesTask::class.java) {
-      it.resolvedDependenciesReports.setFrom(resolvedDepsResolver.artifactFilesProvider())
-      it.output.set(paths.duplicateDependenciesPath)
+    val computeDuplicatesTask =
+      tasks.register("computeDuplicateDependencies", ComputeDuplicateDependenciesTask::class.java) { t ->
+        t.resolvedDependenciesReports.setFrom(resolvedDepsResolver.artifactFilesProvider())
+        t.output.set(paths.duplicateDependenciesPath)
+      }
+
+    tasks.register("printDuplicateDependencies", PrintDuplicateDependenciesTask::class.java) { t ->
+      t.duplicateDependenciesReport.set(computeDuplicatesTask.flatMap { it.output })
     }
 
-    tasks.register("printDuplicateDependencies", PrintDuplicateDependenciesTask::class.java) {
-      it.duplicateDependenciesReport.set(computeDuplicatesTask.flatMap { it.output })
-    }
-
-    tasks.register("computeAllDependencies", ComputeAllDependenciesTask::class.java) {
-      it.resolvedDependenciesReports.setFrom(resolvedDepsResolver.artifactFilesProvider())
-      it.output.set(paths.allLibsVersionsTomlPath)
+    tasks.register("computeAllDependencies", ComputeAllDependenciesTask::class.java) { t ->
+      t.resolvedDependenciesReports.setFrom(resolvedDepsResolver.artifactFilesProvider())
+      t.output.set(paths.allLibsVersionsTomlPath)
     }
 
     val generateBuildHealthTask = tasks.register("generateBuildHealth", GenerateBuildHealthTask::class.java) { t ->
@@ -123,44 +133,42 @@ internal class RootPlugin(private val project: Project) {
       t.outputFail.set(paths.shouldFailPath)
     }
 
-    tasks.register("buildHealth", BuildHealthTask::class.java) {
-      it.shouldFail.set(generateBuildHealthTask.flatMap { it.outputFail })
-      it.buildHealth.set(generateBuildHealthTask.flatMap { it.output })
-      it.consoleReport.set(generateBuildHealthTask.flatMap { it.consoleOutput })
-      it.printBuildHealth.set(dagpExtension.reportingHandler.printBuildHealth.orElse(printBuildHealth()))
-      it.postscript.set(dagpExtension.reportingHandler.postscript)
+    tasks.register("buildHealth", BuildHealthTask::class.java) { t ->
+      t.shouldFail.set(generateBuildHealthTask.flatMap { it.outputFail })
+      t.buildHealth.set(generateBuildHealthTask.flatMap { it.output })
+      t.consoleReport.set(generateBuildHealthTask.flatMap { it.consoleOutput })
+      t.printBuildHealth.set(dagpExtension.reportingHandler.printBuildHealth.orElse(printBuildHealth()))
+      t.postscript.set(dagpExtension.reportingHandler.postscript)
     }
 
-    tasks.register("generateWorkPlan", GenerateWorkPlan::class.java) {
-      it.buildPath.set(buildPath(combinedGraphResolver.internal.name))
-      it.combinedProjectGraphs.setFrom(combinedGraphResolver.internal.map { it.artifactsFor("json").artifactFiles })
-      it.outputDirectory.set(paths.workPlanDir)
+    val generatePublicTypeUsages =
+      tasks.register("generatePublicTypeUsages", GeneratePublicTypeUsageTask::class.java) { t ->
+        t.publicClassesReports.from(publicClassesResolver.internal.map { it.artifactsFor("json").artifactFiles })
+        t.typeUsageReports.from(typeUsagesResolver.internal.map { it.artifactsFor("json").artifactFiles })
+        t.output.set(paths.publicTypeUsagePath)
+        t.outputConsole.set(paths.publicTypeUsageConsolePath)
+      }
+
+    tasks.register("publicTypeUsage", PublicTypeUsageTask::class.java) { t ->
+      t.consoleReport.set(generatePublicTypeUsages.flatMap { it.outputConsole })
+    }
+
+    tasks.register("generateWorkPlan", GenerateWorkPlan::class.java) { t ->
+      t.buildPath.set(buildPath(combinedGraphResolver.internal.name))
+      t.combinedProjectGraphs.setFrom(combinedGraphResolver.internal.map { it.artifactsFor("json").artifactFiles })
+      t.outputDirectory.set(paths.workPlanDir)
     }
 
     // Add a dependency from the root project to all projects (including itself).
-    val combinedGraphPublisher = interProjectPublisher(
-      project = this,
-      artifactDescription = DagpArtifacts.Kind.COMBINED_GRAPH,
-    )
-    val projectHealthPublisher = interProjectPublisher(
-      project = this,
-      artifactDescription = DagpArtifacts.Kind.PROJECT_HEALTH,
-    )
-    val projectMetadataPublisher = interProjectPublisher(
-      project = this,
-      artifactDescription = DagpArtifacts.Kind.PROJECT_METADATA,
-    )
-    val resolvedDependenciesPublisher = interProjectPublisher(
-      project = this,
-      artifactDescription = DagpArtifacts.Kind.RESOLVED_DEPS,
-    )
+    val publishers = DagpArtifacts.Kind.entries.map { kind ->
+      interProjectPublisher(this, kind)
+    }
 
     allprojects.forEach { p ->
       dependencies.let { d ->
-        d.add(combinedGraphPublisher.declarableName, d.project(mapOf("path" to p.path)))
-        d.add(projectHealthPublisher.declarableName, d.project(mapOf("path" to p.path)))
-        d.add(projectMetadataPublisher.declarableName, d.project(mapOf("path" to p.path)))
-        d.add(resolvedDependenciesPublisher.declarableName, d.project(mapOf("path" to p.path)))
+        publishers.forEach { publisher ->
+          d.add(publisher.declarableName, d.project(mapOf("path" to p.path)))
+        }
       }
     }
   }

--- a/src/main/kotlin/com/autonomousapps/tasks/AggregatePublicTypesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/AggregatePublicTypesTask.kt
@@ -1,0 +1,66 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.tasks
+
+import com.autonomousapps.internal.utils.bufferWriteJson
+import com.autonomousapps.internal.utils.fromJsonSet
+import com.autonomousapps.internal.utils.getAndDelete
+import com.autonomousapps.internal.utils.mapToOrderedSet
+import com.autonomousapps.model.internal.PublicTypes
+import com.autonomousapps.model.internal.intermediates.consumer.ExplodingAbi
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.*
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+@CacheableTask
+public abstract class AggregatePublicTypesTask @Inject constructor(
+  private val workerExecutor: WorkerExecutor,
+) : DefaultTask() {
+
+  init {
+    group = "Writes report of all public classes across all variants or source sets in this project"
+  }
+
+  @get:Input
+  public abstract val projectPath: Property<String>
+
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  @get:InputFiles
+  public abstract val abiReports: ConfigurableFileCollection
+
+  @get:OutputFile
+  public abstract val output: RegularFileProperty
+
+  @TaskAction public fun action() {
+    workerExecutor.noIsolation().submit(Action::class.java) {
+      it.projectPath.set(projectPath)
+      it.abiReports.setFrom(abiReports)
+      it.output.set(output)
+    }
+  }
+
+  public interface Parameters : WorkParameters {
+    public val projectPath: Property<String>
+    public val abiReports: ConfigurableFileCollection
+    public val output: RegularFileProperty
+  }
+
+  public abstract class Action : WorkAction<Parameters> {
+
+    override fun execute() {
+      val output = parameters.output.getAndDelete()
+
+      val reports = parameters.abiReports.flatMap { it.fromJsonSet<ExplodingAbi>() }
+      val classNames = reports.mapToOrderedSet { it.className }
+      val publicTypes = PublicTypes(parameters.projectPath.get(), classNames)
+
+      output.bufferWriteJson(publicTypes)
+    }
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/tasks/AggregateTypeUsageTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/AggregateTypeUsageTask.kt
@@ -1,0 +1,90 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.tasks
+
+import com.autonomousapps.internal.utils.bufferWriteJson
+import com.autonomousapps.internal.utils.fromJson
+import com.autonomousapps.internal.utils.getAndDelete
+import com.autonomousapps.model.ProjectTypeUsage
+import com.autonomousapps.model.internal.AggregateTypeUsageReport
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.*
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+@CacheableTask
+public abstract class AggregateTypeUsageTask @Inject constructor(
+  private val workerExecutor: WorkerExecutor,
+) : DefaultTask() {
+
+  init {
+    description = "Computes type-level dependency usage, aggregating all variants or source sets in this project"
+  }
+
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  @get:InputFiles
+  public abstract val typeUsageReports: ConfigurableFileCollection
+
+  @get:OutputFile
+  public abstract val output: RegularFileProperty
+
+  @TaskAction
+  public fun action() {
+    workerExecutor.noIsolation().submit(Action::class.java) {
+      it.typeUsageReports.setFrom(typeUsageReports)
+      it.output.set(output)
+    }
+  }
+
+  public interface Parameters : WorkParameters {
+    public val typeUsageReports: ConfigurableFileCollection
+    public val output: RegularFileProperty
+  }
+
+  public interface Action : WorkAction<Parameters> {
+    override fun execute() {
+      val output = parameters.output.getAndDelete()
+
+      val reports = parameters.typeUsageReports.files.map { it.fromJson<ProjectTypeUsage>() }
+      val combiner = ProjectTypeUsageCombiner(reports)
+      val aggregateReport = combiner.combine()
+
+      output.bufferWriteJson(aggregateReport)
+    }
+  }
+
+  // TODO(tsr): consider unit tests for this complex logic
+  // internal for testing
+  internal class ProjectTypeUsageCombiner(private val reports: List<ProjectTypeUsage>) {
+    fun combine(): AggregateTypeUsageReport {
+      val builder = AggregateTypeUsageReport.Builder()
+      reports.forEach { report ->
+        with(builder) {
+          projectPath = report.projectPath
+          internal.addAll(report.internal.keys)
+          unknownDependencies.addAll(report.unknownDependencies.keys)
+          report.projectDependencies.forEach { (coords, classNamesMap) ->
+            classNamesMap.keys.forEach { className ->
+              projectDependencies.merge(coords, sortedSetOf(className)) { acc, inc ->
+                acc.apply { addAll(inc) }
+              }
+            }
+          }
+          report.libraryDependencies.forEach { (coords, classNamesMap) ->
+            classNamesMap.keys.forEach { className ->
+              libraryDependencies.merge(coords, sortedSetOf(className)) { acc, inc ->
+                acc.apply { addAll(inc) }
+              }
+            }
+          }
+        }
+      }
+
+      return builder.build()
+    }
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/tasks/CodeSourceExploderTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/CodeSourceExploderTask.kt
@@ -16,7 +16,6 @@ import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 import org.gradle.workers.WorkerExecutor
 import java.io.File
-import java.nio.file.Paths
 import javax.inject.Inject
 
 @CacheableTask
@@ -179,38 +178,46 @@ private class SourceExploder(
     val destination = sortedSetOf<ExplodingSourceCode>()
     javaSourceFiles.mapTo(destination) { f ->
       val rel = relativize(f)
+      val sourceListener = SourceListener.parseSourceFile(f)
+      val pkg = packageFrom(sourceListener)
       ExplodingSourceCode(
         relativePath = rel,
-        className = canonicalClassName(rel),
+        className = canonicalClassName(pkg, f),
         kind = Kind.JAVA,
-        imports = SourceListener.parseSourceFileForImports(f)
+        imports = importsFrom(sourceListener),
       )
     }
     kotlinSourceFiles.mapTo(destination) { f ->
       val rel = relativize(f)
+      val sourceListener = SourceListener.parseSourceFile(f)
+      val pkg = packageFrom(sourceListener)
       ExplodingSourceCode(
         relativePath = rel,
-        className = canonicalClassName(rel),
+        className = canonicalClassName(pkg, f),
         kind = Kind.KOTLIN,
-        imports = SourceListener.parseSourceFileForImports(f)
+        imports = importsFrom(sourceListener),
       )
     }
     groovySourceFiles.mapTo(destination) { f ->
       val rel = relativize(f)
+      val sourceListener = SourceListener.parseSourceFile(f)
+      val pkg = packageFrom(sourceListener)
       ExplodingSourceCode(
         relativePath = rel,
-        className = canonicalClassName(rel),
+        className = canonicalClassName(pkg, f),
         kind = Kind.GROOVY,
-        imports = SourceListener.parseSourceFileForImports(f)
+        imports = importsFrom(sourceListener),
       )
     }
     scalaSourceFiles.mapTo(destination) { f ->
       val rel = relativize(f)
+      val sourceListener = SourceListener.parseSourceFile(f)
+      val pkg = packageFrom(sourceListener)
       ExplodingSourceCode(
         relativePath = rel,
-        className = canonicalClassName(rel),
+        className = canonicalClassName(pkg, f),
         kind = Kind.SCALA,
-        imports = SourceListener.parseSourceFileForImports(f)
+        imports = importsFrom(sourceListener),
       )
     }
 
@@ -219,13 +226,21 @@ private class SourceExploder(
 
   private fun relativize(file: File) = file.toRelativeString(projectDir)
 
-  private fun canonicalClassName(relativePath: String): String {
-    return Paths.get(relativePath)
-      // Hack to drop e.g. `src/main/java`. Would be better if a FileTree exposed that info.
-      .drop(3)
-      // com/example/Foo.java -> com.example.Foo.java
-      .joinToString(separator = ".")
-      // Drop file extension (.java, .kt, etc.) as well.
-      .substringBeforeLast('.')
+  private fun canonicalClassName(pkg: String?, file: File): String {
+    // Foo.java -> Foo
+    val name = file.name.substringBeforeLast('.')
+    return if (pkg != null) {
+      "$pkg.$name"
+    } else {
+      name
+    }
   }
+
+  /*
+   * nb: the "cannot access..." IDE error is incorrect. It's failing at something to do with shaded packages yet again.
+   * I put these functions down here to consolidate the errors.
+   */
+
+  private fun packageFrom(sourceListener: SourceListener): String? = sourceListener.packageDeclaration()
+  private fun importsFrom(sourceListener: SourceListener): Set<String> = sourceListener.imports()
 }

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeTypeUsageTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeTypeUsageTask.kt
@@ -2,19 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.tasks
 
+import com.autonomousapps.internal.utils.*
 import com.autonomousapps.internal.utils.strings.ensureSuffix
-import com.autonomousapps.internal.utils.bufferWriteJson
-import com.autonomousapps.internal.utils.fromJson
-import com.autonomousapps.internal.utils.fromJsonSet
-import com.autonomousapps.internal.utils.getAndDelete
-import com.autonomousapps.model.Coordinates
-import com.autonomousapps.model.ModuleCoordinates
-import com.autonomousapps.model.ProjectCoordinates
-import com.autonomousapps.model.ProjectTypeUsage
-import com.autonomousapps.model.TypeUsageSummary
-import com.autonomousapps.model.internal.intermediates.producer.ExplodedJar
+import com.autonomousapps.model.*
+import com.autonomousapps.model.internal.BinaryClassCapability
+import com.autonomousapps.model.internal.Dependency
+import com.autonomousapps.model.internal.InlineMemberCapability
 import com.autonomousapps.model.internal.ProjectVariant
+import com.autonomousapps.model.internal.intermediates.producer.ExplodedJar
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
@@ -45,6 +42,10 @@ public abstract class ComputeTypeUsageTask @Inject constructor(
   @get:InputFile
   public abstract val explodedJars: RegularFileProperty
 
+  @get:PathSensitive(PathSensitivity.NONE)
+  @get:InputDirectory
+  public abstract val dependencies: DirectoryProperty
+
   @get:Input
   public abstract val excludedPackages: SetProperty<String>
 
@@ -63,6 +64,7 @@ public abstract class ComputeTypeUsageTask @Inject constructor(
       it.buildPath.set(buildPath)
       it.syntheticProject.set(syntheticProject)
       it.explodedJars.set(explodedJars)
+      it.dependencies.set(dependencies)
       it.excludedPackages.set(excludedPackages)
       it.excludedTypes.set(excludedTypes)
       it.excludedRegexPatterns.set(excludedRegexPatterns)
@@ -74,6 +76,7 @@ public abstract class ComputeTypeUsageTask @Inject constructor(
     public val buildPath: Property<String>
     public val syntheticProject: RegularFileProperty
     public val explodedJars: RegularFileProperty
+    public val dependencies: DirectoryProperty
     public val excludedPackages: SetProperty<String>
     public val excludedTypes: SetProperty<String>
     public val excludedRegexPatterns: ListProperty<String>
@@ -89,17 +92,18 @@ public abstract class ComputeTypeUsageTask @Inject constructor(
 
       // 1. Load data
       val project = parameters.syntheticProject.fromJson<ProjectVariant>()
+      val dependencies = project.dependencies(parameters.dependencies.get())
       val classToCoords = buildClassIndex()
 
       // 2. Build filter
       val filter = TypeFilter(
         excludedPackages = parameters.excludedPackages.get(),
         excludedTypes = parameters.excludedTypes.get(),
-        excludedRegexPatterns = parameters.excludedRegexPatterns.get()
+        excludedRegexPatterns = parameters.excludedRegexPatterns.get(),
       )
 
       // 3. Analyze usage
-      val analyzer = TypeUsageAnalyzer(project, classToCoords, filter)
+      val analyzer = TypeUsageAnalyzer(project, classToCoords, filter, dependencies)
       val typeUsage = analyzer.analyze()
 
       // 4. Write output
@@ -125,9 +129,9 @@ public abstract class ComputeTypeUsageTask @Inject constructor(
 private class TypeFilter(
   excludedPackages: Set<String>,
   val excludedTypes: Set<String>,
-  excludedRegexPatterns: List<String>
+  excludedRegexPatterns: List<String>,
 ) {
-  private val normalizedPackages = excludedPackages.map { it.ensureSuffix(".") }.toSet()
+  private val normalizedPackages = excludedPackages.mapToSet { it.ensureSuffix(".") }
   private val compiledPatterns = excludedRegexPatterns.map { it.toRegex() }
 
   fun shouldExclude(className: String): Boolean {
@@ -141,8 +145,10 @@ private class TypeFilter(
 private class TypeUsageAnalyzer(
   private val project: ProjectVariant,
   private val classToCoords: Map<String, Coordinates>,
-  private val filter: TypeFilter
+  private val filter: TypeFilter,
+  private val dependencies: Set<Dependency>,
 ) {
+
   fun analyze(): ProjectTypeUsage {
     val usageMap = mutableMapOf<Coordinates, MutableMap<String, Int>>()
     val unknown = mutableMapOf<String, Int>()
@@ -154,18 +160,22 @@ private class TypeUsageAnalyzer(
     project.codeSource.forEach { source ->
       val allUsedClasses = source.usedNonAnnotationClasses + source.usedAnnotationClasses
 
-      allUsedClasses.filter { !filter.shouldExclude(it) }.forEach { className ->
-        // Determine coordinates: check project classes first, then external
-        val coords = classToCoords[className]
+      allUsedClasses
+        // classes referenced via inline functions
+        .plus(findInlineClassNames(source.imports))
+        .filterNot(filter::shouldExclude)
+        .forEach { className ->
+          // Determine coordinates: check project classes first, then external
+          val coords = classToCoords[className]
 
-        if (coords != null || projectClasses.contains(className)) {
-          usageMap
-            .getOrPut(coords ?: project.coordinates) { mutableMapOf() }
-            .merge(className, 1, Int::plus)
-        } else {
-          unknown.merge(className, 1, Int::plus)
+          if (coords != null || projectClasses.contains(className)) {
+            usageMap
+              .getOrPut(coords ?: project.coordinates) { mutableMapOf() }
+              .merge(className, 1, Int::plus)
+          } else {
+            unknown.merge(className, 1, Int::plus)
+          }
         }
-      }
     }
 
     // Categorize dependencies
@@ -189,12 +199,91 @@ private class TypeUsageAnalyzer(
         totalFiles = project.codeSource.size,
         internalTypes = internal.size,
         projectDependencies = projectDeps.size,
-        libraryDependencies = libraryDeps.size
+        libraryDependencies = libraryDeps.size,
       ),
       internal = internal.toSortedMap(),
       projectDependencies = projectDeps.toSortedMap(),
       libraryDependencies = libraryDeps.toSortedMap(),
-      unknownDependencies = unknown.toSortedMap()
+      unknownDependencies = unknown.toSortedMap(),
     )
+  }
+
+  // dependency -> inline imports
+  private val inlineCache = mutableMapOf<Dependency, Set<Imports>>()
+
+  // mapping imports to their "Kt" class names
+  private fun findInlineClassNames(imports: Set<String>): Set<String> {
+    return dependencies
+      .flatMapToOrderedSet { dependency ->
+        getCacheEntry(dependency)
+          .filter { entry -> entry.candidateImports.any { it in imports } }
+          .mapToOrderedSet { entry -> entry.className }
+      }
+  }
+
+  private fun getCacheEntry(dependency: Dependency): Set<Imports> {
+    return inlineCache.getOrPut(dependency) {
+      val binaryEntries = dependency.findCapability<BinaryClassCapability>()?.let(Imports::of).orEmpty()
+      val inlineEntries = dependency.findCapability<InlineMemberCapability>()?.let(Imports::of).orEmpty()
+
+      binaryEntries + inlineEntries
+    }
+  }
+
+  /**
+   * Maps class names to import statements. Currently used for inline functions and source-retained annotations.
+   *
+   * For inline functions, given a source file `com/foo/Bar.kt`, which produces a class file `com/foo/Bar.class`:
+   * ```
+   * inline fun inlineFun1() { ... }
+   *
+   * inline fun inlineFun2() { ... }
+   * ```
+   *
+   * Imports in other sources files will look like:
+   * ```
+   * import com.foo.inlineFun1
+   * import com.foo.*
+   * ```
+   */
+  private data class Imports(
+    /** com.foo.BarKt */
+    val className: String,
+    /** list: `com.foo.inlineFun1`, `com.foo.inlineFun1`, `com.foo.SourceRetainedAnnotation`. */
+    val candidateImports: Set<String>,
+  ) : Comparable<Imports> {
+    override fun compareTo(other: Imports): Int {
+      return compareBy(Imports::className)
+        .thenBy(LexicographicIterableComparator()) { it.candidateImports }
+        .compare(this, other)
+    }
+
+    companion object {
+      fun of(inlineMember: InlineMemberCapability): Set<Imports> {
+        return inlineMember.inlineMembers.mapToOrderedSet(Imports::of)
+      }
+
+      fun of(inlineMember: InlineMemberCapability.InlineMember): Imports {
+        return Imports(
+          className = inlineMember.className,
+          candidateImports = inlineMember.candidateImports(),
+        )
+      }
+
+      fun of(binary: BinaryClassCapability): Set<Imports> {
+        return binary.classes.mapToOrderedSet { className ->
+          val candidateImports = if (className.contains('.')) {
+            sortedSetOf(className, className.substringBeforeLast('.') + ".*")
+          } else {
+            sortedSetOf(className)
+          }
+
+          Imports(
+            className = className,
+            candidateImports = candidateImports,
+          )
+        }
+      }
+    }
   }
 }

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeUsagesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeUsagesTask.kt
@@ -877,11 +877,8 @@ private class GraphVisitor(
     capability: InlineMemberCapability,
     context: GraphViewVisitor.Context,
   ): Boolean {
-    val candidateImports = capability.inlineMembers.asSequence()
-      .flatMap { (pn, names) ->
-        listOf("$pn.*") + names.map { name -> "$pn.$name" }
-      }
-      .toSet()
+    val candidateImports = capability.inlineMembers
+      .flatMapToOrderedSet(InlineMemberCapability.InlineMember::candidateImports)
 
     val imports = context.project.imports.asSequence().filter { import ->
       candidateImports.contains(import)

--- a/src/main/kotlin/com/autonomousapps/tasks/FindKotlinMagicTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindKotlinMagicTask.kt
@@ -176,6 +176,11 @@ internal class KotlinMagicFinder(
       }
     }
 
+    // com/foo/BarKt.class -> com.foo.BarKt
+    fun className(entryName: String): String {
+      return entryName.replace('/', '.').substringBeforeLast(".class")
+    }
+
     val inlineMembers = mutableSetOf<InlineMemberCapability.InlineMember>()
     val typealiases = mutableSetOf<TypealiasCapability.Typealias>()
 
@@ -201,6 +206,7 @@ internal class KotlinMagicFinder(
             .forEach { (entry, kotlinMagic) ->
               if (kotlinMagic.inlineMembers != null) {
                 inlineMembers += InlineMemberCapability.InlineMember.newInstance(
+                  className = className(entry.name),
                   packageName = packageName(entry.name),
                   // Guaranteed to be non-empty
                   inlineMembers = kotlinMagic.inlineMembers
@@ -233,8 +239,12 @@ internal class KotlinMagicFinder(
           }
           .forEach { (classFile, kotlinMagic) ->
             if (kotlinMagic.inlineMembers != null) {
+              val packageName = packageName(Files.asPackagePath(classFile))
+              val className = packageName + classFile.name.substringBeforeLast(".class")
+
               inlineMembers += InlineMemberCapability.InlineMember.newInstance(
-                packageName = packageName(Files.asPackagePath(classFile)),
+                className = className,
+                packageName = packageName,
                 // Guaranteed to be non-empty
                 inlineMembers = kotlinMagic.inlineMembers
               )

--- a/src/main/kotlin/com/autonomousapps/tasks/GeneratePublicTypeUsageTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/GeneratePublicTypeUsageTask.kt
@@ -1,0 +1,205 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.tasks
+
+import com.autonomousapps.internal.utils.*
+import com.autonomousapps.model.internal.AggregateTypeUsageReport
+import com.autonomousapps.model.internal.PublicTypeUsage
+import com.autonomousapps.model.internal.PublicTypeUsage.Report
+import com.autonomousapps.model.internal.PublicTypes
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.*
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import org.gradle.workers.WorkerExecutor
+import java.util.*
+import javax.inject.Inject
+
+@CacheableTask
+public abstract class GeneratePublicTypeUsageTask @Inject constructor(
+  private val workerExecutor: WorkerExecutor,
+) : DefaultTask() {
+
+  init {
+    description = "Generates the aggregate public class usage report"
+  }
+
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  @get:InputFiles
+  public abstract val publicClassesReports: ConfigurableFileCollection
+
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  @get:InputFiles
+  public abstract val typeUsageReports: ConfigurableFileCollection
+
+  /**
+   * A machine-readable JSON report.
+   *
+   * @see [PublicTypeUsage]
+   */
+  @get:OutputFile
+  public abstract val output: RegularFileProperty
+
+  /** A human-readable console report, derived from [output]. */
+  @get:OutputFile
+  public abstract val outputConsole: RegularFileProperty
+
+  @TaskAction public fun action() {
+    workerExecutor.noIsolation().submit(Action::class.java) {
+      it.publicClassesReports.setFrom(publicClassesReports)
+      it.typeUsageReports.setFrom(typeUsageReports)
+      it.output.set(output)
+      it.outputConsole.set(outputConsole)
+    }
+  }
+
+  public interface Parameters : WorkParameters {
+    public val publicClassesReports: ConfigurableFileCollection
+    public val typeUsageReports: ConfigurableFileCollection
+    public val output: RegularFileProperty
+    public val outputConsole: RegularFileProperty
+  }
+
+  public abstract class Action : WorkAction<Parameters> {
+    override fun execute() {
+      val output = parameters.output.getAndDelete()
+      val outputConsole = parameters.outputConsole.getAndDelete()
+
+      val publicClassReports = parameters.publicClassesReports.mapToOrderedSet { it.fromJson<PublicTypes>() }
+      val typeUsageReports = parameters.typeUsageReports.mapToOrderedSet { it.fromJson<AggregateTypeUsageReport>() }
+      val analyzer = Analyzer(publicClassReports, typeUsageReports)
+      val publicClassUsage = analyzer.analyze()
+      val consoleReport = ConsoleReportBuilder(publicClassUsage).buildReport()
+
+      output.bufferWriteJson(publicClassUsage)
+      outputConsole.writeText(consoleReport)
+    }
+  }
+
+  private class Analyzer(
+    private val publicClassReports: Set<PublicTypes>,
+    private val typeUsageReports: Set<AggregateTypeUsageReport>,
+  ) {
+    fun analyze(): PublicTypeUsage {
+      // owningProjectPath -> accessors (accessingProjectPath -> accessedClasses)
+      val accessorMap = mutableMapOf<String, SortedSet<Accessor>>()
+
+      typeUsageReports.forEach { report ->
+        val accessingProjectPath = report.projectPath
+        // only projectDependencies could be accessors of public classes in this build
+        report.projectDependencies.entries.forEach { (owningProjectPath, classNames) ->
+          val accessor = Accessor(accessingProjectPath, classNames)
+          accessorMap.merge(owningProjectPath, sortedSetOf(accessor)) { acc, inc ->
+            acc.apply { addAll(inc) }
+          }
+        }
+      }
+
+      // owningProject -> reports
+      val reports = publicClassReports.mapToOrderedSet { publicClasses ->
+        val owningProject = publicClasses.projectPath
+        val builder = ReportBuilder().apply {
+          this.owningProject = owningProject
+          this.publicClasses.addAll(publicClasses.types)
+        }
+
+        // Can be null (empty) if there are no accessors
+        val accessors = accessorMap[owningProject].orEmpty()
+
+        accessors.forEach { accessor ->
+          val accessingProject = accessor.accessingProject
+          val accessedClasses = accessor.accessedClasses
+
+          builder.accessedClasses.addAll(accessedClasses)
+
+          accessedClasses.forEach { accessedClass ->
+            builder.accesses.merge(accessedClass, sortedSetOf(accessingProject)) { acc, inc ->
+              acc.apply { addAll(inc) }
+            }
+          }
+        }
+
+        builder.build()
+      }
+
+      return PublicTypeUsage(reports)
+    }
+  }
+
+  private data class Accessor(
+    val accessingProject: String,
+    /** From a specific other subproject. */
+    val accessedClasses: Set<String>,
+  ) : Comparable<Accessor> {
+    override fun compareTo(other: Accessor): Int {
+      return compareBy(Accessor::accessingProject)
+        .thenBy(LexicographicIterableComparator()) { it.accessedClasses }
+        .compare(this, other)
+    }
+  }
+
+  private class ReportBuilder {
+    var owningProject: String? = null
+    val publicClasses = mutableSetOf<String>()
+    val accessedClasses = mutableSetOf<String>()
+    val accesses = mutableMapOf<String, SortedSet<String>>()
+    val unaccessedClasses = sortedSetOf<String>()
+
+    fun build(): Report {
+      return Report(
+        owningProject = requireNotNull(owningProject),
+        accesses = buildAccesses(),
+        unaccessedTypes = (publicClasses - accessedClasses).toSortedSet(),
+      )
+    }
+
+    private fun buildAccesses(): Set<PublicTypeUsage.Accesses> {
+      return accesses
+        .mapTo(TreeSet()) { (className, accessingProjects) ->
+          PublicTypeUsage.Accesses(
+            typeName = className,
+            accessingProjects = accessingProjects,
+          )
+        }
+    }
+  }
+
+  private class ConsoleReportBuilder(private val report: PublicTypeUsage) {
+    fun buildReport() = buildString {
+      appendLine("These projects have public types (classes, interfaces) that have no external accessors. Those types' visibilities could be restricted (e.g., made `internal`).")
+      appendLine()
+
+      var lineBreak = false
+
+      report.reports.asSequence()
+        .filter { r -> r.unaccessedTypes.isNotEmpty() }
+        .forEach { r ->
+          if (lineBreak) {
+            appendLine()
+          }
+          lineBreak = true
+
+          val size = r.unaccessedTypes.size
+
+          append(r.owningProject)
+          append(" (")
+          append(size)
+          append(" ")
+          append(pluralize(size))
+          appendLine(")")
+
+          r.unaccessedTypes.forEach { type ->
+            append("- ").appendLine(type)
+          }
+        }
+    }
+
+    private fun pluralize(size: Int): String = if (size == 1) {
+      "type"
+    } else {
+      "types"
+    }
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/tasks/PublicTypeUsageTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/PublicTypeUsageTask.kt
@@ -1,0 +1,48 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.tasks
+
+import com.autonomousapps.TASK_GROUP_DEP
+import com.autonomousapps.internal.utils.getLogger
+import com.autonomousapps.internal.utils.readText
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.*
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+@UntrackedTask(because = "Always prints output")
+public abstract class PublicTypeUsageTask @Inject constructor(
+  private val workerExecutor: WorkerExecutor,
+) : DefaultTask() {
+
+  init {
+    group = TASK_GROUP_DEP
+    description = "Generates a global report of public type usage"
+  }
+
+  @get:PathSensitive(PathSensitivity.NONE)
+  @get:InputFile
+  public abstract val consoleReport: RegularFileProperty
+
+  @TaskAction public fun action() {
+    workerExecutor.noIsolation().submit(Action::class.java) {
+      it.consoleReport.set(consoleReport)
+    }
+  }
+
+  public interface Parameters : WorkParameters {
+    public val consoleReport: RegularFileProperty
+  }
+
+  public abstract class Action : WorkAction<Parameters> {
+
+    private val logger = getLogger<PublicTypeUsageTask>()
+
+    override fun execute() {
+      logger.quiet(parameters.consoleReport.readText())
+    }
+  }
+}

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/android/AndroidManifest.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/android/AndroidManifest.kt
@@ -46,6 +46,21 @@ public class AndroidManifest(public val content: String) {
     )
 
     @JvmStatic
+    public fun appWithoutStyle(application: String): AndroidManifest = AndroidManifest(
+      """
+      |<?xml version="1.0" encoding="utf-8"?>
+      |<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+      |
+      |<application
+      |  android:allowBackup="true"
+      |  android:label="Test app"
+      |  android:name="$application">
+      |  </application>
+      |</manifest>
+      """.trimMargin()
+    )
+
+    @JvmStatic
     public fun appWithoutPackage(application: String? = null): AndroidManifest {
       return AndroidManifest(
         """

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/GradleProperties.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/GradleProperties.kt
@@ -86,9 +86,7 @@ public class GradleProperties(private val lines: MutableList<String>) {
     public fun minimalAndroidProperties(): GradleProperties = of(JVM_ARGS, USE_ANDROID_X, NON_TRANSITIVE_R)
 
     @JvmStatic
-    public fun enableConfigurationCache(): GradleProperties = of(
-      CONFIGURATION_CACHE_STABLE, CONFIGURATION_CACHE_UNSTABLE
-    )
+    public fun enableConfigurationCache(): GradleProperties = of(CONFIGURATION_CACHE_STABLE)
 
     @JvmStatic
     public fun enableIsolatedProjects(): GradleProperties = of(ISOLATED_PROJECTS_UNSTABLE)

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/android/DefaultConfig.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/android/DefaultConfig.kt
@@ -125,7 +125,7 @@ public class DefaultConfig @JvmOverloads constructor(
     @JvmField
     public val DEFAULT_APP: DefaultConfig = DefaultConfig(
       applicationId = "com.example",
-      minSdkVersion = 21,
+      minSdkVersion = 23,
       targetSdkVersion = 29,
       versionCode = 1,
       versionName = "1.0",
@@ -133,7 +133,7 @@ public class DefaultConfig @JvmOverloads constructor(
 
     @JvmField
     public val DEFAULT_LIB: DefaultConfig = DefaultConfig(
-      minSdkVersion = 21,
+      minSdkVersion = 23,
       targetSdkVersion = 29,
       versionCode = 1,
       versionName = "1.0",
@@ -141,7 +141,7 @@ public class DefaultConfig @JvmOverloads constructor(
 
     @JvmField
     public val DEFAULT_TEST: DefaultConfig = DefaultConfig(
-      minSdkVersion = 21,
+      minSdkVersion = 23,
       targetSdkVersion = 29,
       versionCode = 1,
       versionName = "1.0",

--- a/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestGroovy.kt
+++ b/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestGroovy.kt
@@ -524,7 +524,7 @@ internal class ScribeTestGroovy {
             compileSdkVersion 34
             defaultConfig {
               applicationId 'com.example'
-              minSdkVersion 21
+              minSdkVersion 23
               targetSdkVersion 29
               versionCode 1
               versionName '1.0'
@@ -580,7 +580,7 @@ internal class ScribeTestGroovy {
             compileSdkVersion 34
             defaultConfig {
               applicationId 'com.example'
-              minSdkVersion 21
+              minSdkVersion 23
               targetSdkVersion 29
               versionCode 1
               versionName '1.0'

--- a/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestKotlin.kt
+++ b/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestKotlin.kt
@@ -527,7 +527,7 @@ internal class ScribeTestKotlin {
             compileSdk = 34
             defaultConfig {
               applicationId = "com.example"
-              minSdk = 21
+              minSdk = 23
               targetSdk = 29
               versionCode = 1
               versionName = "1.0"
@@ -582,7 +582,7 @@ internal class ScribeTestKotlin {
             compileSdk = 34
             defaultConfig {
               applicationId = "com.example"
-              minSdk = 21
+              minSdk = 23
               targetSdk = 29
               versionCode = 1
               versionName = "1.0"


### PR DESCRIPTION
For example (from `PublicTypeUsageSpec`):

```shell
./gradlew :publicTypeUsage

These projects have public types (classes, interfaces) that have no external accessors. Those types' visibilities could be restricted (e.g., made `internal`).
        
:module-fire
(1 type)
- com.example.module.RealMagic
        
:module-water
(1 type)
- com.example.module.RealMagic
```