### PR TITLE
Fix `JarSubject.resource` failing on nested entry paths

### DIFF
--- a/testkit/gradle-testkit-truth/CHANGELOG.md
+++ b/testkit/gradle-testkit-truth/CHANGELOG.md
@@ -1,5 +1,8 @@
 Gradle TestKit Support Changelog
 
+# Unreleased
+* [fix] `JarSubject.resource()` no longer fails with `NoSuchFileException` for entries in nested paths (e.g. `META-INF/services/...`).
+
 # Version 1.7.0
 * Compiled against Kotlin 2.2 and Gradle 9.4.1.
 

--- a/testkit/gradle-testkit-truth/src/main/kotlin/com/autonomousapps/kit/truth/artifact/JarSubject.kt
+++ b/testkit/gradle-testkit-truth/src/main/kotlin/com/autonomousapps/kit/truth/artifact/JarSubject.kt
@@ -42,8 +42,9 @@ public class JarSubject private constructor(
         failWithActual(Fact.simpleFact("No resource found at '$path' in '$actual'"))
       }
 
-      val tempDir = Files.createTempDirectory(null)
-      Files.copy(resource, tempDir.resolve(path), StandardCopyOption.REPLACE_EXISTING)
+      val target = Files.createTempDirectory(null).resolve(path)
+      Files.createDirectories(target.parent)
+      Files.copy(resource, target, StandardCopyOption.REPLACE_EXISTING)
     }
 
     return PathSubject.assertThat(tempResource)


### PR DESCRIPTION
Create the missing parent directories before copying the jar entry to the temp dir. `Files.copy` does not create them, so entries in nested paths like `META-INF/services/...` threw `NoSuchFileException`.