### PR TITLE
fix: make GraphViewTask sensitive to new transitive project edges

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/GraphViewProjectEdgeCacheSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/GraphViewProjectEdgeCacheSpec.groovy
@@ -1,0 +1,63 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.jvm
+
+import com.autonomousapps.jvm.projects.GraphViewProjectEdgeCacheProject
+import com.autonomousapps.model.Advice
+import org.gradle.util.GradleVersion
+
+import static com.autonomousapps.AdviceHelper.projectCoordinates
+import static com.autonomousapps.kit.truth.BuildTaskSubject.buildTasks
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertAbout
+import static com.google.common.truth.Truth.assertThat
+
+final class GraphViewProjectEdgeCacheSpec extends AbstractJvmSpec {
+
+  def "graphViewTask is sensitive to new transitive project edges"() {
+    given:
+    def project = new GraphViewProjectEdgeCacheProject()
+    gradleProject = project.gradleProject
+    def task = ':consumer:graphViewMain'
+    def gradleVersion = GradleVersion.current()
+    def graphOutput = new File(
+      gradleProject.rootDir,
+      'consumer/build/reports/dependency-analysis/main/graph/graph-compile.json'
+    )
+
+    when: 'First build, without the direct -> transitive edge'
+    def result = build(gradleVersion, gradleProject.rootDir, task, '--build-cache')
+
+    then: 'Task executed and transitive is not in the graph'
+    assertAbout(buildTasks()).that(result.task(task)).succeeded()
+    assertThat(graphOutput.text).doesNotContain(':transitive')
+
+    when: 'Second build, after the direct project adds an api dependency on transitive'
+    result = build(gradleVersion, gradleProject.rootDir, 'clean', task, '--build-cache', '-Dedge=true')
+
+    then: 'Task executed (not FROM_CACHE) and transitive is in the graph'
+    assertAbout(buildTasks()).that(result.task(task)).succeeded()
+    assertThat(graphOutput.text).contains(':transitive')
+  }
+
+  def "stale project graph does not suppress dependency advice"() {
+    given:
+    def project = new GraphViewProjectEdgeCacheProject()
+    gradleProject = project.gradleProject
+    def task = ':consumer:projectHealth'
+    def gradleVersion = GradleVersion.current()
+
+    when: 'First build, without the direct -> transitive edge'
+    build(gradleVersion, gradleProject.rootDir, task, '--build-cache')
+
+    then: 'There is no advice'
+    assertThat(actualProjectAdvice('consumer').dependencyAdvice).isEmpty()
+
+    when: 'Second build, after the direct project adds an api dependency on transitive'
+    build(gradleVersion, gradleProject.rootDir, 'clean', task, '--build-cache', '-Dedge=true')
+
+    then: 'DAGP advises declaring the used transitive dependency directly'
+    assertThat(actualProjectAdvice('consumer').dependencyAdvice)
+      .containsExactly(Advice.ofAdd(projectCoordinates(':transitive'), 'implementation'))
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/GraphViewProjectEdgeCacheProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/GraphViewProjectEdgeCacheProject.groovy
@@ -1,0 +1,108 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.kit.gradle.SettingsScript
+
+final class GraphViewProjectEdgeCacheProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  GraphViewProjectEdgeCacheProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newGradleProjectBuilder()
+      .withRootProject { s ->
+        s.settingsScript = new SettingsScript().tap {
+          // Since this test exercises the build cache, we can't rely on the default location
+          additions = """
+          buildCache {
+            local {
+              directory = new File(rootDir, 'build-cache')
+            }
+          }""".stripIndent()
+        }
+      }
+      .withSubproject('consumer') { s ->
+        s.sources = [CONSUMER_SOURCE]
+        s.withFile(
+          'src/edge/kotlin/com/example/UsesTransitive.kt',
+          """\
+          package com.example
+
+          import com.example.transitive.Transitive
+
+          class UsesTransitive {
+            private val transitive = Transitive()
+          }
+          """.stripIndent()
+        )
+        s.withBuildScript { bs ->
+          bs.plugins = kotlin
+          bs.withGroovy("""\
+          if (providers.systemProperty('edge').present) {
+            sourceSets.main.kotlin.srcDir('src/edge/kotlin')
+          }
+
+          dependencies {
+            implementation project(':direct')
+          }""")
+        }
+      }
+      .withSubproject('direct') { s ->
+        s.sources = [DIRECT_SOURCE]
+        s.withBuildScript { bs ->
+          bs.plugins = kotlinOnly
+          // The system property models an upstream change adding a project edge: the
+          // consumer's own build script and declarations are untouched by it.
+          bs.withGroovy("""\
+          if (providers.systemProperty('edge').present) {
+            dependencies {
+              api project(':transitive')
+            }
+          }""")
+        }
+      }
+      .withSubproject('transitive') { s ->
+        s.sources = [TRANSITIVE_SOURCE]
+        s.withBuildScript { bs ->
+          bs.plugins = kotlinOnly
+        }
+      }
+      .write()
+  }
+
+  private static final Source CONSUMER_SOURCE = new Source(
+    SourceType.KOTLIN, 'Main', 'com/example',
+    """\
+      package com.example
+
+      import com.example.direct.Direct
+      
+      class Main {
+        private val direct = Direct()
+      }""".stripIndent()
+  )
+
+  private static final Source DIRECT_SOURCE = new Source(
+    SourceType.KOTLIN, 'Direct', 'com/example/direct',
+    """\
+      package com.example.direct
+      
+      class Direct""".stripIndent()
+  )
+
+  private static final Source TRANSITIVE_SOURCE = new Source(
+    SourceType.KOTLIN, 'Transitive', 'com/example/transitive',
+    """\
+      package com.example.transitive
+      
+      class Transitive""".stripIndent()
+  )
+}

--- a/src/main/kotlin/com/autonomousapps/tasks/GraphViewTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/GraphViewTask.kt
@@ -8,6 +8,7 @@ import com.autonomousapps.internal.graph.GraphWriter
 import com.autonomousapps.internal.utils.bufferWriteJson
 import com.autonomousapps.internal.utils.getAndDelete
 import com.autonomousapps.internal.utils.mapNotNullToSet
+import com.autonomousapps.internal.utils.mapToOrderedSet
 import com.autonomousapps.internal.utils.toCoordinates
 import com.autonomousapps.model.Coordinates
 import com.autonomousapps.model.CoordinatesContainer
@@ -18,6 +19,7 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.FileCollectionDependency
 import org.gradle.api.artifacts.result.ResolvedComponentResult
+import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
@@ -64,6 +66,14 @@ public abstract class GraphViewTask : DefaultTask() {
   @get:PathSensitive(PathSensitivity.NONE)
   @get:InputFile
   public abstract val declarations: RegularFileProperty
+
+  /** Tracks resolved components so project dependency changes invalidate this task. */
+  @get:Input
+  public abstract val compileClasspathComponentIds: SetProperty<String>
+
+  /** See [compileClasspathComponentIds]. */
+  @get:Input
+  public abstract val runtimeClasspathComponentIds: SetProperty<String>
 
   /** Needed to make sure task gives the same result if the build configuration in a composite changed between runs. */
   @get:Input
@@ -118,6 +128,9 @@ public abstract class GraphViewTask : DefaultTask() {
         .mapNotNullToSet { it.toCoordinates() }
     })
 
+    compileClasspathComponentIds.set(compileClasspathResult.map { it.allComponentIds() })
+    runtimeClasspathComponentIds.set(runtimeClasspathResult.map { it.allComponentIds() })
+
     compileFiles.setFrom(project.provider { compileClasspath.externalArtifactsFor(jarAttr).artifactFiles })
     runtimeFiles.setFrom(project.provider { runtimeClasspath.externalArtifactsFor(jarAttr).artifactFiles })
   }
@@ -152,4 +165,22 @@ public abstract class GraphViewTask : DefaultTask() {
     outputRuntime.bufferWriteJson(runtimeGraphView)
     outputRuntimeDot.writeText(graphWriter.toDot(runtimeGraph))
   }
+}
+
+private fun ResolvedComponentResult.allComponentIds(): Set<String> {
+  val visited = mutableSetOf<ResolvedComponentResult>()
+  val queue = ArrayDeque<ResolvedComponentResult>()
+  queue.add(this)
+
+  while (queue.isNotEmpty()) {
+    val node = queue.removeFirst()
+    if (!visited.add(node)) {
+      continue
+    }
+    node.dependencies.asSequence()
+      .filterIsInstance<ResolvedDependencyResult>()
+      .forEach { queue.add(it.selected) }
+  }
+
+  return visited.mapToOrderedSet { it.id.displayName }
 }


### PR DESCRIPTION
Fixes #1775.

Adds regression tests demonstrating stale GraphViewTask outputs when an upstream project dependency changes. Fixes the issue by tracking resolved component IDs as task inputs, ensuring those changes invalidate the task’s build cache entry.