### PR TITLE
fix: use Iterator.remove() for safe modification.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/android/ConcurrentModificationSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/ConcurrentModificationSpec.groovy
@@ -1,0 +1,31 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.android
+
+import com.autonomousapps.android.projects.ConcurrentModificationProject
+import spock.lang.Issue
+
+import static com.autonomousapps.advice.truth.BuildHealthSubject.buildHealth
+import static com.autonomousapps.kit.GradleBuilder.build
+import static com.google.common.truth.Truth.assertAbout
+
+final class ConcurrentModificationSpec extends AbstractAndroidSpec {
+
+  @Issue("https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1747")
+  def "does not throw ConcurrentModificationException (#gradleVersion AGP #agpVersion)"() {
+    given:
+    def project = new ConcurrentModificationProject(agpVersion)
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertAbout(buildHealth())
+      .that(project.actualBuildHealth())
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth)
+
+    where:
+    [gradleVersion, agpVersion] << gradleAgpMatrix()
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AbstractAndroidProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AbstractAndroidProject.groovy
@@ -118,7 +118,12 @@ abstract class AbstractAndroidProject extends AbstractProject {
     return null
   }
 
+  @Deprecated
   protected GradleProject.Builder newAndroidGradleProjectBuilder(String agpVersion) {
+    return newAndroidGradleProjectBuilder()
+  }
+
+  protected GradleProject.Builder newAndroidGradleProjectBuilder() {
     return newGradleProjectBuilder()
       .withRootProject { root ->
         root.gradleProperties += GradleProperties.minimalAndroidProperties()

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/CompileOnlyProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/CompileOnlyProject.groovy
@@ -24,7 +24,7 @@ final class CompileOnlyProject extends AbstractAndroidProject {
   }
 
   private GradleProject build() {
-    return newAndroidGradleProjectBuilder(agpVersion)
+    return newAndroidGradleProjectBuilder()
       .withAndroidLibProject('lib') { lib ->
         lib.manifest = libraryManifest()
         lib.withBuildScript { bs ->

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/ConcurrentModificationProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/ConcurrentModificationProject.groovy
@@ -1,0 +1,86 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.android.projects
+
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.model.Advice
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.*
+import static com.autonomousapps.kit.gradle.Dependency.project
+
+final class ConcurrentModificationProject extends AbstractAndroidProject {
+
+  final GradleProject gradleProject
+
+  ConcurrentModificationProject(agpVersion) {
+    super(agpVersion as String)
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newAndroidGradleProjectBuilder()
+      .withAndroidLibProject('consumer') { lib ->
+        lib.sources = consumerSources
+        lib.withBuildScript { bs ->
+          bs.plugins = androidLib(false)
+          bs.android = defaultAndroidLibBlock(false)
+          bs.dependencies(
+            project('implementation', ':producer'),
+            project('testFixturesImplementation', ':producer'),
+          )
+        }
+      }
+      .withSubproject('producer') { lib ->
+        lib.sources = producerSources
+        lib.withBuildScript { bs ->
+          bs.plugins(javaLibrary)
+        }
+      }
+      .write()
+  }
+
+  private consumerSources = [
+    Source.java(
+      """\
+      package com.example.consumer;
+      
+      import com.example.producer.Producer;
+
+      public class TestConsumer {
+        private void function() {
+          Producer producer = new Producer();
+        } 
+      }
+      """
+    )
+      .withSourceSet('test')
+      .build(),
+  ]
+
+  private producerSources = [
+    Source.java(
+      """\
+      package com.example.producer;
+      
+      public class Producer {}
+      """
+    )
+      .build(),
+  ]
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  private final Set<Advice> consumerAdvice = [
+    Advice.ofChange(projectCoordinates(':producer'), 'implementation', 'testImplementation'),
+    Advice.ofChange(projectCoordinates(':producer'), 'testFixturesImplementation', 'testImplementation'),
+  ]
+
+  final Set<ProjectAdvice> expectedBuildHealth = [
+    projectAdviceForDependencies(':consumer', consumerAdvice),
+    emptyProjectAdviceFor(':producer'),
+  ]
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/ConcurrentModificationSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/ConcurrentModificationSpec.groovy
@@ -1,0 +1,28 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.jvm
+
+import com.autonomousapps.jvm.projects.ConcurrentModificationProject
+import spock.lang.Issue
+
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertThat
+
+final class ConcurrentModificationSpec extends AbstractJvmSpec {
+
+  @Issue("https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1747")
+  def "does not throw ConcurrentModificationException (#gradleVersion)"() {
+    given:
+    def project = new ConcurrentModificationProject()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualProjectAdvice()).containsExactlyElementsIn(project.expectedProjectAdvice)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/ConcurrentModificationProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/ConcurrentModificationProject.groovy
@@ -1,0 +1,82 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.model.Advice
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.*
+import static com.autonomousapps.kit.gradle.Dependency.project
+
+final class ConcurrentModificationProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  ConcurrentModificationProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newGradleProjectBuilder(GradleProject.DslKind.KOTLIN)
+      .withSubproject('consumer') { c ->
+        c.sources = consumerSources
+        c.withBuildScript { bs ->
+          bs.plugins = kotlin + plugins.javaTestFixtures
+          bs.dependencies(
+            project('implementation', ':producer'),
+            project('testFixturesImplementation', ':producer'),
+          )
+        }
+      }
+      .withSubproject('producer') { c ->
+        c.sources = producerSources
+        c.withBuildScript { bs ->
+          bs.plugins = kotlin
+        }
+      }
+      .write()
+  }
+
+  private consumerSources = [
+    Source.kotlin(
+      """\
+      package com.example.consumer
+      import com.example.producer.Producer
+
+      fun main() = println(Producer)
+      """
+    )
+      .withSourceSet("test")
+      .withPath('com.example.consumer', 'TestConsumer')
+      .build(),
+  ]
+
+  private producerSources = [
+    Source.kotlin(
+      """\
+      package com.example.producer
+      
+      object Producer
+      """
+    )
+      .withPath('com.example.producer', 'Producer')
+      .build(),
+  ]
+
+  Set<ProjectAdvice> actualProjectAdvice() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  private final Set<Advice> consumerAdvice = [
+    Advice.ofChange(projectCoordinates(':producer'), 'implementation', 'testImplementation'),
+    Advice.ofRemove(projectCoordinates(':producer'), 'testFixturesImplementation'),
+  ]
+
+  final Set<ProjectAdvice> expectedProjectAdvice = [
+    projectAdviceForDependencies(':consumer', consumerAdvice),
+    emptyProjectAdviceFor(':producer'),
+  ]
+}

--- a/src/main/kotlin/com/autonomousapps/internal/transform/AndroidTransform.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/transform/AndroidTransform.kt
@@ -318,8 +318,28 @@ internal class AndroidTransform(
       { it.isAnyChange() },
     )
 
+    // TODO(tsr): this results in slightly weird advice, like the following. It's actually unclear which is better.
+    //  ```
+    //  Advice for :consumer
+    //  Existing dependencies which should be modified to be as indicated:
+    //    testImplementation project(':producer') (was implementation)
+    //    testImplementation project(':producer') (was testFixturesImplementation)
+    //  ```
+    //  Compare to the JVM/KMP advice resulting from the same structure:
+    //  ```
+    //  Advice for :consumer
+    //  Unused dependencies which should be removed:
+    //    testFixturesImplementation(project(":producer"))
+    //  Existing dependencies which should be modified to be as indicated:
+    //    testImplementation(project(":producer")) (was implementation)
+    //  ```
+    // See `android.ConcurrentModificationSpec` and `jvm.ConcurrentModificationSpec`.
+    //
     // debugImplementation -> null
-    remove.forEach { theRemove ->
+    val iter = remove.iterator()
+    while (iter.hasNext()) {
+      val theRemove = iter.next()
+
       // null -> fireDebugRuntimeOnly, null -> waterDebugRuntimeOnly
       val adds = add.filterToSet { theAdd -> theAdd.coordinates == theRemove.coordinates }
       if (adds.size > 1) {
@@ -332,7 +352,7 @@ internal class AndroidTransform(
         if (toConfiguration != null) {
           advice.removeAll(adds)
           advice -= theRemove
-          remove -= theRemove
+          iter.remove()
 
           advice += Advice.ofChange(
             coordinates = theRemove.coordinates,
@@ -347,7 +367,7 @@ internal class AndroidTransform(
         // Replace add + remove => change.
         advice -= theAdd
         advice -= theRemove
-        remove -= theRemove
+        iter.remove()
 
         advice += Advice.ofChange(
           coordinates = theRemove.coordinates,

--- a/src/main/kotlin/com/autonomousapps/internal/transform/JvmTransform.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/transform/JvmTransform.kt
@@ -279,6 +279,7 @@ internal class JvmTransform(
    * dependencies.
    */
   private fun simplify(advice: MutableSet<Advice>): Set<Advice> {
+    // TODO(tsr): This top part is identical to KmpTransform
     val (add, remove) = advice.mutPartitionOf(
       { it.isAdd() || it.isCompileOnly() },
       { it.isRemove() || it.isRemoveCompileOnly() },

--- a/src/main/kotlin/com/autonomousapps/internal/transform/KmpTransform.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/transform/KmpTransform.kt
@@ -279,6 +279,7 @@ internal class KmpTransform(
    * dependencies.
    */
   private fun simplify(advice: MutableSet<Advice>): Set<Advice> {
+    // TODO(tsr): This top part is identical to JvmTransform
     val (add, remove) = advice.mutPartitionOf(
       { it.isAdd() || it.isCompileOnly() },
       { it.isRemove() || it.isRemoveCompileOnly() },


### PR DESCRIPTION
Resolves https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1747

Note that the original issue was reported on a non-Android project, and that issue was no longer reproducible. This PR fixes the remaining issue for Android (non-KMP) projects.