### PR TITLE
fix: invalidate artifact reports when resolved versions change

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/ArtifactsReportCacheSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/ArtifactsReportCacheSpec.groovy
@@ -1,0 +1,58 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.jvm
+
+import com.autonomousapps.jvm.projects.ArtifactsReportCacheProject
+
+import static com.autonomousapps.kit.truth.BuildTaskSubject.buildTasks
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertAbout
+import static com.google.common.truth.Truth.assertThat
+
+final class ArtifactsReportCacheSpec extends AbstractJvmSpec {
+
+  def "artifact reports are sensitive to resolved versions (#gradleVersion)"() {
+    given:
+    def project = new ArtifactsReportCacheProject()
+    gradleProject = project.gradleProject
+    def compileTask = ':proj:artifactsReportMain'
+    def runtimeTask = ':proj:artifactsReportRuntimeMain'
+
+    when: 'First build with version 1.0 selected by the BOM'
+    def result = build(gradleVersion, gradleProject.rootDir, ':buildHealth', '-DbomVersion=1.0')
+
+    then: 'Both reports execute and contain version 1.0'
+    assertAbout(buildTasks()).that(result.task(compileTask)).succeeded()
+    assertAbout(buildTasks()).that(result.task(runtimeTask)).succeeded()
+    assertReportsContainVersion(project, '1.0')
+    assertThat(actualProjectAdvice('proj').dependencyAdvice).isEmpty()
+
+    when: 'The build is cleaned and repeated with the same resolved version'
+    result = build(gradleVersion, gradleProject.rootDir, 'clean', ':buildHealth', '-DbomVersion=1.0')
+
+    then: 'The unchanged reports are restored from cache'
+    assertAbout(buildTasks()).that(result.task(compileTask)).fromCache()
+    assertAbout(buildTasks()).that(result.task(runtimeTask)).fromCache()
+    assertReportsContainVersion(project, '1.0')
+    assertThat(actualProjectAdvice('proj').dependencyAdvice).isEmpty()
+
+    when: 'The BOM selects version 2.0 with a byte-identical artifact'
+    result = build(gradleVersion, gradleProject.rootDir, 'clean', ':buildHealth', '-DbomVersion=2.0')
+
+    then: 'Both reports execute with the new identity and advice remains correct'
+    assertAbout(buildTasks()).that(result.task(compileTask)).succeeded()
+    assertAbout(buildTasks()).that(result.task(runtimeTask)).succeeded()
+    assertReportsContainVersion(project, '2.0')
+    assertThat(project.compileArtifactsReport).doesNotContain('"resolvedVersion":"1.0"')
+    assertThat(project.runtimeArtifactsReport).doesNotContain('"resolvedVersion":"1.0"')
+    assertThat(actualProjectAdvice('proj').dependencyAdvice).isEmpty()
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+
+  private static void assertReportsContainVersion(ArtifactsReportCacheProject project, String version) {
+    assertThat(project.compileArtifactsReport).contains("\"resolvedVersion\":\"$version\"")
+    assertThat(project.runtimeArtifactsReport).contains("\"resolvedVersion\":\"$version\"")
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/ArtifactsReportCacheProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/ArtifactsReportCacheProject.groovy
@@ -1,0 +1,195 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.kit.gradle.SettingsScript
+
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+import javax.tools.ToolProvider
+
+final class ArtifactsReportCacheProject extends AbstractProject {
+
+  private static final String ARTIFACTS_PATH = 'reports/dependency-analysis/main/intermediates/artifacts.json'
+  private static final String RUNTIME_ARTIFACTS_PATH =
+    'reports/dependency-analysis/main/intermediates/artifacts-runtime.json'
+
+  final GradleProject gradleProject
+
+  ArtifactsReportCacheProject() {
+    this.gradleProject = build()
+    writeRepository()
+  }
+
+  String getCompileArtifactsReport() {
+    return gradleProject.singleArtifact('proj', ARTIFACTS_PATH).asFile.text
+  }
+
+  String getRuntimeArtifactsReport() {
+    return gradleProject.singleArtifact('proj', RUNTIME_ARTIFACTS_PATH).asFile.text
+  }
+
+  private GradleProject build() {
+    return newGradleProjectBuilder()
+      .withRootProject { s ->
+        s.settingsScript = new SettingsScript().tap {
+          // Since this test exercises the build cache, we can't rely on the default location
+          additions = """
+          buildCache {
+            local {
+              directory = new File(rootDir, 'build-cache')
+            }
+          }""".stripIndent()
+        }
+      }
+      .withSubproject('proj') { s ->
+        s.sources = [SOURCE]
+        s.withBuildScript { bs ->
+          bs.plugins = javaLibrary
+          bs.withGroovy("""\
+          repositories {
+            maven { url = rootProject.file('repository') }
+          }
+
+          dependencies {
+            implementation platform(providers.systemProperty('bomVersion').map { version ->
+              "com.example:fixture-bom:\$version"
+            })
+            implementation 'com.example:fixture-library'
+          }
+
+          def artifactType = Attribute.of('artifactType', String)
+          def normalized = Attribute.of('cache-test-normalized', Boolean)
+          dependencies.attributesSchema { attribute(normalized) }
+          dependencies.artifactTypes.jar.attributes.attribute(normalized, false)
+          dependencies.registerTransform(NormalizeJarTransform) {
+            from.attribute(artifactType, 'jar').attribute(normalized, false)
+            to.attribute(artifactType, 'jar').attribute(normalized, true)
+          }
+
+          afterEvaluate {
+            [
+              artifactsReportMain: configurations.named('compileClasspath'),
+              artifactsReportRuntimeMain: configurations.named('runtimeClasspath'),
+            ].each { taskName, configuration ->
+              tasks.named(taskName) {
+                setConfiguration(configuration) { c ->
+                  c.incoming.artifactView {
+                    attributes.attribute(artifactType, 'jar')
+                    attributes.attribute(normalized, true)
+                    lenient(true)
+                  }.artifacts
+                }
+              }
+            }
+          }
+
+          import org.gradle.api.artifacts.transform.*
+
+          abstract class NormalizeJarTransform implements TransformAction<TransformParameters.None> {
+            @InputArtifact
+            @Classpath
+            abstract Provider<FileSystemLocation> getInputJar()
+
+            @Override
+            void transform(TransformOutputs outputs) {
+              def output = outputs.file('artifact.jar')
+              output.bytes = inputJar.get().asFile.bytes
+            }
+          }""")
+        }
+      }
+      .write()
+  }
+
+  private void writeRepository() {
+    def repository = new File(gradleProject.rootDir, 'repository')
+    def source = new File(gradleProject.rootDir, 'fixture-src/com/example/library/Library.java')
+    def classes = new File(gradleProject.rootDir, 'fixture-classes')
+    source.parentFile.mkdirs()
+    classes.mkdirs()
+    source.text = '''\
+      package com.example.library;
+
+      public final class Library {
+        public static String value() {
+          return "same";
+        }
+      }
+    '''.stripIndent()
+
+    def compiler = ToolProvider.systemJavaCompiler
+    assert compiler != null
+    assert compiler.run(null, null, null, '-d', classes.path, source.path) == 0
+
+    def classFile = new File(classes, 'com/example/library/Library.class')
+    def jarBytes = new ByteArrayOutputStream().withCloseable { bytes ->
+      new JarOutputStream(bytes).withCloseable { jar ->
+        jar.putNextEntry(new JarEntry('com/example/library/Library.class'))
+        jar.write(classFile.bytes)
+        jar.closeEntry()
+      }
+      bytes.toByteArray()
+    }
+
+    ['1.0', '2.0'].each { version ->
+      writeModule(repository, 'fixture-library', version, jarBytes)
+      writeBom(repository, version)
+    }
+  }
+
+  private static void writeModule(File repository, String artifact, String version, byte[] jarBytes) {
+    def moduleDir = new File(repository, "com/example/$artifact/$version")
+    moduleDir.mkdirs()
+    new File(moduleDir, "$artifact-$version.jar").bytes = jarBytes
+    new File(moduleDir, "$artifact-$version.pom").text = """\
+      <project xmlns="http://maven.apache.org/POM/4.0.0">
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>com.example</groupId>
+        <artifactId>$artifact</artifactId>
+        <version>$version</version>
+      </project>
+    """.stripIndent()
+  }
+
+  private static void writeBom(File repository, String version) {
+    def moduleDir = new File(repository, "com/example/fixture-bom/$version")
+    moduleDir.mkdirs()
+    new File(moduleDir, "fixture-bom-$version.pom").text = """\
+      <project xmlns="http://maven.apache.org/POM/4.0.0">
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>com.example</groupId>
+        <artifactId>fixture-bom</artifactId>
+        <version>$version</version>
+        <packaging>pom</packaging>
+        <dependencyManagement>
+          <dependencies>
+            <dependency>
+              <groupId>com.example</groupId>
+              <artifactId>fixture-library</artifactId>
+              <version>$version</version>
+            </dependency>
+          </dependencies>
+        </dependencyManagement>
+      </project>
+    """.stripIndent()
+  }
+
+  private static final Source SOURCE = new Source(
+    SourceType.JAVA, 'Main', 'com/example',
+    '''\
+      package com.example;
+
+      import com.example.library.Library;
+
+      public class Main {
+        public String value() {
+          return Library.value();
+        }
+      }'''.stripIndent()
+  )
+}

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/DependencyAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/DependencyAnalyzer.kt
@@ -228,6 +228,8 @@ internal abstract class AbstractDependencyAnalyzer(
       t.setOpaqueConfiguration(project.configurations.named(compileConfigurationName)) { c ->
         c.opaqueComponentArtifacts()
       }
+      t.artifactIds.addAll(t.artifacts.map { artifacts -> artifacts.map { it.id.displayName } })
+      t.artifactIds.addAll(t.opaqueArtifacts.map { artifacts -> artifacts.map { it.id.displayName } })
       t.buildPath.set(project.buildPath(compileConfigurationName))
 
       t.output.set(outputPaths.compileArtifactsPath)
@@ -243,6 +245,8 @@ internal abstract class AbstractDependencyAnalyzer(
       t.setOpaqueConfiguration(project.configurations.named(runtimeConfigurationName)) { c ->
         c.opaqueComponentArtifacts()
       }
+      t.artifactIds.addAll(t.artifacts.map { artifacts -> artifacts.map { it.id.displayName } })
+      t.artifactIds.addAll(t.opaqueArtifacts.map { artifacts -> artifacts.map { it.id.displayName } })
       t.buildPath.set(project.buildPath(runtimeConfigurationName))
 
       t.output.set(outputPaths.runtimeArtifactsPath)

--- a/src/main/kotlin/com/autonomousapps/tasks/ArtifactsReportTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ArtifactsReportTask.kt
@@ -41,6 +41,10 @@ public abstract class ArtifactsReportTask : DefaultTask() {
   @get:Internal
   public abstract val opaqueArtifacts: Property<ArtifactCollection>
 
+  /** Tracks resolved artifact identities because their coordinates are serialized in [output]. */
+  @get:Input
+  public abstract val artifactIds: SetProperty<String>
+
   /**
    * This is the "official" input for wiring task dependencies correctly, but is otherwise
    * unused. This needs to use [InputFiles] and [PathSensitivity.ABSOLUTE] because the path to the


### PR DESCRIPTION
Add a normalized, order-independent input to `ArtifactsReportTask` that captures the identities of the resolved artifacts whose coordinates are serialized, including both ordinary and opaque artifact collections where applicable. `ArtifactsReportTask` writes resolved coordinates into each `PhysicalArtifact`, but its declared cache inputs cover artifact files, build path, and exclusions rather than the resolved artifact identities used to produce that output.

Happy path: build health with BOM version A, clean, then build with BOM version B whose selected artifact bytes are identical; both compile and runtime artifact-report tasks execute with the new identities, their reports contain version B, and no false unused advice is emitted; Edge cases: exercise the fixture across the repository's supported Gradle-version matrix and verify both ordinary compile/runtime artifacts and any opaque artifact input remain deterministic and order-independent.

Fixes #1426
