### PR TITLE
Suggest fixDependencies on health failures

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/advice/ProjectHealthConsoleReportBuilder.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/advice/ProjectHealthConsoleReportBuilder.kt
@@ -129,6 +129,7 @@ internal class ProjectHealthConsoleReportBuilder(
 
       appendModuleAdvice()
       appendWarnings()
+      appendFixDependenciesHelp()
       appendPostscript()
     }.trimEnd()
   }
@@ -211,6 +212,24 @@ internal class ProjectHealthConsoleReportBuilder(
 
     maybeAppendTwoLines()
     appendReproducibleNewLine(postscript.colorize(Colors.BOLD))
+  }
+
+  private fun StringBuilder.appendFixDependenciesHelp() {
+    // Only dependency advice can be applied automatically by fixDependencies.
+    if (projectAdvice.dependencyAdvice.isEmpty()) return
+
+    maybeAppendTwoLines()
+    append(
+      "To apply dependency advice automatically, run `./gradlew ${projectAdvice.fixDependenciesTaskPath()}`."
+    )
+  }
+
+  private fun ProjectAdvice.fixDependenciesTaskPath(): String {
+    return when {
+      projectPath == ":" -> ":fixDependencies"
+      projectPath.startsWith(":") -> "$projectPath:fixDependencies"
+      else -> ":$projectPath:fixDependencies"
+    }
   }
 
   private fun Set<ModuleAdvice>.hasPrintableAdvice(): Boolean {

--- a/src/test/kotlin/com/autonomousapps/internal/advice/ProjectHealthConsoleReportBuilderTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/advice/ProjectHealthConsoleReportBuilderTest.kt
@@ -43,6 +43,8 @@ internal class ProjectHealthConsoleReportBuilderTest {
           api("com.project.c:1.0")
           implementation("com.project.a:1.0")
         
+        To apply dependency advice automatically, run `./gradlew :magic:fixDependencies`.
+
         For help understanding this report, please ask in #my-cool-slack-channel
       """.trimIndent()
     )
@@ -72,6 +74,8 @@ internal class ProjectHealthConsoleReportBuilderTest {
           api projects.sadRobot1.corePublic2 (was implementation)
           implementation projects.marvin (was api)
         
+        To apply dependency advice automatically, run `./gradlew :dummy:fixDependencies`.
+
         For help understanding this report, please ask in #my-cool-slack-channel
       """.trimIndent()
     )
@@ -101,6 +105,8 @@ internal class ProjectHealthConsoleReportBuilderTest {
           api(projects.sadRobot.internal) (was implementation)
           implementation(projects.marvin) (was api)
         
+        To apply dependency advice automatically, run `./gradlew :dummy:fixDependencies`.
+
         For help understanding this report, please ask in #my-cool-slack-channel
       """.trimIndent()
     )
@@ -129,6 +135,8 @@ internal class ProjectHealthConsoleReportBuilderTest {
           implementation("com.project.b:1.0") (was api)
           implementation("com.project.c:1.0") (was api)
         
+        To apply dependency advice automatically, run `./gradlew :dummy:fixDependencies`.
+
         For help understanding this report, please ask in #my-cool-slack-channel
       """.trimIndent()
     )
@@ -157,6 +165,8 @@ internal class ProjectHealthConsoleReportBuilderTest {
           api("com.project.c:1.0")
           implementation("com.project.a:1.0")
         
+        To apply dependency advice automatically, run `./gradlew :dummy:fixDependencies`.
+
         For help understanding this report, please ask in #my-cool-slack-channel
       """.trimIndent()
     )


### PR DESCRIPTION
## Summary
- add a fixDependencies hint to project health console reports when dependency advice is present
- derive the task path from the reported project path
- update console report expectations for dependency advice output

Fixes #1053.

## Test
- ./gradlew.bat --no-daemon --console=plain --max-workers=1 --no-configuration-cache --rerun-tasks :test --tests com.autonomousapps.internal.advice.ProjectHealthConsoleReportBuilderTest