### PR TITLE
fix: JarExploder should ignore some MRJar content

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
@@ -28,6 +28,44 @@ internal fun Sequence<ResolvedArtifactResult>.filterNonGradle() = filterNot {
   it.id.componentIdentifier is OpaqueComponentIdentifier
 }
 
+private val CURRENT_JVM_FEATURE_VERSION = Runtime.version().feature()
+
+/**
+ * Matches a multi-release JAR versioned entry, e.g. `META-INF/versions/25/com/example/Foo.class`,
+ * capturing the targeted Java major version (`25` in this example). See
+ * [JEP 238](https://openjdk.org/jeps/238).
+ */
+private val MULTI_RELEASE_VERSION_REGEX = Regex("""(?:^|/)META-INF/versions/(\d+)/""")
+
+/**
+ * Returns `true` if [entryName] is a class from a multi-release JAR version directory
+ * (`META-INF/versions/<N>/...`) where `<N>` is higher than the major Java version currently running
+ * the analysis ([CURRENT_JVM_FEATURE_VERSION]).
+ *
+ * Such classes cannot influence the analysis result and could cause issues with the bundled ASM version.
+ * See [issue #1692](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1692).
+ */
+internal fun isUnsupportedMultiReleaseClass(
+  entryName: String,
+  currentJvmMajor: Int = CURRENT_JVM_FEATURE_VERSION,
+): Boolean {
+  val version = MULTI_RELEASE_VERSION_REGEX.find(entryName)
+    ?.groupValues?.get(1)
+    ?.toIntOrNull()
+    ?: return false
+  return version > currentJvmMajor
+}
+
+private fun String.isAnalyzableClassFileName(): Boolean {
+  return endsWith(".class") && !endsWith("module-info.class") && !isUnsupportedMultiReleaseClass(this)
+}
+
+private fun File.isAnalyzableClassFile(): Boolean {
+  return extension == "class" &&
+    !name.endsWith("module-info.class") &&
+    !isUnsupportedMultiReleaseClass(invariantSeparatorsPath)
+}
+
 /**
  * Transforms a [ZipFile] into a collection of [ZipEntry]s, which contains only class files (and not
  * the module-info.class file).
@@ -38,21 +76,21 @@ internal fun ZipFile.asClassFiles(): Set<ZipEntry> {
 
 internal fun ZipFile.asSequenceOfClassFiles(): Sequence<ZipEntry> {
   return entries().asSequence().filter {
-    it.name.endsWith(".class") && !it.name.endsWith("module-info.class")
+    it.name.isAnalyzableClassFileName()
   }
 }
 
 /** Filters a collection of [ZipEntry]s to contain only class files (and not the module-info.class file). */
 internal fun Iterable<ZipEntry>.filterToSetOfClassFiles(): Set<ZipEntry> {
   return filterToSet {
-    it.name.endsWith(".class") && !it.name.endsWith("module-info.class")
+    it.name.isAnalyzableClassFileName()
   }
 }
 
 /** Filters a collection of [ZipEntry]s to contain only class files (and not the module-info.class file). */
 internal fun Iterable<ZipEntry>.asSequenceOfClassFiles(): Sequence<ZipEntry> {
   return asSequence().filter {
-    it.name.endsWith(".class") && !it.name.endsWith("module-info.class")
+    it.name.isAnalyzableClassFileName()
   }
 }
 
@@ -67,12 +105,12 @@ internal fun Collection<File>.asSequenceOfClassFiles(): Sequence<File> {
 }
 
 internal fun Sequence<File>.filterToClassFiles(): Sequence<File> {
-  return filter { it.extension == "class" && !it.name.endsWith("module-info.class") }
+  return filter { it.isAnalyzableClassFile() }
 }
 
 
 internal fun Iterable<File>.filterToClassFiles(): List<File> {
-  return filter { it.extension == "class" && !it.name.endsWith("module-info.class") }
+  return filter { it.isAnalyzableClassFile() }
 }
 
 /** Filters a [FileCollection] to contain only class files. */

--- a/src/test/kotlin/com/autonomousapps/internal/JarExploderTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/JarExploderTest.kt
@@ -1,0 +1,82 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.internal
+
+import com.autonomousapps.internal.asm.ClassWriter
+import com.autonomousapps.internal.asm.Opcodes
+import com.autonomousapps.model.GradleVariantIdentification
+import com.autonomousapps.model.ModuleCoordinates
+import com.autonomousapps.model.internal.PhysicalArtifact
+import com.autonomousapps.services.InMemoryCache
+import com.google.common.truth.Truth.assertThat
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+internal class JarExploderTest {
+
+  /**
+   * Regression test for https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1692.
+   *
+   * A multi-release JAR may ship classes for a Java version newer than the JVM (and bundled ASM) running the analysis.
+   * Such classes would crash ASM's `ClassReader`.
+   * [JarExploder] must skip them and still successfully analyze the rest of the jar.
+   */
+  @Test fun `does not fail on multi-release classes targeting a future Java version`(@TempDir dir: File) {
+    val futureVersion = Runtime.version().feature() + 1
+    val jar = File(dir, "example-1.jar").apply {
+      ZipOutputStream(outputStream()).use { zip ->
+        // A real, parseable class targeting the base version.
+        zip.writeEntry("com/example/Foo.class", validClass("com/example/Foo"))
+        // Bytecode the bundled ASM cannot parse — reading it through ClassReader would throw.
+        zip.writeEntry("META-INF/versions/$futureVersion/com/example/Future.class", byteArrayOf(0, 1, 2, 3))
+        zip.writeEntry("META-INF/MANIFEST.MF", "Manifest-Version: 1.0\nMulti-Release: true\n".toByteArray())
+      }
+    }
+
+    val artifact = PhysicalArtifact(
+      coordinates = ModuleCoordinates("org.example:example", "1", GradleVariantIdentification.EMPTY),
+      file = jar,
+    )
+
+    val exploder = JarExploder(
+      artifacts = listOf(artifact),
+      androidLinters = emptySet(),
+      inMemoryCache = newInMemoryCache(),
+    )
+
+    // Must not throw — the future-versioned class is skipped rather than handed to ASM.
+    val exploded = exploder.explodedJars()
+
+    assertThat(exploded).hasSize(1)
+    val classNames = exploded.first().binaryClasses.map { it.className }
+    assertThat(classNames).contains("com.example.Foo")
+    assertThat(classNames).doesNotContain("com.example.Future")
+  }
+
+  private fun newInMemoryCache(): InMemoryCache {
+    val project = ProjectBuilder.builder().build()
+    return project.gradle.sharedServices
+      .registerIfAbsent("inMemoryCache", InMemoryCache::class.java) {
+        it.parameters.cacheSize.set(-1L)
+      }
+      .get()
+  }
+
+  private fun ZipOutputStream.writeEntry(name: String, bytes: ByteArray) {
+    putNextEntry(ZipEntry(name))
+    write(bytes)
+    closeEntry()
+  }
+
+  /** Generates a minimal, valid `.class` file (parseable by ASM) for the given internal name, e.g. `com/example/Foo`. */
+  private fun validClass(internalName: String): ByteArray {
+    val cw = ClassWriter(0)
+    cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, internalName, null, "java/lang/Object", null)
+    cw.visitEnd()
+    return cw.toByteArray()
+  }
+}

--- a/src/test/kotlin/com/autonomousapps/internal/utils/CollectionsTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/utils/CollectionsTest.kt
@@ -1,0 +1,32 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.internal.utils
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+internal class CollectionsTest {
+
+  @Test fun `keeps multi-release classes targeting the current or older Java versions`() {
+    val current = 21
+
+    assertThat(isUnsupportedMultiReleaseClass("META-INF/versions/17/com/example/Foo.class", current)).isFalse()
+    assertThat(isUnsupportedMultiReleaseClass("META-INF/versions/21/com/example/Foo.class", current)).isFalse()
+  }
+
+  @Test fun `skips multi-release classes targeting a newer Java version`() {
+    val current = 21
+
+    assertThat(isUnsupportedMultiReleaseClass("META-INF/versions/25/com/example/Foo.class", current)).isTrue()
+    assertThat(isUnsupportedMultiReleaseClass("META-INF/versions/99/Foo.class", current)).isTrue()
+  }
+
+  @Test fun `ordinary class entries are never treated as unsupported multi-release classes`() {
+    val current = 21
+
+    assertThat(isUnsupportedMultiReleaseClass("com/example/Foo.class", current)).isFalse()
+    assertThat(isUnsupportedMultiReleaseClass("META-INF/MANIFEST.MF", current)).isFalse()
+    // A package literally named "versions" must not be misinterpreted as a multi-release directory.
+    assertThat(isUnsupportedMultiReleaseClass("com/example/versions/Foo.class", current)).isFalse()
+  }
+}


### PR DESCRIPTION
Content of a MRJar that is for a Java version higher than the one running the analysis should be ignored as it should not influence analysis and could cause bundled ASM crashes if the bytecode is too recent.