### PR TITLE
Isolate usage of kotlin-metadata to workers and downgrade Kotlin version used by the plugin

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/autonomousapps/convention/internal/kotlin/KotlinConfigurer.kt
+++ b/build-logic/convention/src/main/kotlin/com/autonomousapps/convention/internal/kotlin/KotlinConfigurer.kt
@@ -13,7 +13,9 @@ internal class KotlinConfigurer(private val project: Project) {
 
   private val versionCatalog = project.extensions.getByType(VersionCatalogsExtension::class.java).named("libs")
   private val javaTarget = versionCatalog.findVersion("javaTarget").orElseThrow().requiredVersion
-  private val kotlin = versionCatalog.findVersion("kotlin").get().requiredVersion
+
+  /** Version of the bundled `kotlin-stdlib*`/`kotlin-reflect`. Capped for Gradle 8.x compatibility (see `libs.versions.toml`). */
+  private val kotlinRuntime = versionCatalog.findVersion("kotlinRuntime").get().requiredVersion
   private val kotlinLanguageVersion = versionCatalog.findVersion("kotlinLanguageVersion").get().requiredVersion
     .toKotlinVersion()
 
@@ -28,7 +30,8 @@ internal class KotlinConfigurer(private val project: Project) {
   private fun Project.configureKotlinExtension() {
     project.extensions.getByType(KotlinJvmProjectExtension::class.java).run {
       explicitApi()
-      coreLibrariesVersion = kotlin
+      // Bundled stdlib is capped for Gradle 8.x compatibility; compile against that same API level.
+      coreLibrariesVersion = kotlinRuntime
     }
   }
 
@@ -48,7 +51,14 @@ internal class KotlinConfigurer(private val project: Project) {
     }
   }
 
-  /** @see <a href="https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1537#issuecomment-3293306966">Issue 1537</a> */
+  /**
+   * Pin the bundled Kotlin runtime libraries (`kotlin-stdlib*`, `kotlin-reflect`) to [kotlinRuntime]. These end up on
+   * DAGP's shaded runtime classpath, so their binary-metadata version must stay readable by the oldest supported
+   * Gradle's Kotlin DSL script compiler.
+   *
+   * @see <a href="https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1537#issuecomment-3293306966">Issue 1537</a>
+   * @see <a href="https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1671">Issue 1671</a>
+   */
   private fun Project.configureKotlinVersion() {
     configurations.configureEach { c ->
       if (c.isCanBeResolved) {
@@ -56,9 +66,12 @@ internal class KotlinConfigurer(private val project: Project) {
           r.eachDependency { details ->
             val requested = details.requested
 
-            if (requested.group == "org.jetbrains.kotlin" && requested.name.startsWith("kotlin-stdlib")) {
-              details.useVersion(kotlin)
-              details.because("Downgrading the stdlib for enhanced compatibility")
+            if (
+              requested.group == "org.jetbrains.kotlin" &&
+              (requested.name.startsWith("kotlin-stdlib") || requested.name == "kotlin-reflect")
+            ) {
+              details.useVersion(kotlinRuntime)
+              details.because("Downgrading the Kotlin runtime libraries for enhanced compatibility (issues 1537, 1671)")
             }
           }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,6 +74,8 @@ buildConfig {
 
   buildConfigField("String", "GRADLE_MIN_VERSION", libs.versions.gradle.version.min.map { "\"$it\"" })
   buildConfigField("String", "GRADLE_MAX_VERSION", libs.versions.gradle.version.max.map { "\"$it\"" })
+  // The kotlin-metadata-jvm version supplied to classloader-isolated workers (see issue 1671). Not bundled in the jar.
+  buildConfigField("String", "KOTLIN_METADATA_VERSION", libs.versions.kotlinMetadata.map { "\"$it\"" })
 }
 
 val main = sourceSets["main"]
@@ -133,9 +135,11 @@ dependencies {
   implementation(libs.moshi.kotlin)
   implementation(libs.moshix.sealed.reflect)
   implementation(libs.okio)
-  implementation(libs.kotlin.metadata.jvm) {
+
+  compileOnly(libs.kotlin.metadata.jvm) {
     // Trying to get support for analyzing K2.2 projects without bumping our stdlib
     exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
+    because("Will be provided at runtime only to the worker action classpath, so there is no upgrade of Kotlin on the plugin classpath")
   }
   implementation(libs.caffeine) {
     because("High performance, concurrent cache")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -213,7 +213,7 @@ val functionalTest = tasks.named("functionalTest", Test::class) {
   jvmArgs("-XX:+HeapDumpOnOutOfMemoryError", "-XX:MaxMetaspaceSize=1g")
 
   systemProperty("com.autonomousapps.quick", "${quickTest()}")
-  systemProperty("com.autonomousapps.test.versions.kotlin", libs.versions.kotlin.get())
+  systemProperty("com.autonomousapps.test.versions.kotlin", libs.versions.kotlinGradlePlugin.get())
   systemProperty("com.autonomousapps.test.versions.kotlin.later", libs.versions.kotlinForAndroidtests.get())
 
   beforeTest(closureOf<TestDescriptor> {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,9 +32,8 @@ kotlinRuntime = "2.1.21"
 kotlinForAndroidtests = "2.2.21"
 kotlinMetadata = "2.2.21"
 kotlinDokka = "2.2.0"
-# Cannot be called kotlin-editor as it causes `libs.versions.kotlin.get()` to fail
-kotlineditor-core = "0.24"
-kotlineditor-relocated = "0.24.0"
+kotlin-editor-core = "0.24"
+kotlin-editor-relocated = "0.24.0"
 # 0.36.0 requires JDK 17
 mavenPublish = "0.35.0"
 metalava = "1.0.0-alpha14"
@@ -69,9 +68,9 @@ junit-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 junit-params = { module = "org.junit.jupiter:junit-jupiter-params" }
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlinGradlePlugin" }
 kotlinDokkaGradlePlugin = { module = "org.jetbrains.dokka-javadoc:org.jetbrains.dokka-javadoc.gradle.plugin", version.ref = "kotlinDokka" }
-kotlin-editor-core = { module = "app.cash.kotlin-editor:core", version.ref = "kotlineditor-core" }
-kotlin-editor-grammar = { module = "app.cash.kotlin-editor:grammar", version.ref = "kotlineditor-core" }
-kotlin-editor-relocated = { module = "com.autonomousapps:kotlin-editor-relocated", version.ref = "kotlineditor-relocated" }
+kotlin-editor-core = { module = "app.cash.kotlin-editor:core", version.ref = "kotlin-editor-core" }
+kotlin-editor-grammar = { module = "app.cash.kotlin-editor:grammar", version.ref = "kotlin-editor-core" }
+kotlin-editor-relocated = { module = "com.autonomousapps:kotlin-editor-relocated", version.ref = "kotlin-editor-relocated" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinGradlePlugin" }
 kotlin-multiplatform-gradle = { module = "org.jetbrains.kotlin.multiplatform:org.jetbrains.kotlin.multiplatform.gradle.plugin", version.ref = "kotlinGradlePlugin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlinRuntime" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,11 +22,13 @@ javaTarget = "11"
 jdkVersion = "17"
 jspecify = "1.0.0"
 junit = "5.14.1"
-# IMPORTANT: keep this version in sync with build-logic/build.gradle.kts
-# See https://docs.gradle.org/9.4.1/userguide/compatibility.html.
-# Gradle 9.x uses Kotlin language version 2.2
-kotlinLanguageVersion = "2.2"
-kotlin = "2.2.21"
+kotlinGradlePlugin = "2.2.21"
+# Constraint: while Gradle 8.x is supported, every Kotlin artifact on DAGP's plugin classpath must have
+# binary-metadata version <= 2.1.x or Kotlin DSL script compilation breaks. Caps kotlinLanguageVersion (DAGP's classes)
+# and kotlinRuntime (bundled kotlin-stdlib*/kotlin-reflect). kotlinGradlePlugin (compiler/KGP) and kotlinMetadata
+# (isolated workers only) are exempt.
+kotlinLanguageVersion = "2.1"
+kotlinRuntime = "2.1.21"
 kotlinForAndroidtests = "2.2.21"
 kotlinMetadata = "2.2.21"
 kotlinDokka = "2.2.0"
@@ -39,7 +41,8 @@ metalava = "1.0.0-alpha14"
 moshi = "1.15.2"
 moshix = "0.30.0"
 #moshix = "0.31.0"
-okio = "3.16.4"
+# Keep on a release built with Kotlin <= 2.1 (3.15.0 is the latest; 3.16+ breaks Gradle 8.x). See kotlin* note above.
+okio = "3.15.0"
 shadow = "8.3.10"
 spock = "2.3-groovy-4.0"
 truth = "1.4.5"
@@ -64,16 +67,16 @@ junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 junit-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
 junit-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 junit-params = { module = "org.junit.jupiter:junit-jupiter-params" }
-kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
+kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlinGradlePlugin" }
 kotlinDokkaGradlePlugin = { module = "org.jetbrains.dokka-javadoc:org.jetbrains.dokka-javadoc.gradle.plugin", version.ref = "kotlinDokka" }
 kotlin-editor-core = { module = "app.cash.kotlin-editor:core", version.ref = "kotlineditor-core" }
 kotlin-editor-grammar = { module = "app.cash.kotlin-editor:grammar", version.ref = "kotlineditor-core" }
 kotlin-editor-relocated = { module = "com.autonomousapps:kotlin-editor-relocated", version.ref = "kotlineditor-relocated" }
-kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-kotlin-multiplatform-gradle = { module = "org.jetbrains.kotlin.multiplatform:org.jetbrains.kotlin.multiplatform.gradle.plugin", version.ref = "kotlin" }
-kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
-kotlin-stdlib-core = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
-kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
+kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinGradlePlugin" }
+kotlin-multiplatform-gradle = { module = "org.jetbrains.kotlin.multiplatform:org.jetbrains.kotlin.multiplatform.gradle.plugin", version.ref = "kotlinGradlePlugin" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlinRuntime" }
+kotlin-stdlib-core = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlinRuntime" }
+kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlinRuntime" }
 kotlin-metadata-jvm = { module = "org.jetbrains.kotlin:kotlin-metadata-jvm", version.ref = "kotlinMetadata" }
 mavenPublishPlugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenPublish" }
 metalava = { module = "com.android.tools.metalava:metalava", version.ref = "metalava" }
@@ -94,6 +97,6 @@ buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig
 dependencyAnalysis = { id = "com.autonomousapps.dependency-analysis", version.ref = "dagp" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "kotlinDokka" }
 gradlePublishPlugin = { id = "com.gradle.plugin-publish", version.ref = "gradle-publish-plugin" }
-kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlinGradlePlugin" }
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
 testkit = { id = "com.autonomousapps.testkit", version.ref = "gradleTestKitPlugin" }

--- a/shadowed/kotlin-editor-relocated/build.gradle.kts
+++ b/shadowed/kotlin-editor-relocated/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
   id("build-logic.lib.java")
 }
 
-version = "${libs.versions.kotlineditor.core.get()}.0"
+version = "${libs.versions.kotlin.editor.core.get()}.0"
 
 dagp {
   version(version)

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/InMemoryCacheSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/InMemoryCacheSpec.groovy
@@ -15,7 +15,8 @@ class InMemoryCacheSpec extends AbstractJvmSpec {
     gradleProject = project.gradleProject
 
     when:
-    def result = build(gradleVersion, gradleProject.rootDir, ':buildHealth', ':second-build:buildHealth')
+    // '--no-build-cache': to make sure doLast always runs, printing the service identity.
+    def result = build(gradleVersion, gradleProject.rootDir, '--no-build-cache', ':buildHealth', ':second-build:buildHealth')
 
     then:
     def serviceObjects = parseServiceObjects(result)
@@ -35,7 +36,8 @@ class InMemoryCacheSpec extends AbstractJvmSpec {
     gradleProject = project.gradleProject
 
     when:
-    def result = build(gradleVersion, gradleProject.rootDir, ':buildHealth', ':second-build:buildHealth')
+    // '--no-build-cache': to make sure doLast always runs, printing the service identity.
+    def result = build(gradleVersion, gradleProject.rootDir, '--no-build-cache', ':buildHealth', ':second-build:buildHealth')
 
     then:
     def serviceObjects = parseServiceObjects(result)

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/KotlinDslMetadataVersionSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/KotlinDslMetadataVersionSpec.groovy
@@ -1,0 +1,31 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.jvm
+
+import com.autonomousapps.jvm.projects.KotlinDslMetadataVersionProject
+import spock.lang.Issue
+
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertThat
+
+final class KotlinDslMetadataVersionSpec extends AbstractJvmSpec {
+
+  @Issue('https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1671')
+  def "applies on Gradle 8.x with Kotlin DSL and the metadata version check enabled (#gradleVersion)"() {
+    given:
+    def project = new KotlinDslMetadataVersionProject()
+    gradleProject = project.gradleProject
+
+    when: 'the Kotlin DSL scripts compile against the plugin classpath with the metadata check enabled, and buildHealth runs'
+    // Before the fix, this failed during script compilation on Gradle 8.x with:
+    //   "Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 2.2.0,
+    //    expected version is 2.0.0."
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then: 'the build succeeds and there is no advice'
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/KotlinDslMetadataVersionProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/KotlinDslMetadataVersionProject.groovy
@@ -1,0 +1,98 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.kit.gradle.Dependency
+import com.autonomousapps.kit.gradle.GradleProperties
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.actualProjectAdvice
+import static com.autonomousapps.AdviceHelper.emptyProjectAdviceFor
+
+/**
+ * Regression project for <a href="https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1671">
+ * issue 1671</a>: applying DAGP on Gradle 8.x while compiling <strong>Kotlin DSL</strong> build scripts with the Kotlin
+ * metadata version check <em>enabled</em> ({@code org.gradle.kotlin.dsl.skipMetadataVersionCheck=false}) used to fail
+ * script compilation with:
+ *
+ * <pre>
+ *   Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 2.2.0, expected
+ *   version is 2.0.0.
+ * </pre>
+ *
+ * because DAGP shipped Kotlin 2.2 metadata on its plugin classpath. This project uses Kotlin DSL build scripts (so the
+ * Kotlin DSL compiler scans the plugin classpath) and enables the check, and exercises the Kotlin-metadata-reading
+ * tasks ({@code FindKotlinMagic*}, {@code AbiAnalysis*}, {@code explodeJar*}) so the classloader-isolated workers that
+ * now carry {@code kotlin-metadata-jvm} are also covered.
+ */
+final class KotlinDslMetadataVersionProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  KotlinDslMetadataVersionProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newGradleProjectBuilder(GradleProject.DslKind.KOTLIN)
+      .withRootProject { r ->
+        // The whole point of the regression: opt IN to the metadata version check (default is to skip it), which is
+        // what trips DAGP's incompatible metadata on Gradle 8.x.
+        r.gradleProperties += GradleProperties.of('org.gradle.kotlin.dsl.skipMetadataVersionCheck=false')
+      }
+      .withSubproject('producer') { s ->
+        s.withBuildScript { bs ->
+          bs.plugins = kotlin
+        }
+        s.sources = [
+          new Source(
+            SourceType.KOTLIN, 'Producer', 'com/example/producer',
+            """\
+            package com.example.producer
+
+            // Public ABI -> exercises AbiAnalysisTask's metadata reader.
+            class Producer {
+              fun greeting(): String = "hello"
+            }
+
+            // Inline member -> exercises FindKotlinMagicTask's metadata reader.
+            inline fun greet(): String = Producer().greeting()""".stripIndent()
+          )
+        ]
+      }
+      .withSubproject('consumer') { s ->
+        s.withBuildScript { bs ->
+          bs.plugins = kotlin
+          bs.dependencies = [
+            Dependency.project('implementation', ':producer')
+          ]
+        }
+        s.sources = [
+          new Source(
+            SourceType.KOTLIN, 'Consumer', 'com/example/consumer',
+            """\
+            package com.example.consumer
+
+            import com.example.producer.greet
+
+            fun main() {
+              println(greet())
+            }""".stripIndent()
+          )
+        ]
+      }
+      .write()
+  }
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  final Set<ProjectAdvice> expectedBuildHealth = emptyProjectAdviceFor(
+    ':producer', ':consumer'
+  )
+}

--- a/src/main/kotlin/com/autonomousapps/internal/GradleVersions.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/GradleVersions.kt
@@ -20,6 +20,8 @@ internal object GradleVersions {
   private val gradle811: GradleVersion = GradleVersion.version("8.11.1")
   private val gradle900: GradleVersion = GradleVersion.version("9.0.0")
   private val gradle910: GradleVersion = GradleVersion.version("9.1.0")
+  private val gradle940: GradleVersion = GradleVersion.version("9.4.0")
+  private val gradle970: GradleVersion = GradleVersion.version("9.7.0-rc-1")
 
   val isAtLeastMinimum: Boolean = current >= minGradleVersion
 
@@ -28,4 +30,6 @@ internal object GradleVersions {
 
   val isAtLeastGradle900: Boolean = current >= gradle900
   val isAtLeastGradle910: Boolean = current >= gradle910
+  val isAtLeastGradle940: Boolean = current >= gradle940
+  val isAtLeastGradle970: Boolean = current >= gradle970
 }

--- a/src/main/kotlin/com/autonomousapps/internal/JarExploder.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/JarExploder.kt
@@ -11,17 +11,19 @@ import com.autonomousapps.model.internal.PhysicalArtifact.Mode
 import com.autonomousapps.model.internal.intermediates.producer.AndroidLinterDependency
 import com.autonomousapps.model.internal.intermediates.ExplodingJar
 import com.autonomousapps.model.internal.intermediates.producer.ExplodedJar
-import com.autonomousapps.services.InMemoryCache
 import com.autonomousapps.tasks.ExplodeJarTask
 import java.util.zip.ZipFile
 
 internal class JarExploder(
   private val artifacts: List<PhysicalArtifact>,
   private val androidLinters: Set<AndroidLinterDependency>,
-  private val inMemoryCache: InMemoryCache
+  private val seedCache: Map<String, ExplodedJar>,
 ) {
 
   private val logger = getLogger<ExplodeJarTask>()
+
+  /** [ExplodedJar]s computed during this run (cache misses), keyed by artifact path, to merge back into the cache. */
+  val newEntries: MutableMap<String, ExplodedJar> = LinkedHashMap()
 
   fun explodedJars(): Set<ExplodedJar> {
     return artifacts.asSequence()
@@ -34,16 +36,19 @@ internal class JarExploder(
 
   private fun Sequence<PhysicalArtifact>.toExplodedJars(): Set<ExplodedJar> =
     map { artifact ->
-      val explodedJar = if (artifact.isJar()) {
-        explode(artifact, Mode.ZIP)
-      } else {
-        explode(artifact, Mode.CLASSES)
-      }
+      val key = artifact.file.absolutePath
+      seedCache[key] ?: run {
+        val explodingJar = if (artifact.isJar()) {
+          explode(artifact, Mode.ZIP)
+        } else {
+          explode(artifact, Mode.CLASSES)
+        }
 
-      ExplodedJar(
-        artifact = artifact,
-        exploding = explodedJar
-      )
+        ExplodedJar(
+          artifact = artifact,
+          exploding = explodingJar
+        ).also { newEntries[key] = it }
+      }
     }.toSortedSet()
 
   /**
@@ -55,9 +60,6 @@ internal class JarExploder(
    * get jars, but now we get class files).
    */
   private fun explode(artifact: PhysicalArtifact, mode: Mode): ExplodingJar {
-    val entry = findInCache(artifact)
-    if (entry != null) return entry
-
     val ktFiles: Set<KtFile>
 
     val visitors = when (mode) {
@@ -96,15 +98,7 @@ internal class JarExploder(
       analyzedClasses = analyzedClasses,
       ktFiles = ktFiles,
       androidLintRegistry = findAndroidLinter(artifact)
-    ).also { putInCache(artifact, it) }
-  }
-
-  private fun findInCache(artifact: PhysicalArtifact): ExplodingJar? {
-    return inMemoryCache.explodedJar(artifact.file.absolutePath)
-  }
-
-  private fun putInCache(artifact: PhysicalArtifact, explodingJar: ExplodingJar) {
-    inMemoryCache.explodedJars(artifact.file.absolutePath, explodingJar)
+    )
   }
 
   private fun findAndroidLinter(physicalArtifact: PhysicalArtifact): String? {

--- a/src/main/kotlin/com/autonomousapps/internal/JarExploder.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/JarExploder.kt
@@ -37,7 +37,11 @@ internal class JarExploder(
   private fun Sequence<PhysicalArtifact>.toExplodedJars(): Set<ExplodedJar> =
     map { artifact ->
       val key = artifact.file.absolutePath
-      seedCache[key] ?: run {
+      // A cache hit reuses the file-content-derived analysis, but the cached ExplodedJar also carries the coordinates
+      // of whichever artifact first populated this path in the build-scoped cache. Rebind to THIS artifact's identity;
+      // otherwise a file shared by two dependencies (e.g. a classifier/capability variant resolved by multiple
+      // projects) leaks the other's coordinates and produces wrong advice.
+      seedCache[key]?.copy(coordinates = artifact.coordinates) ?: run {
         val explodingJar = if (artifact.isJar()) {
           explode(artifact, Mode.ZIP)
         } else {

--- a/src/main/kotlin/com/autonomousapps/internal/KotlinMetadataClasspath.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/KotlinMetadataClasspath.kt
@@ -2,9 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.internal
 
+import com.autonomousapps.artifacts.dependencyScopeConfiguration
+import com.autonomousapps.artifacts.resolvableConfiguration
+import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ExternalModuleDependency
-import org.gradle.api.file.FileCollection
 
 /**
  * The classpath supplied to DAGP's classloader-isolated workers that read Kotlin metadata (`FindKotlinMagicTask`,
@@ -23,15 +26,14 @@ internal object KotlinMetadataClasspath {
 
   private const val CONFIGURATION_NAME = "dependencyAnalysisKotlinMetadata"
 
-  /** Returns the (idempotently created) resolvable configuration as a [FileCollection] suitable for a task input. */
-  fun of(project: Project): FileCollection {
-    project.configurations.findByName(CONFIGURATION_NAME)?.let { return it }
-
-    return project.configurations.create(CONFIGURATION_NAME) { c ->
-      c.isCanBeResolved = true
-      c.isCanBeConsumed = false
-      c.description = "kotlin-metadata-jvm, supplied to classloader-isolated DAGP workers."
-      c.defaultDependencies { deps ->
+  /**
+   * Registers the dependency-scope and resolvable configurations for this project. Must be called once at plugin-apply
+   * time, before any task that calls [of] is registered.
+   */
+  fun register(project: Project) {
+    val scope = project.dependencyScopeConfiguration(CONFIGURATION_NAME)
+    scope.configure { configuration ->
+      configuration.defaultDependencies { deps ->
         val dep = project.dependencies.create(
           "org.jetbrains.kotlin:kotlin-metadata-jvm:${BuildConfig.KOTLIN_METADATA_VERSION}"
         ) as ExternalModuleDependency
@@ -40,5 +42,13 @@ internal object KotlinMetadataClasspath {
         deps.add(dep)
       }
     }
+    project.resolvableConfiguration("${CONFIGURATION_NAME}Classpath", scope) { c ->
+      c.description = "kotlin-metadata-jvm, supplied to classloader-isolated DAGP workers."
+    }
+  }
+
+  /** Returns the resolvable configuration as a lazy provider suitable for a task input. */
+  fun of(project: Project): NamedDomainObjectProvider<out Configuration> {
+    return project.configurations.named("${CONFIGURATION_NAME}Classpath")
   }
 }

--- a/src/main/kotlin/com/autonomousapps/internal/KotlinMetadataClasspath.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/KotlinMetadataClasspath.kt
@@ -24,31 +24,43 @@ import org.gradle.api.artifacts.ExternalModuleDependency
  */
 internal object KotlinMetadataClasspath {
 
-  private const val CONFIGURATION_NAME = "dependencyAnalysisKotlinMetadata"
+  private const val DEPENDENCY_SCOPE = "dependencyAnalysisKotlinMetadata"
+  private const val RESOLVABLE = "${DEPENDENCY_SCOPE}Classpath"
 
   /**
    * Registers the dependency-scope and resolvable configurations for this project. Must be called once at plugin-apply
    * time, before any task that calls [of] is registered.
    */
   fun register(project: Project) {
-    val scope = project.dependencyScopeConfiguration(CONFIGURATION_NAME)
+    // https://docs.gradle.org/9.7.0-rc-1/userguide/compatibility.html
+    val kotlinMetadataVersion = if (GradleVersions.isAtLeastGradle970) {
+      "2.4.0"
+    } else if (GradleVersions.isAtLeastGradle940) {
+      "2.3.0"
+    } else if (GradleVersions.isAtLeastGradle811) {
+      BuildConfig.KOTLIN_METADATA_VERSION
+    } else {
+      error("Unsupported Gradle version: '${GradleVersions.current}'. Expected at least '${GradleVersions.minGradleVersion}'.")
+    }
+
+    val scope = project.dependencyScopeConfiguration(DEPENDENCY_SCOPE)
     scope.configure { configuration ->
       configuration.defaultDependencies { deps ->
         val dep = project.dependencies.create(
-          "org.jetbrains.kotlin:kotlin-metadata-jvm:${BuildConfig.KOTLIN_METADATA_VERSION}"
+          "org.jetbrains.kotlin:kotlin-metadata-jvm:$kotlinMetadataVersion"
         ) as ExternalModuleDependency
         // The stdlib is inherited from DAGP's own (capped) classpath; don't drag a newer one onto the worker classpath.
         dep.exclude(mapOf("group" to "org.jetbrains.kotlin", "module" to "kotlin-stdlib"))
         deps.add(dep)
       }
     }
-    project.resolvableConfiguration("${CONFIGURATION_NAME}Classpath", scope) { c ->
+    project.resolvableConfiguration(RESOLVABLE, scope) { c ->
       c.description = "kotlin-metadata-jvm, supplied to classloader-isolated DAGP workers."
     }
   }
 
   /** Returns the resolvable configuration as a lazy provider suitable for a task input. */
   fun of(project: Project): NamedDomainObjectProvider<out Configuration> {
-    return project.configurations.named("${CONFIGURATION_NAME}Classpath")
+    return project.configurations.named(RESOLVABLE)
   }
 }

--- a/src/main/kotlin/com/autonomousapps/internal/KotlinMetadataClasspath.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/KotlinMetadataClasspath.kt
@@ -1,0 +1,44 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.internal
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.ExternalModuleDependency
+import org.gradle.api.file.FileCollection
+
+/**
+ * The classpath supplied to DAGP's classloader-isolated workers that read Kotlin metadata (`FindKotlinMagicTask`,
+ * `AbiAnalysisTask`, `ExplodeJarTask`).
+ *
+ * `kotlin-metadata-jvm` is deliberately NOT bundled into DAGP's shaded jar: its classes carry a newer Kotlin
+ * binary-metadata version (2.2.0+) that would break Kotlin DSL script compilation on the oldest supported Gradle (see
+ * [issue 1671](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1671)). Instead it is resolved
+ * from the consuming build's repositories and added to a `classLoaderIsolation` worker classpath at execution time. The
+ * isolated worker classloader already inherits DAGP's own classpath (work-action classes, relocated ASM, the bundled
+ * `kotlin-stdlib`), so only `kotlin-metadata-jvm` itself needs to be added here.
+ *
+ * NOTE: consuming builds with locked-down repositories must make `org.jetbrains.kotlin:kotlin-metadata-jvm` resolvable.
+ */
+internal object KotlinMetadataClasspath {
+
+  private const val CONFIGURATION_NAME = "dependencyAnalysisKotlinMetadata"
+
+  /** Returns the (idempotently created) resolvable configuration as a [FileCollection] suitable for a task input. */
+  fun of(project: Project): FileCollection {
+    project.configurations.findByName(CONFIGURATION_NAME)?.let { return it }
+
+    return project.configurations.create(CONFIGURATION_NAME) { c ->
+      c.isCanBeResolved = true
+      c.isCanBeConsumed = false
+      c.description = "kotlin-metadata-jvm, supplied to classloader-isolated DAGP workers."
+      c.defaultDependencies { deps ->
+        val dep = project.dependencies.create(
+          "org.jetbrains.kotlin:kotlin-metadata-jvm:${BuildConfig.KOTLIN_METADATA_VERSION}"
+        ) as ExternalModuleDependency
+        // The stdlib is inherited from DAGP's own (capped) classpath; don't drag a newer one onto the worker classpath.
+        dep.exclude(mapOf("group" to "org.jetbrains.kotlin", "module" to "kotlin-stdlib"))
+        deps.add(dep)
+      }
+    }
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidProjectAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidProjectAnalyzer.kt
@@ -5,6 +5,7 @@
 package com.autonomousapps.internal.analyzer
 
 import com.autonomousapps.internal.ArtifactAttributes
+import com.autonomousapps.internal.KotlinMetadataClasspath
 import com.autonomousapps.internal.OutputPaths
 import com.autonomousapps.internal.android.AndroidGradlePluginFactory
 import com.autonomousapps.internal.artifactsFor
@@ -196,6 +197,7 @@ internal class AndroidLibAnalyzer(
 
     return project.tasks.register("abiAnalysis$taskNameSuffix", AbiAnalysisTask::class.java) {
       it.exclusions.set(abiExclusions)
+      it.kotlinMetadataClasspath.setFrom(KotlinMetadataClasspath.of(project))
       it.output.set(outputPaths.abiAnalysisPath)
       it.abiDump.set(outputPaths.abiDumpPath)
     }.also { provider ->

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/DependencyAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/DependencyAnalyzer.kt
@@ -5,6 +5,7 @@
 package com.autonomousapps.internal.analyzer
 
 import com.autonomousapps.AbstractExtension
+import com.autonomousapps.internal.KotlinMetadataClasspath
 import com.autonomousapps.internal.OutputPaths
 import com.autonomousapps.internal.artifactsFor
 import com.autonomousapps.internal.opaqueComponentArtifacts
@@ -409,6 +410,7 @@ internal abstract class AbstractDependencyAnalyzer(
       )
       t.physicalArtifacts.set(artifactsReport.flatMap { it.output })
       androidLintTask?.let { t2 -> t.androidLinters.set(t2.flatMap { it.output }) }
+      t.kotlinMetadataClasspath.setFrom(KotlinMetadataClasspath.of(project))
 
       t.output.set(outputPaths.explodedJarsPath)
     }
@@ -423,6 +425,7 @@ internal abstract class AbstractDependencyAnalyzer(
           .artifactFiles
       )
       t.artifacts.set(artifactsReport.flatMap { it.output })
+      t.kotlinMetadataClasspath.setFrom(KotlinMetadataClasspath.of(project))
       t.outputInlineMembers.set(outputPaths.inlineUsagePath)
       t.outputTypealiases.set(outputPaths.typealiasUsagePath)
       t.outputErrors.set(outputPaths.inlineUsageErrorsPath)

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmProjectAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmProjectAnalyzer.kt
@@ -5,6 +5,7 @@
 package com.autonomousapps.internal.analyzer
 
 import com.autonomousapps.internal.ArtifactAttributes
+import com.autonomousapps.internal.KotlinMetadataClasspath
 import com.autonomousapps.internal.OutputPaths
 import com.autonomousapps.internal.artifactsFor
 import com.autonomousapps.internal.utils.capitalizeSafely
@@ -65,6 +66,7 @@ internal abstract class JvmAnalyzer(
     return project.tasks.register("abiAnalysis$taskNameSuffix", AbiAnalysisTask::class.java) {
       it.classes.setFrom(sourceSet.classesDirs)
       it.exclusions.set(abiExclusions)
+      it.kotlinMetadataClasspath.setFrom(KotlinMetadataClasspath.of(project))
       it.output.set(outputPaths.abiAnalysisPath)
       it.abiDump.set(outputPaths.abiDumpPath)
     }

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/KmpProjectAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/KmpProjectAnalyzer.kt
@@ -3,6 +3,7 @@
 package com.autonomousapps.internal.analyzer
 
 import com.autonomousapps.internal.ArtifactAttributes
+import com.autonomousapps.internal.KotlinMetadataClasspath
 import com.autonomousapps.internal.OutputPaths
 import com.autonomousapps.internal.artifactsFor
 import com.autonomousapps.internal.utils.capitalizeSafely
@@ -62,6 +63,7 @@ internal class KmpProjectAnalyzer(
     return project.tasks.register("abiAnalysis$taskNameSuffix", AbiAnalysisTask::class.java) {
       it.classes.setFrom(sourceSet.classesDirs)
       it.exclusions.set(abiExclusions)
+      it.kotlinMetadataClasspath.setFrom(KotlinMetadataClasspath.of(project))
       it.output.set(outputPaths.abiAnalysisPath)
       it.abiDump.set(outputPaths.abiDumpPath)
     }

--- a/src/main/kotlin/com/autonomousapps/internal/transform/AbstractTransform.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/transform/AbstractTransform.kt
@@ -76,13 +76,20 @@ internal abstract class AbstractTransform(
 
   /** Use coordinates/variant of the original declaration when reporting remove/change as it is more precise. */
   protected fun declarationCoordinates(decl: Declaration): Coordinates {
+    // NB: written without `when` guards so it compiles at language version 2.1 (Gradle 8.x compat; see issue 1671).
     return when (coordinates) {
-      is IncludedBuildCoordinates if decl.identifier.startsWith(":") -> coordinates.resolvedProject
+      is IncludedBuildCoordinates -> {
+        if (decl.identifier.startsWith(":")) coordinates.resolvedProject else coordinates
+      }
 
       // This handles the case where we have an unused dependency because it's been excluded via
       // configurations.<foo>.exclude(group = "group", module = "module")
-      is FlatCoordinates if decl.version != null -> {
-        ModuleCoordinates(coordinates.identifier, decl.version, decl.gradleVariantIdentification)
+      is FlatCoordinates -> {
+        if (decl.version != null) {
+          ModuleCoordinates(coordinates.identifier, decl.version, decl.gradleVariantIdentification)
+        } else {
+          coordinates
+        }
       }
 
       else -> coordinates

--- a/src/main/kotlin/com/autonomousapps/internal/utils/utils.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/utils.kt
@@ -102,6 +102,25 @@ internal inline fun <reified K, reified V> File.fromJsonMapSet(
   return bufferRead(compressed).fromJsonMapSet()
 }
 
+/** Buffers reads of the RegularFileProperty from disk to the set. */
+internal inline fun <reified K, reified V> RegularFileProperty.fromJsonMap(
+  compressed: Boolean = false,
+): Map<K, V> = get().fromJsonMap(compressed)
+
+/** Buffers reads of the RegularFile from disk to the set. */
+internal inline fun <reified K, reified V> RegularFile.fromJsonMap(
+  compressed: Boolean = false,
+): Map<K, V> = asFile.fromJsonMap(compressed)
+
+/** Buffers reads of the File from disk to the set. */
+internal inline fun <reified K, reified V> File.fromJsonMap(
+  compressed: Boolean = false,
+): Map<K, V> {
+  return bufferRead(compressed).use { reader ->
+    getJsonMapAdapter<K, V>().fromJson(reader)!!
+  }
+}
+
 /** Buffer reads of the RegularFileProperty from disk to the set. */
 internal inline fun <reified T> RegularFileProperty.fromJson(
   compressed: Boolean = false,

--- a/src/main/kotlin/com/autonomousapps/services/InMemoryCache.kt
+++ b/src/main/kotlin/com/autonomousapps/services/InMemoryCache.kt
@@ -6,7 +6,7 @@ package com.autonomousapps.services
 
 import com.autonomousapps.Flags.cacheSize
 import com.autonomousapps.model.internal.intermediates.producer.AnnotationProcessorDependency
-import com.autonomousapps.model.internal.intermediates.ExplodingJar
+import com.autonomousapps.model.internal.intermediates.producer.ExplodedJar
 import com.autonomousapps.tasks.KotlinCapabilities
 import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
@@ -31,13 +31,13 @@ public abstract class InMemoryCache : BuildService<InMemoryCache.Params> {
     return builder.build()
   }
 
-  private val explodingJars: Cache<String, ExplodingJar> = newCache()
+  private val explodedJars: Cache<String, ExplodedJar> = newCache()
   private val kotlinCapabilities: Cache<String, KotlinCapabilities> = newCache()
   private val procs: Cache<String, AnnotationProcessorDependency> = newCache()
 
-  internal fun explodedJar(name: String): ExplodingJar? = explodingJars.asMap()[name]
-  internal fun explodedJars(name: String, explodingJar: ExplodingJar) {
-    explodingJars.asMap().putIfAbsent(name, explodingJar)
+  internal fun explodedJar(name: String): ExplodedJar? = explodedJars.asMap()[name]
+  internal fun explodedJars(name: String, explodedJar: ExplodedJar) {
+    explodedJars.asMap().putIfAbsent(name, explodedJar)
   }
 
   internal fun kotlinCapabilities(name: String): KotlinCapabilities? = kotlinCapabilities.asMap()[name]

--- a/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
@@ -14,6 +14,7 @@ import com.autonomousapps.Flags.projectPathRegex
 import com.autonomousapps.Flags.shouldAnalyzeTests
 import com.autonomousapps.artifacts.Publisher.Companion.interProjectPublisher
 import com.autonomousapps.internal.AbiExclusions
+import com.autonomousapps.internal.KotlinMetadataClasspath
 import com.autonomousapps.internal.NoVariantOutputPaths
 import com.autonomousapps.internal.UsagesExclusions
 import com.autonomousapps.internal.advice.DslKind
@@ -159,6 +160,8 @@ internal class ProjectPlugin(private val project: Project) {
       logger.info("Skipping dependency analysis of project '$path'. Does not match regex '$projectPathRegex'.")
       return
     }
+
+    KotlinMetadataClasspath.register(this)
 
     // Hydrate dependencies map with version catalog entries
     dslService.get().withVersionCatalogs(this)

--- a/src/main/kotlin/com/autonomousapps/tasks/AbiAnalysisTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/AbiAnalysisTask.kt
@@ -35,6 +35,10 @@ public abstract class AbiAnalysisTask @Inject constructor(
   @get:InputFiles
   public abstract val classes: ConfigurableFileCollection
 
+  /** `kotlin-metadata-jvm`, added to the isolated worker classpath. */
+  @get:Classpath
+  public abstract val kotlinMetadataClasspath: ConfigurableFileCollection
+
   @get:Optional
   @get:Input
   public abstract val exclusions: Property<String>
@@ -47,7 +51,10 @@ public abstract class AbiAnalysisTask @Inject constructor(
 
   @TaskAction
   public fun action() {
-    workerExecutor.noIsolation().submit(AbiAnalysisWorkAction::class.java) {
+    workerExecutor.classLoaderIsolation {
+      // kotlin-metadata-jvm is not on the main plugin classpath (issue 1671); add it for the isolated worker only.
+      it.classpath.from(kotlinMetadataClasspath)
+    }.submit(AbiAnalysisWorkAction::class.java) {
       // JVM projects
       it.classFiles.setFrom(classes.asFileTree.filterToClassFiles().files)
       // Android projects

--- a/src/main/kotlin/com/autonomousapps/tasks/AggregateTypeUsageTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/AggregateTypeUsageTask.kt
@@ -45,7 +45,8 @@ public abstract class AggregateTypeUsageTask @Inject constructor(
     public val output: RegularFileProperty
   }
 
-  public interface Action : WorkAction<Parameters> {
+  // Must be an abstract class under kotlinLanguageVersion 2.1 (jvm-default=disable) as required by Gradle 8.11.1 ("Cannot have abstract method execute()").
+  public abstract class Action : WorkAction<Parameters> {
     override fun execute() {
       val output = parameters.output.getAndDelete()
 

--- a/src/main/kotlin/com/autonomousapps/tasks/ExplodeJarTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ExplodeJarTask.kt
@@ -111,6 +111,7 @@ public abstract class ExplodeJarTask @Inject constructor(
 
     override fun execute() {
       val output = parameters.output.getAndDelete()
+      val newCacheEntries = parameters.newCacheEntries.getAndDelete()
 
       val exploder = JarExploder(
         artifacts = parameters.physicalArtifacts.fromJsonList(),
@@ -120,7 +121,7 @@ public abstract class ExplodeJarTask @Inject constructor(
       val explodedJars = exploder.explodedJars()
 
       output.bufferWriteJsonSet(explodedJars, compress = true)
-      parameters.newCacheEntries.getAndDelete().bufferWriteJsonMap(exploder.newEntries)
+      newCacheEntries.bufferWriteJsonMap(exploder.newEntries)
     }
   }
 }

--- a/src/main/kotlin/com/autonomousapps/tasks/ExplodeJarTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ExplodeJarTask.kt
@@ -42,6 +42,10 @@ public abstract class ExplodeJarTask @Inject constructor(
   @get:Classpath
   public abstract val compileClasspath: ConfigurableFileCollection
 
+  /** `kotlin-metadata-jvm`, added to the isolated worker classpath. */
+  @get:Classpath
+  public abstract val kotlinMetadataClasspath: ConfigurableFileCollection
+
   /** [`Set<PhysicalArtifact>`][com.autonomousapps.model.internal.PhysicalArtifact]. */
   @get:PathSensitive(PathSensitivity.RELATIVE)
   @get:InputFile
@@ -70,7 +74,10 @@ public abstract class ExplodeJarTask @Inject constructor(
     val seedFile = File(temporaryDir, "exploded-jars-cache-seed.json").apply { bufferWriteJsonMap(seed) }
     val newEntriesFile = File(temporaryDir, "exploded-jars-cache-new.json")
 
-    workerExecutor.noIsolation().submit(ExplodeJarWorkAction::class.java) {
+    workerExecutor.classLoaderIsolation {
+      // kotlin-metadata-jvm is not on the main plugin classpath (issue 1671); add it for the isolated worker only.
+      it.classpath.from(kotlinMetadataClasspath)
+    }.submit(ExplodeJarWorkAction::class.java) {
       it.physicalArtifacts.set(physicalArtifacts)
       it.androidLinters.set(androidLinters)
       it.output.set(output)

--- a/src/main/kotlin/com/autonomousapps/tasks/ExplodeJarTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ExplodeJarTask.kt
@@ -5,11 +5,15 @@
 package com.autonomousapps.tasks
 
 import com.autonomousapps.internal.JarExploder
+import com.autonomousapps.internal.utils.bufferWriteJsonMap
 import com.autonomousapps.internal.utils.bufferWriteJsonSet
 import com.autonomousapps.internal.utils.fromJsonList
+import com.autonomousapps.internal.utils.fromJsonMap
 import com.autonomousapps.internal.utils.fromNullableJsonSet
 import com.autonomousapps.internal.utils.getAndDelete
+import com.autonomousapps.model.internal.PhysicalArtifact
 import com.autonomousapps.model.internal.intermediates.producer.AndroidLinterDependency
+import com.autonomousapps.model.internal.intermediates.producer.ExplodedJar
 import com.autonomousapps.services.InMemoryCache
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
@@ -19,6 +23,7 @@ import org.gradle.api.tasks.*
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 import org.gradle.workers.WorkerExecutor
+import java.io.File
 import javax.inject.Inject
 
 @CacheableTask
@@ -53,22 +58,46 @@ public abstract class ExplodeJarTask @Inject constructor(
   public abstract val output: RegularFileProperty
 
   @TaskAction public fun action() {
+    // Pass the shared cache content to the work action, which requires serializable data only
+    val cache = inMemoryCache.get()
+    val seed = physicalArtifacts.fromJsonList<PhysicalArtifact>()
+      .mapNotNull { artifact ->
+        val key = artifact.file.absolutePath
+        cache.explodedJar(key)?.let { key to it }
+      }
+      .toMap()
+
+    val seedFile = File(temporaryDir, "exploded-jars-cache-seed.json").apply { bufferWriteJsonMap(seed) }
+    val newEntriesFile = File(temporaryDir, "exploded-jars-cache-new.json")
+
     workerExecutor.noIsolation().submit(ExplodeJarWorkAction::class.java) {
-      it.inMemoryCache.set(inMemoryCache)
       it.physicalArtifacts.set(physicalArtifacts)
       it.androidLinters.set(androidLinters)
       it.output.set(output)
+      it.cacheSeed.set(seedFile)
+      it.newCacheEntries.set(newEntriesFile)
+    }
+
+    // Block so we can merge the worker's results back into the shared cache.
+    workerExecutor.await()
+    newEntriesFile.fromJsonMap<String, ExplodedJar>().forEach { (key, explodedJar) ->
+      cache.explodedJars(key, explodedJar)
     }
   }
 
   public interface ExplodeJarParameters : WorkParameters {
-    public val inMemoryCache: Property<InMemoryCache>
     public val physicalArtifacts: RegularFileProperty
 
     /** This may be empty. */
     public val androidLinters: RegularFileProperty
 
     public val output: RegularFileProperty
+
+    /** [`Map<String, ExplodedJar>`][ExplodedJar] of already-cached results, keyed by artifact path. */
+    public val cacheSeed: RegularFileProperty
+
+    /** [`Map<String, ExplodedJar>`][ExplodedJar] of cache misses computed by this worker, for the task to merge back. */
+    public val newCacheEntries: RegularFileProperty
   }
 
   public abstract class ExplodeJarWorkAction : WorkAction<ExplodeJarParameters> {
@@ -76,13 +105,15 @@ public abstract class ExplodeJarTask @Inject constructor(
     override fun execute() {
       val output = parameters.output.getAndDelete()
 
-      val explodedJars = JarExploder(
+      val exploder = JarExploder(
         artifacts = parameters.physicalArtifacts.fromJsonList(),
         androidLinters = parameters.androidLinters.fromNullableJsonSet<AndroidLinterDependency>(),
-        inMemoryCache = parameters.inMemoryCache.get()
-      ).explodedJars()
+        seedCache = parameters.cacheSeed.fromJsonMap(),
+      )
+      val explodedJars = exploder.explodedJars()
 
       output.bufferWriteJsonSet(explodedJars, compress = true)
+      parameters.newCacheEntries.getAndDelete().bufferWriteJsonMap(exploder.newEntries)
     }
   }
 }

--- a/src/main/kotlin/com/autonomousapps/tasks/FindKotlinMagicTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindKotlinMagicTask.kt
@@ -45,6 +45,10 @@ public abstract class FindKotlinMagicTask @Inject constructor(
   @get:Classpath
   public abstract val compileClasspath: ConfigurableFileCollection
 
+  /** `kotlin-metadata-jvm`, added to the isolated worker classpath. */
+  @get:Classpath
+  public abstract val kotlinMetadataClasspath: ConfigurableFileCollection
+
   /** [PhysicalArtifact]s used to compile this project. */
   @get:PathSensitive(PathSensitivity.RELATIVE)
   @get:InputFile
@@ -81,7 +85,10 @@ public abstract class FindKotlinMagicTask @Inject constructor(
     val seedFile = File(temporaryDir, "kotlin-magic-cache-seed.json").apply { bufferWriteJsonMap(seed) }
     val newEntriesFile = File(temporaryDir, "kotlin-magic-cache-new.json")
 
-    workerExecutor.noIsolation().submit(Action::class.java) {
+    workerExecutor.classLoaderIsolation {
+      // kotlin-metadata-jvm is not on the main plugin classpath (issue 1671); add it for the isolated worker only.
+      it.classpath.from(kotlinMetadataClasspath)
+    }.submit(Action::class.java) {
       it.artifacts.set(artifacts)
       it.inlineUsageReport.set(outputInlineMembers)
       it.typealiasReport.set(outputTypealiases)

--- a/src/main/kotlin/com/autonomousapps/tasks/FindKotlinMagicTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindKotlinMagicTask.kt
@@ -125,6 +125,7 @@ public abstract class FindKotlinMagicTask @Inject constructor(
       val inlineUsageReportFile = parameters.inlineUsageReport.getAndDelete()
       val typealiasReportFile = parameters.typealiasReport.getAndDelete()
       val errorsReport = parameters.errorsReport.getAndDelete()
+      val newCacheEntries = parameters.newCacheEntries.getAndDelete()
 
       val finder = KotlinMagicFinder(
         seedCache = parameters.cacheSeed.fromJsonMap(),
@@ -137,7 +138,7 @@ public abstract class FindKotlinMagicTask @Inject constructor(
       inlineUsageReportFile.bufferWriteJsonSet(inlineMembers)
       typealiasReportFile.bufferWriteJsonSet(typealiases)
 
-      parameters.newCacheEntries.getAndDelete().bufferWriteJsonMap(finder.newEntries)
+      newCacheEntries.bufferWriteJsonMap(finder.newEntries)
 
       if (finder.didWriteErrors) {
         logger.warn("There were errors during inline member analysis. See ${errorsReport.toPath().toUri()}")

--- a/src/main/kotlin/com/autonomousapps/tasks/FindKotlinMagicTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindKotlinMagicTask.kt
@@ -69,12 +69,31 @@ public abstract class FindKotlinMagicTask @Inject constructor(
 
   @TaskAction
   public fun action() {
+    // Pass the shared cache content to the work action, which requires serializable data only
+    val cache = inMemoryCacheProvider.get()
+    val seed = artifacts.fromJsonList<PhysicalArtifact>()
+      .mapNotNull { artifact ->
+        val key = artifact.file.absolutePath
+        cache.kotlinCapabilities(key)?.let { key to it }
+      }
+      .toMap()
+
+    val seedFile = File(temporaryDir, "kotlin-magic-cache-seed.json").apply { bufferWriteJsonMap(seed) }
+    val newEntriesFile = File(temporaryDir, "kotlin-magic-cache-new.json")
+
     workerExecutor.noIsolation().submit(Action::class.java) {
       it.artifacts.set(artifacts)
       it.inlineUsageReport.set(outputInlineMembers)
       it.typealiasReport.set(outputTypealiases)
       it.errorsReport.set(outputErrors)
-      it.inMemoryCacheProvider.set(inMemoryCacheProvider)
+      it.cacheSeed.set(seedFile)
+      it.newCacheEntries.set(newEntriesFile)
+    }
+
+    // Block so we can merge the worker's results back into the shared cache.
+    workerExecutor.await()
+    newEntriesFile.fromJsonMap<String, KotlinCapabilities>().forEach { (key, capabilities) ->
+      cache.inlineMembers(key, capabilities)
     }
   }
 
@@ -83,7 +102,12 @@ public abstract class FindKotlinMagicTask @Inject constructor(
     public val inlineUsageReport: RegularFileProperty
     public val typealiasReport: RegularFileProperty
     public val errorsReport: RegularFileProperty
-    public val inMemoryCacheProvider: Property<InMemoryCache>
+
+    /** [`Map<String, KotlinCapabilities>`][KotlinCapabilities] of already-cached results, keyed by artifact path. */
+    public val cacheSeed: RegularFileProperty
+
+    /** [`Map<String, KotlinCapabilities>`][KotlinCapabilities] of cache misses, for the task to merge back. */
+    public val newCacheEntries: RegularFileProperty
   }
 
   public abstract class Action : WorkAction<Parameters> {
@@ -96,7 +120,7 @@ public abstract class FindKotlinMagicTask @Inject constructor(
       val errorsReport = parameters.errorsReport.getAndDelete()
 
       val finder = KotlinMagicFinder(
-        inMemoryCache = parameters.inMemoryCacheProvider.get(),
+        seedCache = parameters.cacheSeed.fromJsonMap(),
         artifacts = parameters.artifacts.fromJsonList<PhysicalArtifact>(),
         errorsReport = errorsReport,
       )
@@ -105,6 +129,8 @@ public abstract class FindKotlinMagicTask @Inject constructor(
 
       inlineUsageReportFile.bufferWriteJsonSet(inlineMembers)
       typealiasReportFile.bufferWriteJsonSet(typealiases)
+
+      parameters.newCacheEntries.getAndDelete().bufferWriteJsonMap(finder.newEntries)
 
       if (finder.didWriteErrors) {
         logger.warn("There were errors during inline member analysis. See ${errorsReport.toPath().toUri()}")
@@ -117,7 +143,7 @@ public abstract class FindKotlinMagicTask @Inject constructor(
 }
 
 internal class KotlinMagicFinder(
-  private val inMemoryCache: InMemoryCache,
+  private val seedCache: Map<String, KotlinCapabilities>,
   artifacts: List<PhysicalArtifact>,
   private val errorsReport: File,
 ) {
@@ -128,6 +154,9 @@ internal class KotlinMagicFinder(
   val inlineMembers: Set<InlineMemberDependency>
   val typealiases: Set<TypealiasDependency>
 
+  /** [KotlinCapabilities] computed during this run (cache misses), keyed by artifact path, to merge into the cache. */
+  val newEntries: MutableMap<String, KotlinCapabilities> = LinkedHashMap()
+
   init {
     val inlineMembersMut = mutableSetOf<InlineMemberDependency>()
     val typealiasesMut = mutableSetOf<TypealiasDependency>()
@@ -136,7 +165,9 @@ internal class KotlinMagicFinder(
       .filter {
         it.isJar() || it.containsClassFiles()
       }.map { artifact ->
-        artifact to findKotlinMagic(artifact, artifact.mode)
+        val key = artifact.file.absolutePath
+        val capabilities = seedCache[key] ?: findKotlinMagic(artifact, artifact.mode).also { newEntries[key] = it }
+        artifact to capabilities
       }.forEach { (artifact, capabilities) ->
         if (capabilities.inlineMembers.isNotEmpty()) {
           inlineMembersMut += InlineMemberDependency.newInstance(artifact.coordinates, capabilities.inlineMembers)
@@ -165,9 +196,6 @@ internal class KotlinMagicFinder(
    * TODO(tsr): docs for the TypeAliasCapability portion of this.
    */
   private fun findKotlinMagic(artifact: PhysicalArtifact, mode: Mode): KotlinCapabilities {
-    val cached = findInCache(artifact)
-    if (cached != null) return cached
-
     fun packageName(fileLike: String): String {
       return if (fileLike.contains('/')) {
         // entry is in a package
@@ -264,20 +292,7 @@ internal class KotlinMagicFinder(
       }
     }
 
-    val kotlinCapabilities = KotlinCapabilities(inlineMembers, typealiases)
-
-    // cache
-    putInCache(artifact, kotlinCapabilities)
-
-    return kotlinCapabilities
-  }
-
-  private fun findInCache(artifact: PhysicalArtifact): KotlinCapabilities? {
-    return inMemoryCache.kotlinCapabilities(artifact.file.absolutePath)
-  }
-
-  private fun putInCache(artifact: PhysicalArtifact, capabilities: KotlinCapabilities) {
-    inMemoryCache.inlineMembers(artifact.file.absolutePath, capabilities)
+    return KotlinCapabilities(inlineMembers, typealiases)
   }
 
   /** Returned set is either null or non-empty. */

--- a/src/test/kotlin/com/autonomousapps/internal/JarExploderTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/JarExploderTest.kt
@@ -7,9 +7,7 @@ import com.autonomousapps.internal.asm.Opcodes
 import com.autonomousapps.model.GradleVariantIdentification
 import com.autonomousapps.model.ModuleCoordinates
 import com.autonomousapps.model.internal.PhysicalArtifact
-import com.autonomousapps.services.InMemoryCache
 import com.google.common.truth.Truth.assertThat
-import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
@@ -45,7 +43,7 @@ internal class JarExploderTest {
     val exploder = JarExploder(
       artifacts = listOf(artifact),
       androidLinters = emptySet(),
-      inMemoryCache = newInMemoryCache(),
+      seedCache = emptyMap(),
     )
 
     // Must not throw — the future-versioned class is skipped rather than handed to ASM.
@@ -55,15 +53,6 @@ internal class JarExploderTest {
     val classNames = exploded.first().binaryClasses.map { it.className }
     assertThat(classNames).contains("com.example.Foo")
     assertThat(classNames).doesNotContain("com.example.Future")
-  }
-
-  private fun newInMemoryCache(): InMemoryCache {
-    val project = ProjectBuilder.builder().build()
-    return project.gradle.sharedServices
-      .registerIfAbsent("inMemoryCache", InMemoryCache::class.java) {
-        it.parameters.cacheSize.set(-1L)
-      }
-      .get()
   }
 
   private fun ZipOutputStream.writeEntry(name: String, bytes: ByteArray) {

--- a/src/test/kotlin/com/autonomousapps/internal/JarExploderTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/JarExploderTest.kt
@@ -7,6 +7,7 @@ import com.autonomousapps.internal.asm.Opcodes
 import com.autonomousapps.model.GradleVariantIdentification
 import com.autonomousapps.model.ModuleCoordinates
 import com.autonomousapps.model.internal.PhysicalArtifact
+import com.autonomousapps.model.internal.intermediates.producer.ExplodedJar
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -53,6 +54,49 @@ internal class JarExploderTest {
     val classNames = exploded.first().binaryClasses.map { it.className }
     assertThat(classNames).contains("com.example.Foo")
     assertThat(classNames).doesNotContain("com.example.Future")
+  }
+
+  /**
+   * Regression test for https://github.com/autonomousapps/dependency-analysis-gradle-plugin/pull/1719.
+   *
+   * The exploded-jar cache is keyed by file path, and (once kotlin-metadata was isolated to workers) its value became
+   * [ExplodedJar], which carries the dependency's [ExplodedJar.coordinates]. A single physical file can be resolved
+   * under different coordinates by different consumers. For example, a classifier/capability variant can be pulled by more than one
+   * project. A cache hit must reuse the cached file-content analysis but report the *current* artifact's coordinates,
+   * not whichever consumer populated the (build-scoped) cache first. Otherwise dependencies are mis-attributed and DAGP
+   * emits wrong advice (the `ClassifiersSpec` "transitive classifier" failures).
+   */
+  @Test fun `a cache hit does not leak coordinates across artifacts that share a file`(@TempDir dir: File) {
+    val jar = File(dir, "shared.jar").apply {
+      ZipOutputStream(outputStream()).use { zip ->
+        zip.writeEntry("com/example/Foo.class", validClass("com/example/Foo"))
+      }
+    }
+
+    // The same file on disk, reached under two different coordinates.
+    val firstCoordinates = ModuleCoordinates("joda-time:joda-time", "2.10.7", GradleVariantIdentification.EMPTY)
+    val secondCoordinates = ModuleCoordinates("net.danlew:android.joda", "2.10.7.2", GradleVariantIdentification.EMPTY)
+
+    // The first consumer explodes the file and seeds the build-scoped cache, as ExplodeJarTask merges it back.
+    val first = JarExploder(
+      artifacts = listOf(PhysicalArtifact(coordinates = firstCoordinates, file = jar)),
+      androidLinters = emptySet(),
+      seedCache = emptyMap(),
+    )
+    first.explodedJars()
+    val seededCache: Map<String, ExplodedJar> = first.newEntries
+    // Sanity: the second consumer below must get a cache *hit*, else this test would pass vacuously.
+    assertThat(seededCache).isNotEmpty()
+
+    // The second consumer explodes the same file under different coordinates, seeded from that shared cache.
+    val second = JarExploder(
+      artifacts = listOf(PhysicalArtifact(coordinates = secondCoordinates, file = jar)),
+      androidLinters = emptySet(),
+      seedCache = seededCache,
+    ).explodedJars().single()
+
+    // It must report its own coordinates, not the first consumer's.
+    assertThat(second.coordinates).isEqualTo(secondCoordinates)
   }
 
   private fun ZipOutputStream.writeEntry(name: String, bytes: ByteArray) {


### PR DESCRIPTION
Turns out that while the [base idea for the fix](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1671#issuecomment-4345964746) was right, the devil is in the details.

I attempted to split the commit logically to help the review:
* First one changes the use of the cache, so that work action can serialize what they need. And then their additions to the cache can be loaded back after being done
* Second one effectively moves the usage of kotlin-metadata to be an additional worker dependency, it no longer is anywhere on the plugin classpath
* Third is about making sure the plugin sticks with Kotlin 2.1, which is the last version that Gradle 8.11 will fully support. It should be updated only when support for that version is abandoned.
* Fourth is a minor version catalog change following a rename in the previous commit

If those changes are too impactful - there is a slight risk of a performance regression with the changes to how caching works - the only alternative is to drop support for older Gradle versions. But this will be a never ending race because of the need for the plugin to understand the latest Kotlin metadata.