### PR TITLE
Close leaked `ZipFile` objects

### DIFF
--- a/src/main/kotlin/com/autonomousapps/tasks/DiscoverClasspathDuplicationTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/DiscoverClasspathDuplicationTask.kt
@@ -105,14 +105,15 @@ public abstract class DiscoverClasspathDuplicationTask : DefaultTask() {
     }
 
     private fun inspectJar(artifact: ResolvedArtifactResult) {
-      val zip = ZipFile(artifact.file)
+      ZipFile(artifact.file).use { zip ->
 
-      val coordinates = artifact.toCoordinates()
+        val coordinates = artifact.toCoordinates()
 
-      // Create multimap of class name to [dependencies]
-      zip.asSequenceOfClassFiles()
-        .map(ZipEntry::getName)
-        .forEach { duplicatesMap.put(it, coordinates) }
+        // Create multimap of class name to [dependencies]
+        zip.asSequenceOfClassFiles()
+          .map(ZipEntry::getName)
+          .forEach { duplicatesMap.put(it, coordinates) }
+      }
     }
   }
 }

--- a/src/main/kotlin/com/autonomousapps/tasks/FindAndroidLinters.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindAndroidLinters.kt
@@ -66,7 +66,7 @@ public abstract class FindAndroidLinters : DefaultTask() {
   }
 
   private fun findLintRegistry(jar: File): String {
-    return ZipFile(jar).use { zip ->
+    ZipFile(jar).use { zip ->
 
       val manifestEntry: String? = zip.getEntry(MANIFEST_PATH)?.run {
         zip.getInputStream(this).bufferedReader().use(BufferedReader::readLines)
@@ -74,14 +74,14 @@ public abstract class FindAndroidLinters : DefaultTask() {
           ?.substringAfter(":")
           ?.trim()
       }
-      if (manifestEntry != null) return@use manifestEntry
+      if (manifestEntry != null) return manifestEntry
 
       val serviceEntry: String? = zip.getEntry(LINT_ISSUE_REGISTRY_PATH)?.run {
         zip.getInputStream(this).bufferedReader().use(BufferedReader::readLines)
           .first()
           .trim()
       }
-      if (serviceEntry != null) return@use serviceEntry
+      if (serviceEntry != null) return serviceEntry
 
       // One of the above should be non-null
       throw GradleException("No linter issue registry for ${jar.path}")

--- a/src/main/kotlin/com/autonomousapps/tasks/FindAndroidLinters.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindAndroidLinters.kt
@@ -66,24 +66,25 @@ public abstract class FindAndroidLinters : DefaultTask() {
   }
 
   private fun findLintRegistry(jar: File): String {
-    val zip = ZipFile(jar)
+    return ZipFile(jar).use { zip ->
 
-    val manifestEntry: String? = zip.getEntry(MANIFEST_PATH)?.run {
-      zip.getInputStream(this).bufferedReader().use(BufferedReader::readLines)
-        .find { it.startsWith("Lint-Registry") }
-        ?.substringAfter(":")
-        ?.trim()
+      val manifestEntry: String? = zip.getEntry(MANIFEST_PATH)?.run {
+        zip.getInputStream(this).bufferedReader().use(BufferedReader::readLines)
+          .find { it.startsWith("Lint-Registry") }
+          ?.substringAfter(":")
+          ?.trim()
+      }
+      if (manifestEntry != null) return@use manifestEntry
+
+      val serviceEntry: String? = zip.getEntry(LINT_ISSUE_REGISTRY_PATH)?.run {
+        zip.getInputStream(this).bufferedReader().use(BufferedReader::readLines)
+          .first()
+          .trim()
+      }
+      if (serviceEntry != null) return@use serviceEntry
+
+      // One of the above should be non-null
+      throw GradleException("No linter issue registry for ${jar.path}")
     }
-    if (manifestEntry != null) return manifestEntry
-
-    val serviceEntry: String? = zip.getEntry(LINT_ISSUE_REGISTRY_PATH)?.run {
-      zip.getInputStream(this).bufferedReader().use(BufferedReader::readLines)
-        .first()
-        .trim()
-    }
-    if (serviceEntry != null) return serviceEntry
-
-    // One of the above should be non-null
-    throw GradleException("No linter issue registry for ${jar.path}")
   }
 }

--- a/src/main/kotlin/com/autonomousapps/tasks/FindDeclaredProcsTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindDeclaredProcsTask.kt
@@ -137,7 +137,7 @@ public abstract class FindDeclaredProcsTask : DefaultTask() {
 
   private fun findProcs(file: File): List<String>? {
     return ZipFile(file).use { zip ->
-      return@use zip.getEntry(ANNOTATION_PROCESSOR_PATH)?.let { entry ->
+      zip.getEntry(ANNOTATION_PROCESSOR_PATH)?.let { entry ->
         zip.getInputStream(entry).bufferedReader().use(BufferedReader::readLines)
           // Filter out comments. For example, log4j-core has a license header in this file.
           .filterNot { line -> line.trim().startsWith("#") }

--- a/src/main/kotlin/com/autonomousapps/tasks/FindDeclaredProcsTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindDeclaredProcsTask.kt
@@ -136,14 +136,15 @@ public abstract class FindDeclaredProcsTask : DefaultTask() {
   }
 
   private fun findProcs(file: File): List<String>? {
-    val zip = ZipFile(file)
-    return zip.getEntry(ANNOTATION_PROCESSOR_PATH)?.let { entry ->
-      zip.getInputStream(entry).bufferedReader().use(BufferedReader::readLines)
-        // Filter out comments. For example, log4j-core has a license header in this file.
-        .filterNot { line -> line.trim().startsWith("#") }
-        .map(String::trim)
-        // Filter out blank lines
-        .filter(String::isNotBlank)
+    return ZipFile(file).use { zip ->
+      return@use zip.getEntry(ANNOTATION_PROCESSOR_PATH)?.let { entry ->
+        zip.getInputStream(entry).bufferedReader().use(BufferedReader::readLines)
+          // Filter out comments. For example, log4j-core has a license header in this file.
+          .filterNot { line -> line.trim().startsWith("#") }
+          .map(String::trim)
+          // Filter out blank lines
+          .filter(String::isNotBlank)
+      }
     }
   }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/FindServiceLoadersTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindServiceLoadersTask.kt
@@ -64,9 +64,9 @@ public abstract class FindServiceLoadersTask : DefaultTask() {
   // 1. META-INF/services/kotlinx.coroutines.internal.MainDispatcherFactory
   // 2. META-INF/services/kotlinx.coroutines.CoroutineExceptionHandler
   private fun findServiceLoaders(artifact: ResolvedArtifactResult): Set<ServiceLoaderDependency> {
-    return ZipFile(artifact.file).use { zip ->
+    ZipFile(artifact.file).use { zip ->
 
-      return@use zip.entries().asSequence()
+      return zip.entries().asSequence()
         .filter { it.name.startsWith(SERVICE_LOADER_PATH) }
         .filterNot { it.name.startsWith(ANNOTATION_PROCESSOR_PATH) }
         .filterNot { it.isDirectory }

--- a/src/main/kotlin/com/autonomousapps/tasks/FindServiceLoadersTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindServiceLoadersTask.kt
@@ -64,39 +64,40 @@ public abstract class FindServiceLoadersTask : DefaultTask() {
   // 1. META-INF/services/kotlinx.coroutines.internal.MainDispatcherFactory
   // 2. META-INF/services/kotlinx.coroutines.CoroutineExceptionHandler
   private fun findServiceLoaders(artifact: ResolvedArtifactResult): Set<ServiceLoaderDependency> {
-    val zip = ZipFile(artifact.file)
+    return ZipFile(artifact.file).use { zip ->
 
-    return zip.entries().asSequence()
-      .filter { it.name.startsWith(SERVICE_LOADER_PATH) }
-      .filterNot { it.name.startsWith(ANNOTATION_PROCESSOR_PATH) }
-      .filterNot { it.isDirectory }
-      .mapNotNull { serviceFile ->
-        val providerClasses = zip.getInputStream(serviceFile)
-          .bufferedReader().use(BufferedReader::readLines).asSequence()
-          // remove whitespace
-          .map(String::trim)
-          // remove blank lines
-          .filterNot(String::isBlank)
-          // ignore comments
-          .filter { !it.startsWith("#") }
-          .toSortedSet()
+      return@use zip.entries().asSequence()
+        .filter { it.name.startsWith(SERVICE_LOADER_PATH) }
+        .filterNot { it.name.startsWith(ANNOTATION_PROCESSOR_PATH) }
+        .filterNot { it.isDirectory }
+        .mapNotNull { serviceFile ->
+          val providerClasses = zip.getInputStream(serviceFile)
+            .bufferedReader().use(BufferedReader::readLines).asSequence()
+            // remove whitespace
+            .map(String::trim)
+            // remove blank lines
+            .filterNot(String::isBlank)
+            // ignore comments
+            .filter { !it.startsWith("#") }
+            .toSortedSet()
 
-        // Unclear why this would ever be empty.
-        // See https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/780
-        if (providerClasses.isNotEmpty()) {
-          ServiceLoaderDependency.newInstance(
-            providerFile = serviceFile.name.removePrefix(SERVICE_LOADER_PATH),
-            providerClasses = providerClasses,
-            artifact = artifact
-          )
-        } else {
-          val contents = zip.getInputStream(serviceFile).bufferedReader().use(BufferedReader::readText)
-          logger.debug(
-            "${artifact.file.name} has a services file at path ${serviceFile.name}, but there are no services! " +
-              "File contents:\n<<$contents>>"
-          )
-          null
-        }
-      }.toSortedSet()
+          // Unclear why this would ever be empty.
+          // See https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/780
+          if (providerClasses.isNotEmpty()) {
+            ServiceLoaderDependency.newInstance(
+              providerFile = serviceFile.name.removePrefix(SERVICE_LOADER_PATH),
+              providerClasses = providerClasses,
+              artifact = artifact
+            )
+          } else {
+            val contents = zip.getInputStream(serviceFile).bufferedReader().use(BufferedReader::readText)
+            logger.debug(
+              "${artifact.file.name} has a services file at path ${serviceFile.name}, but there are no services! " +
+                "File contents:\n<<$contents>>"
+            )
+            null
+          }
+        }.toSortedSet()
+    }
   }
 }

--- a/src/main/kotlin/com/autonomousapps/tasks/FindServiceLoadersTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindServiceLoadersTask.kt
@@ -64,9 +64,9 @@ public abstract class FindServiceLoadersTask : DefaultTask() {
   // 1. META-INF/services/kotlinx.coroutines.internal.MainDispatcherFactory
   // 2. META-INF/services/kotlinx.coroutines.CoroutineExceptionHandler
   private fun findServiceLoaders(artifact: ResolvedArtifactResult): Set<ServiceLoaderDependency> {
-    ZipFile(artifact.file).use { zip ->
+    return ZipFile(artifact.file).use { zip ->
 
-      return zip.entries().asSequence()
+      zip.entries().asSequence()
         .filter { it.name.startsWith(SERVICE_LOADER_PATH) }
         .filterNot { it.name.startsWith(ANNOTATION_PROCESSOR_PATH) }
         .filterNot { it.isDirectory }


### PR DESCRIPTION
Currently, several `ZipFile` objects are leaking on each run of `buildHealth`. This PR closes those leaks.

Repro Steps:
- Setup DAGP on a project (latest snapshot is fine)
- Add the [File Leak Detector jar](https://repo1.maven.org/maven2/io/jenkins/tools/file-leak-detector/1.20/file-leak-detector-1.20-jar-with-dependencies.jar) as a java agent to the Gradle daemon
  - Example: `org.gradle.jvmargs=-Xmx8g -javaagent:/home/pablo/file-leak-detector-1.20-jar-with-dependencies.jar=http=19999,strong`
- Sync the project
- Open http://localhost:19999
  - Observe that only some files are open (expected)
- Run `buildHealth` on the project
  - Observe that the number of open files has increased
- Re-run `buildHealth`
  - Observe that the number of open files has roughly doubled

Investigation shows these were basically the only leaks in the project.

Before fix
| buildHealth run 1 | buildHealth run 2 |
| :---: | :----: |
| <img width="321" height="99" alt="Screenshot from 2026-07-10 01-04-11" src="https://github.com/user-attachments/assets/f3362654-0633-4484-8186-71403e8dd55c" /> | <img width="321" height="99" alt="Screenshot from 2026-07-10 01-05-57" src="https://github.com/user-attachments/assets/a01c249e-5277-44c5-98f1-d4b85743e2e2" /> |

After fix
| buildHealth run 1 | buildHealth run 2 |
| :---: | :----: |
| <img width="321" height="99" alt="image" src="https://github.com/user-attachments/assets/602f6bdc-af71-49ee-98e8-54d69a899520" /> | <img width="321" height="99" alt="image" src="https://github.com/user-attachments/assets/3fe6c184-8921-4865-a0a7-99a1f23c9d98" /> |