### PR TITLE
fix: disable caching for ArtifactsReportTask.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/ClassifiersSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/ClassifiersSpec.groovy
@@ -31,8 +31,10 @@ final class ClassifiersSpec extends AbstractJvmSpec {
     def project = new TransitiveClassifierTestProject(variant)
     gradleProject = project.gradleProject
 
-    when: // TODO(tsr): this test fails if the build cache is enabled
-    build(gradleVersion, gradleProject.rootDir, ':buildHealth', '--no-build-cache')
+    // TODO(tsr): this test fails if `ArtifactsReportTask` has caching enabled.
+    when:
+    build(gradleVersion, gradleProject.rootDir, ':buildHealth')
+//    build(gradleVersion, gradleProject.rootDir, ':buildHealth, '--no-build-cache')
 
     then:
     assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth())

--- a/src/main/kotlin/com/autonomousapps/tasks/ArtifactsReportTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ArtifactsReportTask.kt
@@ -7,7 +7,6 @@ package com.autonomousapps.tasks
 import com.autonomousapps.internal.utils.bufferWriteJsonSet
 import com.autonomousapps.internal.utils.filterNonGradle
 import com.autonomousapps.internal.utils.getAndDelete
-import com.autonomousapps.internal.utils.toJson
 import com.autonomousapps.model.internal.ExcludedIdentifier
 import com.autonomousapps.model.internal.PhysicalArtifact
 import org.gradle.api.DefaultTask
@@ -21,6 +20,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.*
+import org.gradle.work.DisableCachingByDefault
 
 /**
  * Produces a report of all the artifacts required to build the given project; i.e., the artifacts on the compile
@@ -28,7 +28,7 @@ import org.gradle.api.tasks.*
  * the full list of analyzed [Configuration][org.gradle.api.artifacts.Configuration]s. These artifacts are physical
  * files on disk, such as jars.
  */
-@CacheableTask
+@DisableCachingByDefault(because = "When this task participates in the build cache, then `ClassifiersSpec.transitive classifier dependencies do not lead to wrong advice` fails")
 public abstract class ArtifactsReportTask : DefaultTask() {
 
   init {


### PR DESCRIPTION
As a follow-up, investigate how to remove `ArtifactsReportTask` entirely. It relies on absolute path sensitivity for some inputs, which breaks cache relocatability.