### PR TITLE
fix: stop checking for missing runtime exceptions.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/ExceptionsAreSpecialSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/ExceptionsAreSpecialSpec.groovy
@@ -4,10 +4,12 @@ package com.autonomousapps.jvm
 
 import com.autonomousapps.jvm.projects.ExceptionsAreSpecialProject
 import com.autonomousapps.utils.Colors
+import spock.lang.Ignore
 
 import static com.autonomousapps.utils.Runner.build
 import static com.google.common.truth.Truth.assertThat
 
+@Ignore("This feature is buggy and really complex to get right for limited utility")
 class ExceptionsAreSpecialSpec extends AbstractJvmSpec {
 
   @SuppressWarnings('GroovyAssignabilityCheck')

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeUsagesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeUsagesTask.kt
@@ -264,7 +264,8 @@ private class GraphVisitor(
         }
 
         is ExceptionCapability -> {
-          hasReferencedExceptionType = isForMissingRuntimeException(dependencyCoordinates, capability, context)
+          // TODO(tsr): this feature is buggy and really complex to get right for limited utility.
+          //hasReferencedExceptionType = isForMissingRuntimeException(dependencyCoordinates, capability, context)
         }
 
         is InferredCapability -> {


### PR DESCRIPTION
Sadly, this feature has some bugs and I don't think it's worth investing the time into fixing them right now.