### PR TITLE
fix: don't report Android R classes as classpath duplicates

### DIFF
--- a/src/main/kotlin/com/autonomousapps/tasks/DiscoverClasspathDuplicationTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/DiscoverClasspathDuplicationTask.kt
@@ -7,6 +7,7 @@ import com.autonomousapps.internal.utils.*
 import com.autonomousapps.model.Coordinates
 import com.autonomousapps.model.DuplicateClass
 import com.autonomousapps.model.internal.ProjectVariant
+import com.autonomousapps.model.source.AndroidSourceKind
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.ArtifactCollection
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
@@ -75,9 +76,12 @@ public abstract class DiscoverClasspathDuplicationTask : DefaultTask() {
     }
 
     fun duplicates(): Set<DuplicateClass> {
+      val isAndroid = project.sourceKind is AndroidSourceKind
       return duplicatesMap.asMap()
         // Find all class files provided by more than one dependency
         .filterValues { it.size > 1 }
+        // R classes are duplicated by design; ignore them on Android.
+        .filterKeys { !isAndroid || !isAndroidRClass(it) }
         // only warn about duplicates if it's about a class that's actually used.
         .filterKeys {
           val fqcn = it.replace('/', '.').removeSuffix(".class")
@@ -111,4 +115,13 @@ public abstract class DiscoverClasspathDuplicationTask : DefaultTask() {
         .forEach { duplicatesMap.put(it, coordinates) }
     }
   }
+}
+
+/**
+ * Returns true if [classFile] (a `/`-delimited class file name, e.g. `androidx/appcompat/R$id.class`) is an Android
+ * `R` class. Android generates `R` and nested `R$*` classes into every module, so they're never actionable duplicates.
+ */
+internal fun isAndroidRClass(classFile: String): Boolean {
+  val simpleName = classFile.removeSuffix(".class").substringAfterLast('/')
+  return simpleName == "R" || simpleName.startsWith("R$")
 }

--- a/src/test/kotlin/com/autonomousapps/tasks/DiscoverClasspathDuplicationTaskTest.kt
+++ b/src/test/kotlin/com/autonomousapps/tasks/DiscoverClasspathDuplicationTaskTest.kt
@@ -1,0 +1,42 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.tasks
+
+import com.google.common.truth.Truth.assertWithMessage
+import org.junit.jupiter.api.Test
+
+internal class DiscoverClasspathDuplicationTaskTest {
+
+  @Test fun `recognizes Android R classes`() {
+    val rClasses = listOf(
+      "androidx/appcompat/R.class",
+      "androidx/appcompat/R\$id.class",
+      "androidx/appcompat/R\$styleable.class",
+      "androidx/preference/R.class",
+      "mozilla/components/browser/menu/R.class",
+      "mozilla/components/feature/addons/R\$string.class",
+      // Default package.
+      "R.class",
+    )
+
+    rClasses.forEach {
+      assertWithMessage(it).that(isAndroidRClass(it)).isTrue()
+    }
+  }
+
+  @Test fun `does not flag other classes that merely start with R`() {
+    val others = listOf(
+      "com/example/MyClass.class",
+      "androidx/appcompat/Rabbit.class",
+      "com/example/MyR.class",
+      "com/example/Resources.class",
+      "com/example/RFoo.class",
+      // Butterknife's R2 is intentionally not treated as an R class.
+      "com/example/R2.class",
+    )
+
+    others.forEach {
+      assertWithMessage(it).that(isAndroidRClass(it)).isFalse()
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1335.

Android generates an `R` class (and nested `R$*` classes) into every dependency that ships resources, as well as the consuming module, so the same `R` legitimately appears on the classpath of multiple artifacts and gets reported as a duplicate even though it's never user-actionable. This skips `R`/`R$*` class files in `DiscoverClasspathDuplicationTask`.

The filter is name-based and unconditional rather than gated on the Android plugin, since `ProjectVariant` has no clean "is Android" signal at this point. Happy to gate it on Android if you'd prefer. I scoped it to `R`/`R$*` only and didn't touch the CHANGELOG, but can add an entry if you'd like.