### PR TITLE
feat: ':printDuplicateDependencies' will now store the console output in a file on disk.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/AdviceHelper.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/AdviceHelper.groovy
@@ -141,6 +141,10 @@ final class AdviceHelper {
     return STRATEGY.getDuplicateDependenciesReport(gradleProject)
   }
 
+  static String duplicateDependenciesConsoleReport(GradleProject gradleProject) {
+    return STRATEGY.getDuplicateDependenciesConsoleReport(gradleProject)
+  }
+
   static List<String> resolvedDependenciesReport(GradleProject gradleProject, String projectPath) {
     return STRATEGY.getResolvedDependenciesReport(gradleProject, projectPath)
   }

--- a/src/functionalTest/groovy/com/autonomousapps/AdviceStrategy.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/AdviceStrategy.groovy
@@ -9,7 +9,6 @@ import com.autonomousapps.model.BuildHealth
 import com.autonomousapps.model.ProjectAdvice
 import com.autonomousapps.model.internal.intermediates.producer.ExplodedJar
 import com.squareup.moshi.Types
-import okio.Okio
 
 import java.util.zip.GZIPInputStream
 
@@ -29,6 +28,8 @@ abstract class AdviceStrategy {
   }
 
   abstract Map<String, Set<String>> getDuplicateDependenciesReport(GradleProject gradleProject)
+
+  abstract String getDuplicateDependenciesConsoleReport(GradleProject gradleProject)
 
   abstract List<String> getResolvedDependenciesReport(GradleProject gradleProject, String projectPath)
 
@@ -55,6 +56,11 @@ abstract class AdviceStrategy {
       def map = Types.newParameterizedType(Map, String, set)
       def adapter = MoshiUtils.MOSHI.<Map<String, Set<String>>> adapter(map)
       return adapter.fromJson(json)
+    }
+
+    @Override
+    String getDuplicateDependenciesConsoleReport(GradleProject gradleProject) {
+      return gradleProject.singleArtifact(':', OutputPathsKt.getDuplicateDependenciesConsoleReport()).asPath.text.trim()
     }
 
     @Override

--- a/src/functionalTest/groovy/com/autonomousapps/android/DuplicateDependencyVersionsSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/DuplicateDependencyVersionsSpec.groovy
@@ -45,11 +45,14 @@ final class DuplicateDependencyVersionsSpec extends AbstractAndroidSpec {
     def report = project.actualDuplicateDependencies()
     assertThat(report['junit:junit']).containsExactlyElementsIn('4.11', '4.12', '4.13').inOrder()
 
-    and: 'output'
+    and: 'stored console output'
+    assertThat(project.actualDuplicateDependenciesConsoleReport()).isEqualTo(project.expectedConsoleOutput)
+
+    and: 'emitted console output'
     assertAbout(buildResults())
       .that(result)
       .output()
-      .contains(project.expectedOutput)
+      .contains(project.expectedConsoleOutput)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/DuplicateDependencyVersionsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/DuplicateDependencyVersionsProject.groovy
@@ -7,8 +7,7 @@ import com.autonomousapps.internal.android.AgpVersion
 import com.autonomousapps.kit.GradleProject
 import com.autonomousapps.kit.gradle.Dependency
 
-import static com.autonomousapps.AdviceHelper.duplicateDependenciesReport
-import static com.autonomousapps.AdviceHelper.resolvedDependenciesReport
+import static com.autonomousapps.AdviceHelper.*
 import static com.autonomousapps.kit.gradle.Dependency.project
 import static com.autonomousapps.kit.gradle.dependencies.Dependencies.appcompat
 
@@ -66,6 +65,10 @@ final class DuplicateDependencyVersionsProject extends AbstractAndroidProject {
 
   Map<String, Set<String>> actualDuplicateDependencies() {
     return duplicateDependenciesReport(gradleProject)
+  }
+
+  String actualDuplicateDependenciesConsoleReport() {
+    return duplicateDependenciesConsoleReport(gradleProject)
   }
 
   List<String> actualResolvedDependenciesFor(String projectPath) {
@@ -135,7 +138,7 @@ final class DuplicateDependencyVersionsProject extends AbstractAndroidProject {
     org-jetbrains-annotations-13-0 = { module = "org.jetbrains:annotations", version = "13.0" }
     '''.stripIndent()
 
-  String expectedOutput = '''\
+  String expectedConsoleOutput = '''\
     Your build uses 51 dependencies, representing 47 distinct 'libraries.' 3 libraries have multiple versions across the build. These are:
     * androidx.arch.core:core-runtime:{2.1.0,2.2.0}
     * androidx.core:core-ktx:{1.2.0,1.13.0}

--- a/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
@@ -111,6 +111,7 @@ internal class RootOutputPaths(private val project: Project) {
   private fun dir(path: String): Provider<Directory> = project.layout.buildDirectory.dir(path)
 
   val duplicateDependenciesPath = file("$ROOT_DIR/duplicate-dependencies-report.json")
+  val duplicateDependenciesConsolePath = file("$ROOT_DIR/duplicate-dependencies-report.txt")
   val buildHealthPath = file("$ROOT_DIR/build-health-report.json")
   val consoleReportPath = file("$ROOT_DIR/build-health-report.txt")
   val allLibsVersionsTomlPath = file("$ROOT_DIR/allLibs.versions.toml")
@@ -137,10 +138,9 @@ internal class RedundantSubPluginOutputPaths(private val project: Project) {
 public fun getAdvicePathV2(): String = "$ROOT_DIR/final-advice.json"
 public fun getAggregateAdvicePathV2(): String = "$ROOT_DIR/final-advice.json"
 public fun getFinalAdvicePathV2(): String = "$ROOT_DIR/build-health-report.json"
-public fun getExplodedJarsPathV2(variantName: String): String =
-  "$ROOT_DIR/$variantName/intermediates/exploded-jars.json.gz"
-
+public fun getExplodedJarsPathV2(variantName: String): String = "$ROOT_DIR/$variantName/intermediates/exploded-jars.json.gz"
 public fun getDuplicateDependenciesReport(): String = "$ROOT_DIR/duplicate-dependencies-report.json"
+public fun getDuplicateDependenciesConsoleReport(): String = "$ROOT_DIR/duplicate-dependencies-report.txt"
 public fun getAllLibsVersionsTomlPath(): String = "$ROOT_DIR/allLibs.versions.toml"
 public fun getResolvedDependenciesReport(): String = "$ROOT_DIR/resolved-dependencies-report.txt"
 public fun getResolvedVersionsTomlPath(): String = "$ROOT_DIR/resolvedAllLibs.versions.toml"

--- a/src/main/kotlin/com/autonomousapps/subplugin/RootPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/RootPlugin.kt
@@ -107,10 +107,11 @@ internal class RootPlugin(private val project: Project) {
       tasks.register("computeDuplicateDependencies", ComputeDuplicateDependenciesTask::class.java) { t ->
         t.resolvedDependenciesReports.setFrom(resolvedDepsResolver.artifactFilesProvider())
         t.output.set(paths.duplicateDependenciesPath)
+        t.outputConsole.set(paths.duplicateDependenciesConsolePath)
       }
 
     tasks.register("printDuplicateDependencies", PrintDuplicateDependenciesTask::class.java) { t ->
-      t.duplicateDependenciesReport.set(computeDuplicatesTask.flatMap { it.output })
+      t.duplicateDependenciesReport.set(computeDuplicatesTask.flatMap { it.outputConsole })
     }
 
     tasks.register("computeAllDependencies", ComputeAllDependenciesTask::class.java) { t ->

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeDuplicateDependenciesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeDuplicateDependenciesTask.kt
@@ -3,6 +3,7 @@
 package com.autonomousapps.tasks
 
 import com.autonomousapps.TASK_GROUP_DEP
+import com.autonomousapps.internal.utils.VersionNumber
 import com.autonomousapps.internal.utils.bufferWriteJsonMapSet
 import com.autonomousapps.internal.utils.dependencyCoordinates
 import com.autonomousapps.internal.utils.getAndDelete
@@ -10,7 +11,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.*
-import java.util.SortedSet
+import java.util.*
 
 @CacheableTask
 public abstract class ComputeDuplicateDependenciesTask : DefaultTask() {
@@ -27,8 +28,12 @@ public abstract class ComputeDuplicateDependenciesTask : DefaultTask() {
   @get:OutputFile
   public abstract val output: RegularFileProperty
 
+  @get:OutputFile
+  public abstract val outputConsole: RegularFileProperty
+
   @TaskAction public fun action() {
     val output = output.getAndDelete()
+    val outputConsole = outputConsole.getAndDelete()
 
     val map = sortedMapOf<String, SortedSet<String>>()
 
@@ -40,6 +45,36 @@ public abstract class ComputeDuplicateDependenciesTask : DefaultTask() {
         }
       }
 
+    val consoleReport = buildConsoleReport(map)
+
     output.bufferWriteJsonMapSet(map)
+    outputConsole.writeText(consoleReport)
+  }
+
+  private fun buildConsoleReport(report: Map<String, SortedSet<String>>): String {
+    val total = report.size
+    val sum = report.values.sumOf { it.size }
+    val duplicates = report.filterTo(sortedMapOf()) { it.value.size > 1 }
+    val duplicateCount = duplicates.size
+
+    return buildString {
+      append("Your build uses $sum dependencies, representing $total distinct 'libraries.' ")
+      append("$duplicateCount libraries have multiple versions across the build.")
+      if (duplicateCount == 0) {
+        appendLine()
+      } else {
+        appendLine(" These are:")
+        duplicates.forEach { (id, versions) ->
+          appendLine("* $id:${versions.sortedVersions().joinToString(separator = ",", prefix = "{", postfix = "}")}")
+        }
+      }
+    }
   }
 }
+
+// visible for testing
+internal fun Iterable<String>.sortedVersions(): Iterable<String> = asSequence()
+  .map { it to VersionNumber.parse(it) }
+  .sortedBy { it.second }
+  .map { it.first }
+  .toList()

--- a/src/main/kotlin/com/autonomousapps/tasks/PrintDuplicateDependenciesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/PrintDuplicateDependenciesTask.kt
@@ -3,15 +3,10 @@
 package com.autonomousapps.tasks
 
 import com.autonomousapps.TASK_GROUP_DEP
-import com.autonomousapps.internal.utils.VersionNumber
-import com.autonomousapps.internal.utils.fromJsonMapSet
+import com.autonomousapps.internal.utils.readText
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
-import org.gradle.api.tasks.TaskAction
-import org.gradle.api.tasks.UntrackedTask
+import org.gradle.api.tasks.*
 
 @UntrackedTask(because = "Always prints output")
 public abstract class PrintDuplicateDependenciesTask : DefaultTask() {
@@ -26,32 +21,7 @@ public abstract class PrintDuplicateDependenciesTask : DefaultTask() {
   public abstract val duplicateDependenciesReport: RegularFileProperty
 
   @TaskAction public fun action() {
-    val report = duplicateDependenciesReport.fromJsonMapSet<String, String>()
-    val total = report.size
-    val sum = report.values.sumOf { it.size }
-    val duplicates = report.filterTo(sortedMapOf()) { it.value.size > 1 }
-    val duplicateCount = duplicates.size
-
-    val output = buildString {
-      append("Your build uses $sum dependencies, representing $total distinct 'libraries.' ")
-      append("$duplicateCount libraries have multiple versions across the build.")
-      if (duplicateCount == 0) {
-        appendLine()
-      } else {
-        appendLine(" These are:")
-        duplicates.forEach { (id, versions) ->
-          appendLine("* $id:${versions.sortedVersions().joinToString(separator = ",", prefix = "{", postfix = "}")}")
-        }
-      }
-    }
-
-    logger.quiet(output)
+    val consoleReport = duplicateDependenciesReport.readText()
+    logger.quiet(consoleReport)
   }
 }
-
-// visible for testing
-internal fun Iterable<String>.sortedVersions(): Iterable<String> = asSequence()
-  .map { it to VersionNumber.parse(it) }
-  .sortedBy { it.second }
-  .map { it.first }
-  .toList()


### PR DESCRIPTION
This enables the console output to be treated as stable for external consumption: it's part of the API now.