### PR TITLE
Escape reserved keywords when using project accessors

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/advice/AdvicePrinter.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/advice/AdvicePrinter.kt
@@ -27,9 +27,10 @@ internal class AdvicePrinter(
       }
     }
 
-    val kotlinReservedKeywords = List(KotlinParser.VOCABULARY.maxTokenType) { KotlinParser.VOCABULARY.getLiteralName(it) }
-      .filterNotNull()
-      .map { it.removeSurrounding("'") }
+    val kotlinReservedKeywords = listOf(
+      "class",
+      "interface",
+    )
   }
 
   fun line(configuration: String, printableIdentifier: String, was: String = ""): String {

--- a/src/main/kotlin/com/autonomousapps/internal/advice/AdvicePrinter.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/advice/AdvicePrinter.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.internal.advice
 
+import com.autonomousapps.internal.squareup.cash.grammar.KotlinParser
 import com.autonomousapps.model.internal.ProjectType
 import com.autonomousapps.model.Advice
 import com.autonomousapps.model.Coordinates
@@ -25,6 +26,10 @@ internal class AdvicePrinter(
         it.value.last().uppercaseChar().toString()
       }
     }
+
+    val kotlinReservedKeywords = List(KotlinParser.VOCABULARY.maxTokenType) { KotlinParser.VOCABULARY.getLiteralName(it) }
+      .filterNotNull()
+      .map { it.removeSurrounding("'") }
   }
 
   fun line(configuration: String, printableIdentifier: String, was: String = ""): String {
@@ -84,7 +89,7 @@ internal class AdvicePrinter(
   private fun getProjectFormat(quotedDep: String): String {
     return if (useTypesafeProjectAccessors) {
       if (dslKind == DslKind.KOTLIN) {
-        "projects${quotedDep.replace(':', '.').replace("\"", "").kebabOrSnakeToCamelCase()}"
+        "projects${quotedDep.replace("\"", "").split(':').joinToString(".") { if (it in kotlinReservedKeywords) "`$it`" else it }.kebabOrSnakeToCamelCase()}"
       } else {
         "projects${quotedDep.replace(':', '.').replace("'", "").kebabOrSnakeToCamelCase()}"
       }

--- a/src/main/kotlin/com/autonomousapps/internal/advice/AdvicePrinter.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/advice/AdvicePrinter.kt
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.internal.advice
 
-import com.autonomousapps.internal.squareup.cash.grammar.KotlinParser
 import com.autonomousapps.model.internal.ProjectType
 import com.autonomousapps.model.Advice
 import com.autonomousapps.model.Coordinates
@@ -21,16 +20,42 @@ internal class AdvicePrinter(
   private companion object {
     val PROJECT_PATH_PATTERN = "[-_][a-z0-9]".toRegex()
 
+    val kotlinHardKeywords = listOf(
+      "as",
+      "break",
+      "class",
+      "continue",
+      "do",
+      "else",
+      "false",
+      "for",
+      "fun",
+      "if",
+      "in",
+      "interface",
+      "is",
+      "null",
+      "object",
+      "package",
+      "return",
+      "super",
+      "this",
+      "throw",
+      "true",
+      "try",
+      "typealias",
+      "typeof",
+      "val",
+      "var",
+      "when",
+      "while",
+    )
+
     fun String.kebabOrSnakeToCamelCase(): String {
       return replace(PROJECT_PATH_PATTERN) {
         it.value.last().uppercaseChar().toString()
       }
     }
-
-    val kotlinReservedKeywords = listOf(
-      "class",
-      "interface",
-    )
   }
 
   fun line(configuration: String, printableIdentifier: String, was: String = ""): String {
@@ -90,7 +115,7 @@ internal class AdvicePrinter(
   private fun getProjectFormat(quotedDep: String): String {
     return if (useTypesafeProjectAccessors) {
       if (dslKind == DslKind.KOTLIN) {
-        "projects${quotedDep.replace("\"", "").split(':').joinToString(".") { if (it in kotlinReservedKeywords) "`$it`" else it }.kebabOrSnakeToCamelCase()}"
+        "projects${quotedDep.replace("\"", "").split(':').joinToString(".") { if (it in kotlinHardKeywords) "`$it`" else it }.kebabOrSnakeToCamelCase()}"
       } else {
         "projects${quotedDep.replace(':', '.').replace("'", "").kebabOrSnakeToCamelCase()}"
       }

--- a/src/test/kotlin/com/autonomousapps/internal/parse/KotlinBuildScriptDependenciesRewriterTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/parse/KotlinBuildScriptDependenciesRewriterTest.kt
@@ -4,6 +4,7 @@ package com.autonomousapps.internal.parse
 
 import com.autonomousapps.internal.advice.AdvicePrinter
 import com.autonomousapps.internal.advice.DslKind
+import com.autonomousapps.internal.squareup.cash.grammar.KotlinParser
 import com.autonomousapps.internal.utils.intoSet
 import com.autonomousapps.model.Advice
 import com.autonomousapps.model.Coordinates
@@ -151,6 +152,7 @@ internal class KotlinBuildScriptDependenciesRewriterTest {
       Advice.ofChange(Coordinates.of(":marvin"), "api", "compileOnly"),
       Advice.ofRemove(Coordinates.of("pan-galactic:gargle-blaster:2.0-SNAPSHOT"), "testImplementation"),
       Advice.ofAdd(Coordinates.of(":sad-robot"), "runtimeOnly"),
+      Advice.ofAdd(Coordinates.of(":interface"), "api"),
     )
 
     // When
@@ -191,6 +193,7 @@ internal class KotlinBuildScriptDependenciesRewriterTest {
           implementation("heart:of-gold:1.+")
           compileOnly(projects.marvin)
           runtimeOnly(projects.sadRobot)
+          api(projects.`interface`)
         }
 
         println("hello, world!")


### PR DESCRIPTION
Fixes #1715.

I kept both commits just to show a train of thought. Initially, I thought that every keyword in Kotlin needs to be escaped, so that's what my implementation in the first commit does. When running the checks before making a PR, the `use typesafe project accessors syntax when dsl is kotlin and useTypesafeProjectAccessors is true is true` test was failing, because it references a coordinate like `:sad-robot:internal`, but interestingly the conversion to `projects.sadRobot.internal` is truly, actually valid.

In the second commit, I'm doing the simpler thing of just listing some known keywords that need to be escaped. I don't know what makes something needing escape or not. I tried a few random keywords, and `interface` and `class` aren't fine but `internal`, `abstract`, `public` are fine.

The downside with the second approach is that this list is most likely incomplete. At least if there are further issues, it's trivial to update.