### PR TITLE
fix: GraphViewTask's inputs are inputs, not internal details.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/CustomSourceSetSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/CustomSourceSetSpec.groovy
@@ -50,6 +50,7 @@ final class CustomSourceSetSpec extends AbstractJvmSpec {
     gradleProject = project.gradleProject
 
     when: // TODO(tsr): this test fails if the build cache is enabled
+//    build(gradleVersion, gradleProject.rootDir, ':buildHealth')
     build(gradleVersion, gradleProject.rootDir, ':buildHealth', '--no-build-cache')
 
     then:
@@ -144,6 +145,7 @@ final class CustomSourceSetSpec extends AbstractJvmSpec {
     gradleProject = project.gradleProject
 
     when: // TODO(tsr): this test fails if the build cache is enabled
+//    build(gradleVersion, gradleProject.rootDir, ':buildHealth')
     build(gradleVersion, gradleProject.rootDir, ':buildHealth', '--no-build-cache')
 
     then:

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/CustomSourceSetSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/CustomSourceSetSpec.groovy
@@ -49,9 +49,8 @@ final class CustomSourceSetSpec extends AbstractJvmSpec {
     def project = new FeatureVariantTestProject(producerCodeInFeature, additionalCapabilities)
     gradleProject = project.gradleProject
 
-    when: // TODO(tsr): this test fails if the build cache is enabled
-//    build(gradleVersion, gradleProject.rootDir, ':buildHealth')
-    build(gradleVersion, gradleProject.rootDir, ':buildHealth', '--no-build-cache')
+    when:
+    build(gradleVersion, gradleProject.rootDir, ':buildHealth')
 
     then:
     assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth())
@@ -144,9 +143,8 @@ final class CustomSourceSetSpec extends AbstractJvmSpec {
     def project = new FeatureVariantTestProject(true, false, true)
     gradleProject = project.gradleProject
 
-    when: // TODO(tsr): this test fails if the build cache is enabled
-//    build(gradleVersion, gradleProject.rootDir, ':buildHealth')
-    build(gradleVersion, gradleProject.rootDir, ':buildHealth', '--no-build-cache')
+    when:
+    build(gradleVersion, gradleProject.rootDir, ':buildHealth')
 
     then:
     assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth())

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/FeatureVariantTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/FeatureVariantTestProject.groovy
@@ -5,8 +5,6 @@ package com.autonomousapps.jvm.projects
 import com.autonomousapps.AbstractProject
 import com.autonomousapps.kit.GradleProject
 import com.autonomousapps.kit.Source
-import com.autonomousapps.kit.SourceType
-import com.autonomousapps.kit.gradle.Feature
 import com.autonomousapps.kit.gradle.Java
 import com.autonomousapps.model.Advice
 import com.autonomousapps.model.ProjectAdvice
@@ -54,6 +52,7 @@ final class FeatureVariantTestProject extends AbstractProject {
 
   private GradleProject build() {
     def builder = newGradleProjectBuilder()
+
     if (ignoreCustomSourceSet) {
       builder.withRootProject { root ->
         root.withBuildScript { bs ->
@@ -68,71 +67,70 @@ final class FeatureVariantTestProject extends AbstractProject {
         }
       }
     }
-    builder.withSubproject('producer') { s ->
-      s.sources = sources
-      s.withBuildScript { bs ->
-        bs.plugins = javaLibrary
-        bs.java = Java.ofFeatures(Feature.ofName('extraFeature'))
-        bs.dependencies = [
-          commonsCollections('api'),
-          commonsCollections('extraFeatureApi')
-        ]
-        bs.withGroovy('group = "examplegroup"\n' + additionalCapabilities)
-      }
-    }
-    builder.withSubproject('consumer') { s ->
-      s.sources = consumerSources
-      s.withBuildScript { bs ->
-        bs.plugins = javaLibrary
-        bs.dependencies = [
-          producerCodeInFeature
-            ? project('api', ':producer', 'examplegroup:producer-extra-feature')
-            : project('api', ':producer')
-        ]
-      }
-    }
 
-    return builder.write()
+    return builder
+      .withSubproject('producer') { s ->
+        s.sources = sources
+        s.withBuildScript { bs ->
+          bs.plugins = javaLibrary
+          bs.java = Java.ofFeatures('extraFeature')
+          bs.dependencies = [
+            commonsCollections('api'),
+            commonsCollections('extraFeatureApi')
+          ]
+          bs.withGroovy('group = "examplegroup"\n' + additionalCapabilities)
+        }
+      }
+      .withSubproject('consumer') { s ->
+        s.sources = consumerSources
+        s.withBuildScript { bs ->
+          bs.plugins = javaLibrary
+          bs.dependencies = [
+            producerCodeInFeature
+              ? project('api', ':producer', 'examplegroup:producer-extra-feature')
+              : project('api', ':producer')
+          ]
+        }
+      }
+      .write()
   }
 
-  private sources = [
-    new Source(
-      SourceType.JAVA, "Example", "com/example",
-      """\
-        package com.example;
+  private List<Source> sources = [
+    Source.java(
+      '''\
+      package com.example;
         
-        import org.apache.commons.collections4.bag.HashBag;
+      import org.apache.commons.collections4.bag.HashBag;
+              
+      public class Example {
+        public HashBag<String> bag;
+      }'''.stripIndent()
+    ).build(),
+    Source.java(
+      '''\
+      package com.example.extra;
         
-        public class Example {
-          public HashBag<String> bag;
-        }""".stripIndent()
-    ),
-    new Source(
-      SourceType.JAVA, "ExtraFeature", "com/example/extra",
-      """\
-        package com.example.extra;
-        
-        import org.apache.commons.collections4.bag.HashBag;
-        
-        public class ExtraFeature {
-          private HashBag<String> internalBag;
-        }""".stripIndent(),
-      producerCodeInFeature ? "extraFeature" : "main"
+      import org.apache.commons.collections4.bag.HashBag;
+              
+      public class ExtraFeature {
+        private HashBag<String> internalBag;
+      }'''.stripIndent()
     )
+      .withSourceSet(producerCodeInFeature ? 'extraFeature' : 'main')
+      .build(),
   ]
 
-  private consumerSources = [
-    new Source(
-      SourceType.JAVA, "Consumer", "com/example/consumer",
-      """\
-        package com.example.consumer;
+  private List<Source> consumerSources = [
+    Source.java(
+      '''\
+      package com.example.consumer;
         
-        import com.example.extra.ExtraFeature;
-        
-        public class Consumer {
-          private ExtraFeature extra;
-        }""".stripIndent()
-    )
+      import com.example.extra.ExtraFeature;
+              
+      public class Consumer {
+        private ExtraFeature extra;
+      }'''.stripIndent()
+    ).build(),
   ]
 
   Set<ProjectAdvice> actualBuildHealth() {
@@ -146,10 +144,12 @@ final class FeatureVariantTestProject extends AbstractProject {
   ]
 
   private final Set<Advice> expectedConsumerAdvice = [
-    Advice.ofChange(producerCodeInFeature
-      ? projectCoordinates(':producer', 'examplegroup:producer-extra-feature')
-      : projectCoordinates(':producer'),
-      'api', 'implementation')
+    Advice.ofChange(
+      producerCodeInFeature
+        ? projectCoordinates(':producer', 'examplegroup:producer-extra-feature')
+        : projectCoordinates(':producer'),
+      'api', 'implementation'
+    )
   ]
 
   final Set<ProjectAdvice> expectedBuildHealth() {

--- a/src/main/kotlin/com/autonomousapps/tasks/GraphViewTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/GraphViewTask.kt
@@ -35,7 +35,7 @@ public abstract class GraphViewTask : DefaultTask() {
   @get:Internal
   public abstract val compileClasspathName: Property<String>
 
-  @get:Internal
+  @get:Input
   public abstract val compileClasspathResult: Property<ResolvedComponentResult>
 
   @get:Internal
@@ -44,7 +44,7 @@ public abstract class GraphViewTask : DefaultTask() {
   @get:Internal
   public abstract val runtimeClasspathName: Property<String>
 
-  @get:Internal
+  @get:Input
   public abstract val runtimeClasspathResult: Property<ResolvedComponentResult>
 
   @get:Internal


### PR DESCRIPTION
This fixes an issue with the build cache that was causing issues with 'CustomSourceSetSpec'.