### PR TITLE
Make InMemoryCache compatible with isolated projects

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IncludedBuildWithDivergingPluginClasspathsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IncludedBuildWithDivergingPluginClasspathsProject.groovy
@@ -4,6 +4,7 @@ package com.autonomousapps.jvm.projects
 
 import com.autonomousapps.AbstractProject
 import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.gradle.GradleProperties
 import com.autonomousapps.kit.gradle.Plugin
 import com.autonomousapps.kit.gradle.dependencies.Plugins
 
@@ -28,6 +29,7 @@ final class IncludedBuildWithDivergingPluginClasspathsProject extends AbstractPr
 
     return newGradleProjectBuilder()
       .withRootProject { root ->
+        root.gradleProperties += GradleProperties.enableIsolatedProjects()
         root.withBuildScript { bs ->
           bs.plugins.add(Plugin.javaLibrary)
           bs.additions = printServiceObject

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidProjectAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidProjectAnalyzer.kt
@@ -132,7 +132,7 @@ internal abstract class AndroidAnalyzer(
 
   final override fun registerFindDeclaredProcsTask(): TaskProvider<FindDeclaredProcsTask> =
     project.tasks.register("findDeclaredProcs$taskNameSuffix", FindDeclaredProcsTask::class.java) {
-      it.inMemoryCacheProvider.set(InMemoryCache.register(project))
+      InMemoryCache.register(it.inMemoryCacheProvider, project)
       kaptConf()?.let { configuration ->
         it.setKaptArtifacts(configuration.incoming.artifacts)
       }

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/DependencyAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/DependencyAnalyzer.kt
@@ -399,7 +399,7 @@ internal abstract class AbstractDependencyAnalyzer(
     androidLintTask: TaskProvider<FindAndroidLinters>?,
   ): TaskProvider<ExplodeJarTask> {
     return project.tasks.register("explodeJar$taskNameSuffix", ExplodeJarTask::class.java) { t ->
-      t.inMemoryCache.set(InMemoryCache.register(project))
+      InMemoryCache.register(t.inMemoryCache, project)
       t.compileClasspath.setFrom(
         project.configurations.getByName(compileConfigurationName)
           .artifactsFor(attributeValueJar)
@@ -414,7 +414,7 @@ internal abstract class AbstractDependencyAnalyzer(
 
   final override fun registerFindKotlinMagicTask(artifactsReport: TaskProvider<ArtifactsReportTask>): TaskProvider<FindKotlinMagicTask> {
     return project.tasks.register("findKotlinMagic$taskNameSuffix", FindKotlinMagicTask::class.java) { t ->
-      t.inMemoryCacheProvider.set(InMemoryCache.register(project))
+      InMemoryCache.register(t.inMemoryCacheProvider, project)
       t.compileClasspath.setFrom(
         project.configurations.getByName(compileConfigurationName)
           .artifactsFor(attributeValueJar)
@@ -527,7 +527,7 @@ internal abstract class AbstractDependencyAnalyzer(
       "synthesizeDependencies$taskNameSuffix",
       SynthesizeDependenciesTask::class.java
     ) { t ->
-      t.inMemoryCache.set(InMemoryCache.register(project))
+
       t.projectPath.set(project.path)
       t.compileDependencies.set(graphViewTask.flatMap { it.outputNodes })
       t.physicalArtifacts.set(artifactsReport.flatMap { it.output })

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmProjectAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmProjectAnalyzer.kt
@@ -72,7 +72,7 @@ internal abstract class JvmAnalyzer(
 
   final override fun registerFindDeclaredProcsTask(): TaskProvider<FindDeclaredProcsTask> {
     return project.tasks.register("findDeclaredProcs$taskNameSuffix", FindDeclaredProcsTask::class.java) {
-      it.inMemoryCacheProvider.set(InMemoryCache.register(project))
+      InMemoryCache.register(it.inMemoryCacheProvider, project)
       kaptConf()?.let { configuration ->
         it.setKaptArtifacts(configuration.incoming.artifacts)
       }

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/KmpProjectAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/KmpProjectAnalyzer.kt
@@ -69,7 +69,7 @@ internal class KmpProjectAnalyzer(
 
   override fun registerFindDeclaredProcsTask(): TaskProvider<FindDeclaredProcsTask> {
     return project.tasks.register("findDeclaredProcs$taskNameSuffix", FindDeclaredProcsTask::class.java) {
-      it.inMemoryCacheProvider.set(InMemoryCache.register(project))
+      InMemoryCache.register(it.inMemoryCacheProvider, project)
       kaptConf()?.let { configuration ->
         it.setKaptArtifacts(configuration.incoming.artifacts)
       }

--- a/src/main/kotlin/com/autonomousapps/services/InMemoryCache.kt
+++ b/src/main/kotlin/com/autonomousapps/services/InMemoryCache.kt
@@ -4,7 +4,6 @@
 
 package com.autonomousapps.services
 
-import com.autonomousapps.DependencyAnalysisPlugin
 import com.autonomousapps.Flags.cacheSize
 import com.autonomousapps.model.internal.intermediates.producer.AnnotationProcessorDependency
 import com.autonomousapps.model.internal.intermediates.ExplodingJar
@@ -59,38 +58,25 @@ public abstract class InMemoryCache : BuildService<InMemoryCache.Params> {
     // To share service across the whole build tree - https://github.com/gradle/gradle/issues/14697
     private fun Gradle.rootBuild(): Gradle = parent?.rootBuild() ?: this
 
-    /**
-     * Determines the build on which to register the service. In a composite build, the root build is used to share the
-     * cache across builds if the root build used that same classloader for loading the plugin as the current build.
-     * See: https://github.com/gradle/gradle/issues/17559
-     */
-    private fun Project.serviceHoldingBuild(): Gradle {
-      val thisBuild = gradle
-      val rootBuild = thisBuild.rootBuild()
-
-      if (thisBuild == rootBuild) {
-        return thisBuild
+    private fun Gradle.registerService(cacheSize: Long): Provider<InMemoryCache> = sharedServices
+      .registerIfAbsent(SHARED_SERVICES_IN_MEMORY_CACHE, InMemoryCache::class.java) {
+        it.parameters.cacheSize.set(cacheSize)
       }
 
-      val thisPluginInstance = thisBuild.rootProject.plugins.findPlugin(DependencyAnalysisPlugin.ID)
-      val rootPluginInstance = rootBuild.rootProject.plugins.findPlugin(DependencyAnalysisPlugin.ID)
+    fun register(property: Property<InMemoryCache>, project: Project) {
+      val cacheSize = project.cacheSize(DEFAULT_CACHE_VALUE)
 
-      if (thisPluginInstance == null || rootPluginInstance == null) {
-        return thisBuild
-      }
-
-      return if (thisPluginInstance::class.java == rootPluginInstance::class.java) {
-        rootBuild // shared cache in the root if plugin was loaded with same classloader
-      } else {
-        thisBuild
+      // In a composite build, the root build is used to share the cache across builds if the root build used
+      // the same classloader for loading the plugin as the current build.
+      // See: https://github.com/gradle/gradle/issues/17559
+      val rootService = project.gradle.rootBuild().registerService(cacheSize)
+      try {
+        property.set(rootService)
+      } catch (_: IllegalArgumentException) {
+        // Root service is not of valid type as it was loaded with a different classloader.
+        // Fall back to an isolated service.
+        property.set(project.gradle.registerService(cacheSize))
       }
     }
-
-    fun register(project: Project): Provider<InMemoryCache> = project
-      .serviceHoldingBuild()
-      .sharedServices
-      .registerIfAbsent(SHARED_SERVICES_IN_MEMORY_CACHE, InMemoryCache::class.java) {
-        it.parameters.cacheSize.set(project.cacheSize(DEFAULT_CACHE_VALUE))
-      }
   }
 }


### PR DESCRIPTION
Solution: no longer access any root build state. Instead, assume that the service can be shared via the root build, and only if that causes and `IllegalArgumentException`, fall back to an isolated service.

Fixes #1317