### PR TITLE
Fix ConcurrentModificationException in AndroidTransform.simplify

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/transform/AndroidTransform.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/transform/AndroidTransform.kt
@@ -386,14 +386,16 @@ internal class AndroidTransform(
     // block below handles this by checking change/add advice to see if they're for the same source kind and product
     // flavor and, if so, removing them.
     // See `ProductFlavorsAndBuildTypesSpec`.
-    change.forEach { theChange ->
+    val changeIter = change.iterator()
+    while (changeIter.hasNext()) {
+      val theChange = changeIter.next()
       val configurationName = theChange.fromConfiguration!!
       val theChangeSourceKind = configurationNames
         .sourceKindFrom(configurationName, false)
         // We only care about the `kind` (MAIN, TEST, etc.), not full equality of SourceKind.
         ?.kind
       // If it's null, can't make a reasonable equality check, so exit.
-        ?: return@forEach
+        ?: continue
 
       val theChangeFlavor = configurationNames.findProductFlavorFrom(configurationName)
       val theChangeBuildType = configurationNames.findBuildTypeFrom(configurationName)
@@ -422,7 +424,7 @@ internal class AndroidTransform(
 
       if (removed) {
         advice -= theChange
-        change -= theChange
+        changeIter.remove()
       }
     }
 


### PR DESCRIPTION
When adding the `v3.16.1` version of the plugin to a private Android project, running `./gradlew :buildHealth` leads to the following exception:

```
Caused by: java.util.ConcurrentModificationException
        at com.autonomousapps.internal.transform.AndroidTransform.simplify(AndroidTransform.kt:522)
        at com.autonomousapps.internal.transform.AndroidTransform.reduce(AndroidTransform.kt:112)
        at com.autonomousapps.tasks.DependencyAdviceBuilder.computeDependencyAdvice$lambda$1(ComputeAdviceTask.kt:353)
        at kotlin.sequences.FlatteningSequence$iterator$1.ensureItemIterator(Sequences.kt:363)
        at kotlin.sequences.FlatteningSequence$iterator$1.hasNext(Sequences.kt:351)
        at kotlin.sequences.TransformingSequence$iterator$1.hasNext(Sequences.kt:247)
        at kotlin.sequences.FilteringSequence$iterator$1.calcNext(Sequences.kt:202)
        at kotlin.sequences.FilteringSequence$iterator$1.hasNext(Sequences.kt:227)
        at kotlin.sequences.FlatteningSequence$iterator$1.ensureItemIterator(Sequences.kt:356)
        at kotlin.sequences.FlatteningSequence$iterator$1.hasNext(Sequences.kt:351)
        at kotlin.sequences.SequencesKt___SequencesKt.toCollection(_Sequences.kt:806)
        at kotlin.sequences.SequencesKt___SequencesJvmKt.toSortedSet(_SequencesJvm.kt:49)
        at com.autonomousapps.tasks.DependencyAdviceBuilder.<init>(ComputeAdviceTask.kt:326)
        at com.autonomousapps.tasks.ComputeAdviceTask$ComputeAdviceAction.execute(ComputeAdviceTask.kt:220)
        at org.gradle.workers.internal.DefaultWorkerServer.execute(DefaultWorkerServer.java:68)
        at org.gradle.workers.internal.NoIsolationWorkerFactory$1$1.create(NoIsolationWorkerFactory.java:64)
        at org.gradle.workers.internal.NoIsolationWorkerFactory$1$1.create(NoIsolationWorkerFactory.java:61)
        at org.gradle.internal.classloader.ClassLoaderUtils.executeInClassloader(ClassLoaderUtils.java:102)
        at org.gradle.workers.internal.NoIsolationWorkerFactory$1.lambda$execute$0(NoIsolationWorkerFactory.java:61)
        at org.gradle.workers.internal.AbstractWorker$1.call(AbstractWorker.java:44)
        at org.gradle.workers.internal.AbstractWorker$1.call(AbstractWorker.java:41)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:210)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:205)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:67)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:60)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:167)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:60)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:54)
        at org.gradle.workers.internal.AbstractWorker.executeWrappedInBuildOperation(AbstractWorker.java:41)
        at org.gradle.workers.internal.NoIsolationWorkerFactory$1.execute(NoIsolationWorkerFactory.java:58)
        at org.gradle.workers.internal.DefaultWorkerExecutor.lambda$submitWork$0(DefaultWorkerExecutor.java:174)
        at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.runExecution(DefaultConditionalExecutionQueue.java:191)
        at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.access$500(DefaultConditionalExecutionQueue.java:112)
        at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner$1.run(DefaultConditionalExecutionQueue.java:168)
        at org.gradle.internal.Factories$1.create(Factories.java:30)
        at org.gradle.internal.work.DefaultWorkerLeaseService.lambda$withLocksAcquired$0(DefaultWorkerLeaseService.java:280)
        at org.gradle.internal.work.ResourceLockStatistics$1.measure(ResourceLockStatistics.java:43)
        at org.gradle.internal.work.DefaultWorkerLeaseService.withLocksAcquired(DefaultWorkerLeaseService.java:278)
        at org.gradle.internal.work.DefaultWorkerLeaseService.withLocks(DefaultWorkerLeaseService.java:270)
        at org.gradle.internal.work.DefaultWorkerLeaseService.runAsWorkerThread(DefaultWorkerLeaseService.java:129)
        at org.gradle.internal.work.DefaultWorkerLeaseService.runAsWorkerThread(DefaultWorkerLeaseService.java:134)
        at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.runBatch(DefaultConditionalExecutionQueue.java:163)
        at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.run(DefaultConditionalExecutionQueue.java:125)
        ... 2 more
```

The exact fix is a copy of the existing fix for a similar issue - https://github.com/autonomousapps/dependency-analysis-gradle-plugin/pull/1762/changes