### PR TITLE
fix: make GraphViewTask sensitive to new transitive project edges

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/GraphViewProjectEdgeCacheSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/GraphViewProjectEdgeCacheSpec.groovy
@@ -1,0 +1,40 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.jvm
+
+import com.autonomousapps.jvm.projects.GraphViewProjectEdgeCacheProject
+import org.gradle.util.GradleVersion
+
+import static com.autonomousapps.kit.truth.BuildTaskSubject.buildTasks
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertAbout
+import static com.google.common.truth.Truth.assertThat
+
+final class GraphViewProjectEdgeCacheSpec extends AbstractJvmSpec {
+
+  def "graphViewTask is sensitive to new transitive project edges"() {
+    given:
+    def project = new GraphViewProjectEdgeCacheProject()
+    gradleProject = project.gradleProject
+    def task = ':consumer:graphViewMain'
+    def gradleVersion = GradleVersion.current()
+    def graphOutput = new File(
+      gradleProject.rootDir,
+      'consumer/build/reports/dependency-analysis/main/graph/graph-compile.json'
+    )
+
+    when: 'First build, without the middle -> leaf edge'
+    def result = build(gradleVersion, gradleProject.rootDir, task, '--build-cache')
+
+    then: 'Task executed and leaf is not in the graph'
+    assertAbout(buildTasks()).that(result.task(task)).succeeded()
+    assertThat(graphOutput.text).doesNotContain(':leaf')
+
+    when: 'Second build, after an upstream project adds an api dependency on leaf'
+    result = build(gradleVersion, gradleProject.rootDir, 'clean', task, '--build-cache', '-Dedge=true')
+
+    then: 'Task executed (not FROM_CACHE) and leaf is in the graph'
+    assertAbout(buildTasks()).that(result.task(task)).succeeded()
+    assertThat(graphOutput.text).contains(':leaf')
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/GraphViewProjectEdgeCacheProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/GraphViewProjectEdgeCacheProject.groovy
@@ -1,0 +1,88 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.kit.gradle.SettingsScript
+
+final class GraphViewProjectEdgeCacheProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  GraphViewProjectEdgeCacheProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newGradleProjectBuilder()
+      .withRootProject { s ->
+        s.settingsScript = new SettingsScript().tap {
+          // Since this test exercises the build cache, we can't rely on the default location
+          additions = """
+          buildCache {
+            local {
+              directory = new File(rootDir, 'build-cache')
+            }
+          }""".stripIndent()
+        }
+      }
+      .withSubproject('consumer') { s ->
+        s.sources = [CONSUMER_SOURCE]
+        s.withBuildScript { bs ->
+          bs.plugins = kotlin
+          bs.withGroovy("""\
+          dependencies {
+            implementation project(':middle')
+          }""")
+        }
+      }
+      .withSubproject('middle') { s ->
+        s.sources = [MIDDLE_SOURCE]
+        s.withBuildScript { bs ->
+          bs.plugins = kotlinOnly
+          // The system property models an upstream change adding a project edge: the
+          // consumer's own build script and declarations are untouched by it.
+          bs.withGroovy("""\
+          if (providers.systemProperty('edge').present) {
+            dependencies {
+              api project(':leaf')
+            }
+          }""")
+        }
+      }
+      .withSubproject('leaf') { s ->
+        s.sources = [LEAF_SOURCE]
+        s.withBuildScript { bs ->
+          bs.plugins = kotlinOnly
+        }
+      }
+      .write()
+  }
+
+  private static final Source CONSUMER_SOURCE = new Source(
+    SourceType.KOTLIN, 'Main', 'com/example',
+    """\
+      package com.example
+      
+      class Main""".stripIndent()
+  )
+
+  private static final Source MIDDLE_SOURCE = new Source(
+    SourceType.KOTLIN, 'Middle', 'com/example/middle',
+    """\
+      package com.example.middle
+      
+      class Middle""".stripIndent()
+  )
+
+  private static final Source LEAF_SOURCE = new Source(
+    SourceType.KOTLIN, 'Leaf', 'com/example/leaf',
+    """\
+      package com.example.leaf
+      
+      class Leaf""".stripIndent()
+  )
+}

--- a/src/main/kotlin/com/autonomousapps/tasks/GraphViewTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/GraphViewTask.kt
@@ -8,6 +8,7 @@ import com.autonomousapps.internal.graph.GraphWriter
 import com.autonomousapps.internal.utils.bufferWriteJson
 import com.autonomousapps.internal.utils.getAndDelete
 import com.autonomousapps.internal.utils.mapNotNullToSet
+import com.autonomousapps.internal.utils.mapToOrderedSet
 import com.autonomousapps.internal.utils.toCoordinates
 import com.autonomousapps.model.Coordinates
 import com.autonomousapps.model.CoordinatesContainer
@@ -18,6 +19,7 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.FileCollectionDependency
 import org.gradle.api.artifacts.result.ResolvedComponentResult
+import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
@@ -64,6 +66,19 @@ public abstract class GraphViewTask : DefaultTask() {
   @get:PathSensitive(PathSensitivity.NONE)
   @get:InputFile
   public abstract val declarations: RegularFileProperty
+
+  /**
+   * Unused, except to influence the up-to-date-ness of this task. [compileFiles] contains external artifacts only and
+   * [declarations] covers only this project's own declarations, so without this input a transitive project dependency
+   * added by an upstream project would not change any tracked input, and a stale graph would be replayed from the
+   * build cache (or the task would be UP-TO-DATE).
+   */
+  @get:Input
+  public abstract val compileClasspathComponentIds: SetProperty<String>
+
+  /** See [compileClasspathComponentIds]. */
+  @get:Input
+  public abstract val runtimeClasspathComponentIds: SetProperty<String>
 
   /** Needed to make sure task gives the same result if the build configuration in a composite changed between runs. */
   @get:Input
@@ -118,8 +133,29 @@ public abstract class GraphViewTask : DefaultTask() {
         .mapNotNullToSet { it.toCoordinates() }
     })
 
+    compileClasspathComponentIds.set(compileClasspathResult.map { it.allComponentIds() })
+    runtimeClasspathComponentIds.set(runtimeClasspathResult.map { it.allComponentIds() })
+
     compileFiles.setFrom(project.provider { compileClasspath.externalArtifactsFor(jarAttr).artifactFiles })
     runtimeFiles.setFrom(project.provider { runtimeClasspath.externalArtifactsFor(jarAttr).artifactFiles })
+  }
+
+  private companion object {
+    private fun ResolvedComponentResult.allComponentIds(): Set<String> {
+      val visited = mutableSetOf<ResolvedComponentResult>()
+      val queue = ArrayDeque<ResolvedComponentResult>()
+      queue.add(this)
+
+      while (queue.isNotEmpty()) {
+        val node = queue.removeFirst()
+        if (!visited.add(node)) continue
+        node.dependencies.asSequence()
+          .filterIsInstance<ResolvedDependencyResult>()
+          .forEach { queue.add(it.selected) }
+      }
+
+      return visited.mapToOrderedSet { it.id.displayName }
+    }
   }
 
   @TaskAction public fun action() {


### PR DESCRIPTION
opened by mistake