### PR TITLE
fix: track multiple package names from libs that provide type aliases, and enhance default kotlin-lib bundle.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/AnnotatedPackageSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/AnnotatedPackageSpec.groovy
@@ -1,0 +1,28 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.jvm
+
+import com.autonomousapps.jvm.projects.AnnotatedPackageProject
+import spock.lang.Issue
+
+import static com.autonomousapps.kit.GradleBuilder.build
+import static com.google.common.truth.Truth.assertThat
+
+final class AnnotatedPackageSpec extends AbstractJvmSpec {
+
+  @Issue("https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1274")
+  def "annotations on packages should be compileOnly (#gradleVersion)"() {
+    given:
+    def project = new AnnotatedPackageProject()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/KotlinTestSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/KotlinTestSpec.groovy
@@ -1,0 +1,26 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.jvm
+
+import com.autonomousapps.jvm.projects.KotlinTestProject
+
+import static com.autonomousapps.kit.GradleBuilder.build
+import static com.google.common.truth.Truth.assertThat
+
+final class KotlinTestSpec extends AbstractJvmSpec {
+
+  def "kotlin-test is not unused when the kotlin.test.Test annotation is used (#gradleVersion)"() {
+    given:
+    def project = new KotlinTestProject()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AnnotatedPackageProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AnnotatedPackageProject.groovy
@@ -1,0 +1,80 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.model.Advice
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.*
+import static com.autonomousapps.kit.gradle.Dependency.implementation
+
+final class AnnotatedPackageProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  AnnotatedPackageProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newGradleProjectBuilder()
+      .withSubproject('consumer') { consumer ->
+        consumer.sources = consumerSources()
+        consumer.withBuildScript { bs ->
+          bs.plugins(javaLibrary)
+          bs.dependencies(implementation(':annotations'))
+        }
+      }
+      .withSubproject('annotations') { annotations ->
+        annotations.sources = annotationsSources()
+        annotations.withBuildScript { bs ->
+          bs.plugins(javaLibrary)
+        }
+      }
+      .write()
+  }
+
+  private static final List<Source> consumerSources() {
+    [
+      Source.java(
+        '''\
+          @Magic
+          package com.consumer;
+          
+          import com.annotations.Magic;'''.stripIndent()
+      )
+        .withPath('com.consumer', 'package-info')
+        .build(),
+    ]
+  }
+
+  private static final List<Source> annotationsSources() {
+    [
+      Source.java(
+        '''\
+          package com.annotations;
+          
+          import java.lang.annotation.*;
+          
+          @Target(ElementType.PACKAGE)
+          public @interface Magic {}'''.stripIndent()
+      ).build(),
+    ]
+  }
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  private static final Set<Advice> consumerAdvice() {
+    [Advice.ofChange(projectCoordinates(':annotations'), 'implementation', 'compileOnly')]
+  }
+
+  final Set<ProjectAdvice> expectedBuildHealth = [
+    projectAdviceForDependencies(':consumer', consumerAdvice()),
+    emptyProjectAdviceFor(':annotations'),
+  ]
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/KotlinTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/KotlinTestProject.groovy
@@ -1,0 +1,79 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.actualProjectAdvice
+import static com.autonomousapps.AdviceHelper.emptyProjectAdviceFor
+
+final class KotlinTestProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  KotlinTestProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newGradleProjectBuilder()
+      .withSubproject('consumer') { consumer ->
+        consumer.sources = consumerSources()
+        consumer.withBuildScript { bs ->
+          bs.plugins(kotlin)
+          bs.dependencies(
+            dependencies.kotlinTest('testImplementation'),
+          )
+          bs.withGroovy(
+            '''\
+              tasks.test { useJUnitPlatform() }
+            '''.stripIndent()
+          )
+        }
+      }
+      .write()
+  }
+
+  private static final List<Source> consumerSources() {
+    [
+      Source.kotlin(
+        '''\
+          package com.consumer
+          
+          fun main() {
+            println("Hello, world!")
+          }'''.stripIndent()
+      )
+        .withPath('com.consumer', 'main')
+        .build(),
+      Source.kotlin(
+        '''\
+          package com.consumer
+
+          import kotlin.test.Test
+          import org.junit.jupiter.api.assertDoesNotThrow
+          
+          class HelloWorldTest {
+            @Test
+            fun `runs without throwing`() {
+              assertDoesNotThrow { main() }
+            }
+          }
+        '''.stripIndent()
+      )
+        .withSourceSet('test')
+        .build()
+    ]
+  }
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  final Set<ProjectAdvice> expectedBuildHealth = [
+    emptyProjectAdviceFor(':consumer'),
+  ]
+}

--- a/src/functionalTest/groovy/com/autonomousapps/kmp/SimpleKmpSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/kmp/SimpleKmpSpec.groovy
@@ -60,12 +60,7 @@ final class SimpleKmpSpec extends AbstractKmpSpec {
           androidMain.dependencies {
             api("${AndroidTargetProject.CAFFEINE}")
           }
-          
-        These transitive dependencies should be declared directly:
-          androidHostTest.dependencies {
-            implementation("${AndroidTargetProject.KOTLIN_TEST}")
-          }
-        
+                  
         Existing dependencies which should be modified to be as indicated:
           commonMain.dependencies {
             api("${AndroidTargetProject.OKIO}") (was commonMainImplementation)
@@ -95,12 +90,7 @@ final class SimpleKmpSpec extends AbstractKmpSpec {
           androidMain.dependencies {
             api("${AndroidAndJvmProject.CAFFEINE}")
           }
-        
-        These transitive dependencies should be declared directly:
-          androidHostTest.dependencies {
-            implementation("${AndroidAndJvmProject.KOTLIN_TEST}")
-          }
-        
+                
         Existing dependencies which should be modified to be as indicated:
           commonMain.dependencies {
             api("${AndroidAndJvmProject.OKIO}") (was commonMainImplementation)

--- a/src/functionalTest/groovy/com/autonomousapps/kmp/projects/AndroidAndJvmProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/kmp/projects/AndroidAndJvmProject.groovy
@@ -18,7 +18,6 @@ final class AndroidAndJvmProject extends AbstractProject {
   private static final String KOTLIN_VERSION = '2.2.21'
 
   static final String CAFFEINE = 'com.github.ben-manes.caffeine:caffeine:3.2.3'
-  static final String KOTLIN_TEST = "org.jetbrains.kotlin:kotlin-test:$KOTLIN_VERSION"
   static final String KOTLINX_COROUTINES_CORE = 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2'
   static final String OKIO = 'com.squareup.okio:okio:3.16.4'
 
@@ -269,8 +268,6 @@ final class AndroidAndJvmProject extends AbstractProject {
     Advice.ofRemove(moduleCoordinates(CAFFEINE), 'androidMainApi'),
     // commonMainApi("com.squareup.okio:okio:3.16.4") (was commonMainImplementation)
     Advice.ofChange(moduleCoordinates(OKIO), 'commonMainImplementation', 'commonMainApi'),
-    // androidHostTestImplementation("org.jetbrains.kotlin:kotlin-test:2.2.21")
-    Advice.ofAdd(moduleCoordinates(KOTLIN_TEST), 'androidHostTestImplementation')
   ]
 
   //  Advice(com.squareup.okio:okio:3.16.4), fromConfiguration=commonMainImplementation, toConfiguration=commonMainApi),

--- a/src/functionalTest/groovy/com/autonomousapps/kmp/projects/AndroidTargetProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/kmp/projects/AndroidTargetProject.groovy
@@ -17,7 +17,6 @@ final class AndroidTargetProject extends AbstractProject {
   private static final String KOTLIN_VERSION = '2.2.21'
 
   static final String CAFFEINE = 'com.github.ben-manes.caffeine:caffeine:3.2.3'
-  static final String KOTLIN_TEST = "org.jetbrains.kotlin:kotlin-test:$KOTLIN_VERSION"
   static final String OKIO = 'com.squareup.okio:okio:3.16.4'
 
   final GradleProject gradleProject
@@ -177,8 +176,6 @@ final class AndroidTargetProject extends AbstractProject {
     Advice.ofRemove(moduleCoordinates(CAFFEINE), 'androidMainApi'),
     // commonMainApi("com.squareup.okio:okio:3.16.4") (was commonMainImplementation)
     Advice.ofChange(moduleCoordinates(OKIO), 'commonMainImplementation', 'commonMainApi'),
-    // androidHostTestImplementation("org.jetbrains.kotlin:kotlin-test:2.2.21")
-    Advice.ofAdd(moduleCoordinates(KOTLIN_TEST), 'androidHostTestImplementation')
   ]
 
   final Set<ProjectAdvice> expectedBuildHealth = [

--- a/src/functionalTest/kotlin/com/autonomousapps/kit/gradle/dependencies/DependencyProvider.kt
+++ b/src/functionalTest/kotlin/com/autonomousapps/kit/gradle/dependencies/DependencyProvider.kt
@@ -30,6 +30,10 @@ class DependencyProvider(
     return Dependency(configuration, "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
   }
 
+  fun kotlinTest(configuration: String): Dependency {
+    return Dependency(configuration, "org.jetbrains.kotlin:kotlin-test:$kotlinVersion")
+  }
+
   fun kotlinTestJunit(configuration: String): Dependency {
     return Dependency(configuration, "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion")
   }

--- a/src/main/kotlin/com/autonomousapps/extension/DependenciesHandler.kt
+++ b/src/main/kotlin/com/autonomousapps/extension/DependenciesHandler.kt
@@ -95,10 +95,14 @@ public abstract class DependenciesHandler @Inject constructor(objects: ObjectFac
     bundle("__kotlin-stdlib") {
       it.include(".*kotlin-stdlib.*")
     }
-    // The kotlin plugin is automatically adding another variant of the kotlin-test dependency, which can show up as
-    // unused with no way to opt out.
+    // The `@kotlin.test.Test` annotation is provided by the `org.jetbrains.kotlin:kotlin-test-junit5` artifact, but
+    // users are expected to declare `org.jetbrains.kotlin:kotlin-test` (or `kotlin("test")`), which is a KMP lib with
+    // many variants.
     bundle("__kotlin-test") {
-      it.includeDependency("org.jetbrains.kotlin:kotlin-test")
+      it.primary("org.jetbrains.kotlin:kotlin-test")
+      it.includeDependency("org.jetbrains.kotlin:kotlin-test-junit5")
+      it.includeDependency("org.jetbrains.kotlin:kotlin-test-junit")
+      it.includeDependency("org.junit.jupiter:junit-jupiter-api")
     }
     // kotlin-test-junit provides junit, and Kotlin projects expect to declare the former.
     bundle("__kotlin-test-junit") {

--- a/src/main/kotlin/com/autonomousapps/model/internal/Capability.kt
+++ b/src/main/kotlin/com/autonomousapps/model/internal/Capability.kt
@@ -57,7 +57,7 @@ internal data class AndroidManifestCapability(
 
     companion object {
       internal fun of(mapKey: String): Component {
-        return values().find {
+        return entries.find {
           it.mapKey == mapKey
         } ?: error("Could not find Manifest.Component for $mapKey")
       }
@@ -282,13 +282,35 @@ internal data class TypealiasCapability(
 
   @JsonClass(generateAdapter = false)
   data class Typealias(
+    /** The actual package visible from the class file. */
     val packageName: String,
+    /**
+     * From `Metadata.packageName`, visible from the `.kotlin_module` header. E.g., kotlin-test-junit5 has an
+     * AnnotationsKt file with this:
+     * ```
+     * @file:JvmPackageName("kotlin.test.junit5.annotations")
+     * package kotlin.test
+     *
+     * public actual typealias Test = org.junit.jupiter.api.Test
+     * ```
+     * Which is obviously insane. Nonetheless, this class essentially has two packages. In user code, you would have:
+     * ```
+     * import kotlin.test.Test
+     *
+     * class MyTest {
+     *   @Test fun test() { ... }
+     * }
+     * ```
+     * So, to detect that `kotlin.test.Test` maps to `kotlin.test.junit5.annotations` (_which is what's in the
+     * bytecode_), we keep track of both package names.
+     */
+    val alternatePackageName: String,
     val typealiases: Set<Alias>,
   ) : Comparable<Typealias> {
 
     companion object {
-      fun newInstance(packageName: String, typealiases: Set<Alias>): Typealias {
-        return Typealias(packageName, typealiases.toSortedSet().efficient())
+      fun newInstance(packageName: String, alternatePackageName: String, typealiases: Set<Alias>): Typealias {
+        return Typealias(packageName, alternatePackageName, typealiases.toSortedSet().efficient())
       }
     }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeUsagesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeUsagesTask.kt
@@ -528,8 +528,13 @@ private class GraphVisitor(
     typealiasCapability: TypealiasCapability,
     context: GraphViewVisitor.Context,
   ): Boolean {
-    val fqnTypealiases = typealiasCapability.typealiases.flatMapToSet { ta ->
-      ta.typealiases.map { "${ta.packageName}.${it.name}" }
+    val fqnTypealiases = typealiasCapability.typealiases.flatMapToOrderedSet { ta ->
+      ta.typealiases.flatMap {
+        listOf(
+          "${ta.packageName}.${it.name}",
+          "${ta.alternatePackageName}.${it.name}",
+        )
+      }
     }
 
     val usedClasses = context.project.usedClasses.asSequence().filter { usedClass ->

--- a/src/main/kotlin/com/autonomousapps/tasks/FindKotlinMagicTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindKotlinMagicTask.kt
@@ -15,8 +15,6 @@ import com.autonomousapps.model.internal.TypealiasCapability
 import com.autonomousapps.model.internal.intermediates.producer.InlineMemberDependency
 import com.autonomousapps.model.internal.intermediates.producer.TypealiasDependency
 import com.autonomousapps.services.InMemoryCache
-import kotlin.metadata.*
-import kotlin.metadata.jvm.KotlinClassMetadata
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
@@ -28,6 +26,8 @@ import org.gradle.workers.WorkerExecutor
 import java.io.File
 import java.util.zip.ZipFile
 import javax.inject.Inject
+import kotlin.metadata.*
+import kotlin.metadata.jvm.KotlinClassMetadata
 
 @CacheableTask
 public abstract class FindKotlinMagicTask @Inject constructor(
@@ -69,7 +69,7 @@ public abstract class FindKotlinMagicTask @Inject constructor(
 
   @TaskAction
   public fun action() {
-    workerExecutor.noIsolation().submit(FindKotlinMagicWorkAction::class.java) {
+    workerExecutor.noIsolation().submit(Action::class.java) {
       it.artifacts.set(artifacts)
       it.inlineUsageReport.set(outputInlineMembers)
       it.typealiasReport.set(outputTypealiases)
@@ -78,7 +78,7 @@ public abstract class FindKotlinMagicTask @Inject constructor(
     }
   }
 
-  public interface FindKotlinMagicParameters : WorkParameters {
+  public interface Parameters : WorkParameters {
     public val artifacts: RegularFileProperty
     public val inlineUsageReport: RegularFileProperty
     public val typealiasReport: RegularFileProperty
@@ -86,7 +86,7 @@ public abstract class FindKotlinMagicTask @Inject constructor(
     public val inMemoryCacheProvider: Property<InMemoryCache>
   }
 
-  public abstract class FindKotlinMagicWorkAction : WorkAction<FindKotlinMagicParameters> {
+  public abstract class Action : WorkAction<Parameters> {
 
     private val logger = getLogger<FindKotlinMagicTask>()
 
@@ -161,6 +161,8 @@ internal class KotlinMagicFinder(
    * ```
    * An import statement with either of those would import the `kotlin.jdk7.use()` inline function, contributed by the
    * "org.jetbrains.kotlin:kotlin-stdlib-jdk7" module.
+   *
+   * TODO(tsr): docs for the TypeAliasCapability portion of this.
    */
   private fun findKotlinMagic(artifact: PhysicalArtifact, mode: Mode): KotlinCapabilities {
     val cached = findInCache(artifact)
@@ -216,6 +218,7 @@ internal class KotlinMagicFinder(
               if (kotlinMagic.typealiases != null) {
                 typealiases += TypealiasCapability.Typealias.newInstance(
                   packageName = packageName(entry.name),
+                  alternatePackageName = kotlinMagic.packageName,
                   typealiases = kotlinMagic.typealiases
                 )
               }
@@ -253,6 +256,7 @@ internal class KotlinMagicFinder(
             if (kotlinMagic.typealiases != null) {
               typealiases += TypealiasCapability.Typealias.newInstance(
                 packageName = packageName(Files.asPackagePath(classFile)),
+                alternatePackageName = kotlinMagic.packageName,
                 typealiases = kotlinMagic.typealiases
               )
             }
@@ -281,6 +285,7 @@ internal class KotlinMagicFinder(
     val metadataVisitor = KotlinMetadataVisitor(logger)
     classReader.accept(metadataVisitor, 0)
 
+    var packageName: String = ""
     var inlineMembers: Set<String>? = null
     var typealiases: Set<TypealiasCapability.Typealias.Alias>? = null
 
@@ -290,8 +295,11 @@ internal class KotlinMagicFinder(
       // file compiled by a "very old" version of Kotlin.
       // See https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1035
       // See https://youtrack.jetbrains.com/issue/KT-60870
-      val metadata = try {
-        KotlinClassMetadata.readLenient(header.build())
+      val kotlinClassMetadata = try {
+        val metadata = header.build()
+        packageName = metadata.packageName // can be empty
+
+        KotlinClassMetadata.readLenient(metadata)
       } catch (_: IllegalArgumentException) {
         logger.debug("Can't read class file '$classFile'")
         errorsReport.appendText("Can't read class file '$classFile'\n")
@@ -299,20 +307,20 @@ internal class KotlinMagicFinder(
         return null
       }
 
-      when (metadata) {
+      when (kotlinClassMetadata) {
         is KotlinClassMetadata.Class -> {
-          inlineMembers = inlineMembers(metadata.kmClass)
-          typealiases = typealiases(metadata.kmClass)
+          inlineMembers = inlineMembers(kotlinClassMetadata.kmClass)
+          typealiases = typealiases(kotlinClassMetadata.kmClass)
         }
 
         is KotlinClassMetadata.FileFacade -> {
-          inlineMembers = inlineMembers(metadata.kmPackage)
-          typealiases = typealiases(metadata.kmPackage)
+          inlineMembers = inlineMembers(kotlinClassMetadata.kmPackage)
+          typealiases = typealiases(kotlinClassMetadata.kmPackage)
         }
 
         is KotlinClassMetadata.MultiFileClassPart -> {
-          inlineMembers = inlineMembers(metadata.kmPackage)
-          typealiases = typealiases(metadata.kmPackage)
+          inlineMembers = inlineMembers(kotlinClassMetadata.kmPackage)
+          typealiases = typealiases(kotlinClassMetadata.kmPackage)
         }
 
         is KotlinClassMetadata.SyntheticClass -> logger.debug("Ignoring SyntheticClass $classFile")
@@ -323,15 +331,14 @@ internal class KotlinMagicFinder(
 
     // It's part of the contract to never return an empty set
     return KotlinMagic(
+      packageName = packageName,
       inlineMembers = inlineMembers?.ifEmpty { null },
       typealiases = typealiases?.ifEmpty { null },
     )
-
-    // It's part of the contract to never return an empty set
-    // return inlineMembers?.ifEmpty { null }
   }
 
   private class KotlinMagic(
+    val packageName: String,
     val inlineMembers: Set<String>?,
     val typealiases: Set<TypealiasCapability.Typealias.Alias>?,
   )


### PR DESCRIPTION
Resolves https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1274