### PR TITLE
fix: test against AGP 9.2.1 and update AGP_MAX to 9.2.1.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
@@ -21,7 +21,7 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
   protected static final AGP_8_13 = AgpVersion.version('8.13.2')
   protected static final AGP_9_0 = AgpVersion.version('9.0.1')
   protected static final AGP_9_1 = AgpVersion.version('9.1.0')
-  protected static final AGP_9_2 = AgpVersion.version('9.2.0')
+  protected static final AGP_9_2 = AgpVersion.version('9.2.1')
 
   protected static final AGP_MIN = AGP_8_10
   protected static final AGP_LATEST_STABLE = AGP_9_2

--- a/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
@@ -13,7 +13,7 @@ internal class AgpVersion private constructor(val version: String) : Comparable<
   companion object {
 
     @JvmField val AGP_MIN = version("8.10.0")
-    @JvmField val AGP_MAX = version("9.1.0")
+    @JvmField val AGP_MAX = version("9.2.1")
 
     @JvmStatic fun current(): AgpVersion = AgpVersion(agpVersion())
     @JvmStatic fun version(version: String): AgpVersion = AgpVersion(version)


### PR DESCRIPTION
Resolves https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1732