### PR TITLE
perf: send only cache misses to the classloader-isolated workers.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/JarExploder.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/JarExploder.kt
@@ -4,78 +4,42 @@ package com.autonomousapps.internal
 
 import com.autonomousapps.internal.asm.ClassReader
 import com.autonomousapps.internal.utils.asSequenceOfClassFiles
-import com.autonomousapps.internal.utils.efficient
 import com.autonomousapps.internal.utils.getLogger
 import com.autonomousapps.internal.utils.mapToOrderedSet
-import com.autonomousapps.model.Coordinates
 import com.autonomousapps.model.internal.KtFile
 import com.autonomousapps.model.internal.PhysicalArtifact
 import com.autonomousapps.model.internal.PhysicalArtifact.Mode
 import com.autonomousapps.model.internal.intermediates.ExplodingJar
 import com.autonomousapps.model.internal.intermediates.producer.AndroidLinterDependency
-import com.autonomousapps.model.internal.intermediates.producer.BinaryClass
 import com.autonomousapps.model.internal.intermediates.producer.ExpensiveJar
 import com.autonomousapps.model.internal.intermediates.producer.ExplodedJar
 import com.autonomousapps.tasks.ExplodeJarTask
 import java.util.zip.ZipFile
 
+/**
+ * Explodes the artifacts it is given, which are only ever the ones [ExplodeJarTask] could not serve from its
+ * build-scoped cache. Cache hits never reach this class, and so never cross the worker boundary.
+ */
 internal class JarExploder(
-  artifacts: List<PhysicalArtifact>,
+  private val artifacts: List<PhysicalArtifact>,
   private val androidLinters: Set<AndroidLinterDependency>,
-  private val seedCache: Map<String, ExpensiveJar>,
 ) {
 
   private val logger = getLogger<ExplodeJarTask>()
 
-  /** [ExplodedJar]s computed during this run (cache misses), keyed by artifact path, to merge back into the cache. */
-  val newEntries: MutableMap<String, ExpensiveJar> = LinkedHashMap()
+  /** [ExpensiveJar]s keyed by artifact path, for [ExplodeJarTask] to merge into its cache. */
+  fun expensiveJars(): Map<String, ExpensiveJar> = artifacts.associate { artifact ->
+    val explodingJar = explode(artifact, artifact.mode)
 
-  private val expensiveJars = artifacts.asSequence()
-    .filter {
-      // We know how to analyze jars, and directories containing class files
-      it.isJar() || it.containsClassFiles()
-    }
-    .toExpensiveJars()
-
-  fun binaryClasses(): Map<Coordinates, Set<BinaryClass>> {
-    return expensiveJars.associate { it.coordinates to it.binaryClasses }.toSortedMap().efficient()
+    artifact.file.absolutePath to ExpensiveJar(
+      coordinates = artifact.coordinates,
+      explodedJar = ExplodedJar(
+        artifact = artifact,
+        exploding = explodingJar,
+      ),
+      binaryClasses = explodingJar.binaryClasses,
+    )
   }
-
-  fun explodedJars(): Set<ExplodedJar> {
-    return expensiveJars.mapToOrderedSet { it.explodedJar }
-  }
-
-  private fun Sequence<PhysicalArtifact>.toExpensiveJars(): Set<ExpensiveJar> =
-    map { artifact ->
-      val key = artifact.file.absolutePath
-      // A cache hit reuses the file-content-derived analysis, but the cached ExpensiveJar also carries the coordinates
-      // of whichever artifact first populated this path in the build-scoped cache. Rebind to THIS artifact's identity;
-      // otherwise a file shared by two dependencies (e.g. a classifier variant resolved by multiple projects) leaks the
-      // other's coordinates and produces wrong advice. Note that Gradle does not provide the classifier in any public
-      // API, so `Coordinates` does not (cannot?) model it.
-      // tl;dr: two Coordinates, one physical artifact.
-      val cached = seedCache[key]
-      if (cached != null) {
-        cached.withCoordinates(artifact.coordinates)
-      } else {
-        val explodingJar = if (artifact.isJar()) {
-          explode(artifact, Mode.ZIP)
-        } else {
-          explode(artifact, Mode.CLASSES)
-        }
-
-        val explodedJar = ExplodedJar(
-          artifact = artifact,
-          exploding = explodingJar
-        )
-
-        ExpensiveJar(
-          coordinates = artifact.coordinates,
-          explodedJar = explodedJar,
-          binaryClasses = explodingJar.binaryClasses,
-        ).also { newEntries[key] = it }
-      }
-    }.toSortedSet()
 
   /**
    * Analyzes bytecode in order to extract class names and some basic structural information from
@@ -130,4 +94,24 @@ internal class JarExploder(
   private fun findAndroidLinter(physicalArtifact: PhysicalArtifact): String? {
     return androidLinters.find { it.coordinates == physicalArtifact.coordinates }?.lintRegistry
   }
+}
+
+/**
+ * Combines the [cacheHits] with the [newEntries] just computed by the worker, into the reports for [artifacts].
+ *
+ * Runs in the daemon, so a cache hit is reused by reference and is never copied.
+ */
+internal fun mergeExpensiveJars(
+  artifacts: List<PhysicalArtifact>,
+  cacheHits: Map<String, ExpensiveJar>,
+  newEntries: Map<String, ExpensiveJar>,
+): Set<ExpensiveJar> = artifacts.mapToOrderedSet { artifact ->
+  val key = artifact.file.absolutePath
+  // A cache hit reuses the file-content-derived analysis, but the cached ExpensiveJar also carries the coordinates of
+  // whichever artifact first populated this path in the build-scoped cache. Rebind to THIS artifact's identity;
+  // otherwise a file shared by two dependencies (e.g. a classifier variant resolved by multiple projects) leaks the
+  // other's coordinates and produces wrong advice. Note that Gradle does not provide the classifier in any public API,
+  // so `Coordinates` does not (cannot?) model it.
+  // tl;dr: two Coordinates, one physical artifact.
+  (cacheHits[key] ?: newEntries.getValue(key)).withCoordinates(artifact.coordinates)
 }

--- a/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
@@ -160,6 +160,26 @@ internal inline fun <T, R> Iterable<T>.mapToOrderedSet(transform: (T) -> R): Set
   return mapTo(TreeSet(), transform)
 }
 
+/**
+ * Splits [this] by whether a cache can already answer for each element: the hits, keyed by [key], and the elements that
+ * missed. Hits are returned as-is, so callers hold them by reference rather than copying them.
+ */
+internal inline fun <T, V : Any> Iterable<T>.partitionByCacheHit(
+  key: (T) -> String,
+  hit: (String) -> V?,
+): Pair<Map<String, V>, List<T>> {
+  val hits = LinkedHashMap<String, V>(collectionSizeOrDefault(10))
+  val misses = ArrayList<T>()
+
+  forEach { element ->
+    val k = key(element)
+    val cached = hit(k)
+    if (cached != null) hits[k] = cached else misses += element
+  }
+
+  return hits to misses
+}
+
 internal inline fun <T, R> Iterable<T>.flatMapToSet(transform: (T) -> Iterable<R>): Set<R> {
   return flatMapToMutableSet(transform)
 }

--- a/src/main/kotlin/com/autonomousapps/tasks/ExplodeJarTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ExplodeJarTask.kt
@@ -5,19 +5,22 @@
 package com.autonomousapps.tasks
 
 import com.autonomousapps.internal.JarExploder
+import com.autonomousapps.internal.mergeExpensiveJars
 import com.autonomousapps.internal.utils.bufferWriteJson
+import com.autonomousapps.internal.utils.bufferWriteJsonList
 import com.autonomousapps.internal.utils.bufferWriteJsonMap
-import com.autonomousapps.internal.utils.bufferWriteJsonMapSet
 import com.autonomousapps.internal.utils.bufferWriteJsonSet
+import com.autonomousapps.internal.utils.efficient
 import com.autonomousapps.internal.utils.fromJsonList
 import com.autonomousapps.internal.utils.fromJsonMap
 import com.autonomousapps.internal.utils.fromNullableJsonSet
 import com.autonomousapps.internal.utils.getAndDelete
+import com.autonomousapps.internal.utils.mapToOrderedSet
+import com.autonomousapps.internal.utils.partitionByCacheHit
 import com.autonomousapps.model.internal.PhysicalArtifact
 import com.autonomousapps.model.internal.intermediates.producer.AndroidLinterDependency
 import com.autonomousapps.model.internal.intermediates.producer.BinaryClasses
 import com.autonomousapps.model.internal.intermediates.producer.ExpensiveJar
-import com.autonomousapps.model.internal.intermediates.producer.ExplodedJar
 import com.autonomousapps.services.InMemoryCache
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
@@ -70,71 +73,72 @@ public abstract class ExplodeJarTask @Inject constructor(
   public abstract val outputBinaryClasses: RegularFileProperty
 
   @TaskAction public fun action() {
-    // Pass the shared cache content to the work action, which requires serializable data only
     val cache = inMemoryCache.get()
-    val seed = physicalArtifacts.fromJsonList<PhysicalArtifact>()
-      .mapNotNull { artifact ->
-        val key = artifact.file.absolutePath
-        cache.expensiveJar(key)?.let { key to it }
-      }
-      .toMap()
+    val artifacts = physicalArtifacts.fromJsonList<PhysicalArtifact>()
+      // We know how to analyze jars, and directories containing class files.
+      .filter { it.isJar() || it.containsClassFiles() }
 
-    val seedFile = File(temporaryDir, "exploded-jars-cache-seed.json").apply { bufferWriteJsonMap(seed) }
+    // The worker runs in an isolated classloader and so cannot share objects with this JVM; anything we hand it must be
+    // serialized out and deserialized back into a full copy. Send it only the artifacts we can't already answer for.
+    // Cache hits are held here, by reference, and never copied. (Seeding the worker with them instead cost a per-task
+    // deep copy of the whole compile classpath: tens of MB of JSON, serialized and parsed again for every task.)
+    val (cacheHits, misses) = artifacts.partitionByCacheHit(
+      key = { it.file.absolutePath },
+      hit = { cache.expensiveJar(it) },
+    )
+
+    val missesFile = File(temporaryDir, "exploded-jars-misses.json").apply { bufferWriteJsonList(misses) }
     val newEntriesFile = File(temporaryDir, "exploded-jars-cache-new.json")
 
     workerExecutor.classLoaderIsolation {
       // kotlin-metadata-jvm is not on the main plugin classpath (issue 1671); add it for the isolated worker only.
       it.classpath.from(kotlinMetadataClasspath)
     }.submit(ExplodeJarWorkAction::class.java) {
-      it.physicalArtifacts.set(physicalArtifacts)
+      it.physicalArtifacts.set(missesFile)
       it.androidLinters.set(androidLinters)
-      it.output.set(output)
-      it.outputBinaryClasses.set(outputBinaryClasses)
-      it.cacheSeed.set(seedFile)
       it.newCacheEntries.set(newEntriesFile)
     }
 
-    // Block so we can merge the worker's results back into the shared cache.
+    // Block so we can merge the worker's results back into the shared cache and write the reports.
     workerExecutor.await()
-    newEntriesFile.fromJsonMap<String, ExpensiveJar>().forEach { (key, expensiveJar) ->
-      cache.expensiveJars(key, expensiveJar)
-    }
+
+    val newEntries = newEntriesFile.fromJsonMap<String, ExpensiveJar>(compressed = true)
+    newEntries.forEach { (key, expensiveJar) -> cache.expensiveJars(key, expensiveJar) }
+
+    val expensiveJars = mergeExpensiveJars(artifacts, cacheHits, newEntries)
+    val binaryClasses = BinaryClasses.of(
+      expensiveJars.associate { it.coordinates to it.binaryClasses }.toSortedMap().efficient()
+    )
+
+    output.getAndDelete().bufferWriteJsonSet(expensiveJars.mapToOrderedSet { it.explodedJar }, compress = true)
+    outputBinaryClasses.getAndDelete().bufferWriteJson(binaryClasses, compress = true)
   }
 
   public interface ExplodeJarParameters : WorkParameters {
+    /**
+     * [`List<PhysicalArtifact>`][PhysicalArtifact] to explode: the subset of the task's artifacts that missed the
+     * build-scoped cache.
+     */
     public val physicalArtifacts: RegularFileProperty
 
     /** This may be empty. */
     public val androidLinters: RegularFileProperty
 
-    public val output: RegularFileProperty
-    public val outputBinaryClasses: RegularFileProperty
-
-    /** [`Map<String, ExplodedJar>`][ExplodedJar] of already-cached results, keyed by artifact path. */
-    public val cacheSeed: RegularFileProperty
-
-    /** [`Map<String, ExplodedJar>`][ExplodedJar] of cache misses computed by this worker, for the task to merge back. */
+    /** [`Map<String, ExpensiveJar>`][ExpensiveJar] computed by this worker, for the task to merge back. */
     public val newCacheEntries: RegularFileProperty
   }
 
   public abstract class ExplodeJarWorkAction : WorkAction<ExplodeJarParameters> {
 
     override fun execute() {
-      val output = parameters.output.getAndDelete()
-      val outputBinaryClasses = parameters.outputBinaryClasses.getAndDelete()
       val newCacheEntries = parameters.newCacheEntries.getAndDelete()
 
-      val exploder = JarExploder(
+      val expensiveJars = JarExploder(
         artifacts = parameters.physicalArtifacts.fromJsonList(),
         androidLinters = parameters.androidLinters.fromNullableJsonSet<AndroidLinterDependency>(),
-        seedCache = parameters.cacheSeed.fromJsonMap(),
-      )
-      val explodedJars = exploder.explodedJars()
-      val binaryClasses = BinaryClasses.of(exploder.binaryClasses())
+      ).expensiveJars()
 
-      output.bufferWriteJsonSet(explodedJars, compress = true)
-      outputBinaryClasses.bufferWriteJson(binaryClasses, compress = true)
-      newCacheEntries.bufferWriteJsonMap(exploder.newEntries)
+      newCacheEntries.bufferWriteJsonMap(expensiveJars, compress = true)
     }
   }
 }

--- a/src/main/kotlin/com/autonomousapps/tasks/FindKotlinMagicTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindKotlinMagicTask.kt
@@ -73,47 +73,51 @@ public abstract class FindKotlinMagicTask @Inject constructor(
 
   @TaskAction
   public fun action() {
-    // Pass the shared cache content to the work action, which requires serializable data only
     val cache = inMemoryCacheProvider.get()
-    val seed = artifacts.fromJsonList<PhysicalArtifact>()
-      .mapNotNull { artifact ->
-        val key = artifact.file.absolutePath
-        cache.kotlinCapabilities(key)?.let { key to it }
-      }
-      .toMap()
+    val allArtifacts = artifacts.fromJsonList<PhysicalArtifact>()
+      .filter { it.isJar() || it.containsClassFiles() }
 
-    val seedFile = File(temporaryDir, "kotlin-magic-cache-seed.json").apply { bufferWriteJsonMap(seed) }
+    // As in ExplodeJarTask: the isolated worker cannot share objects with this JVM, so send it only the artifacts the
+    // cache can't answer for. Cache hits stay here, by reference, rather than being deep-copied into every worker.
+    val (cacheHits, misses) = allArtifacts.partitionByCacheHit(
+      key = { it.file.absolutePath },
+      hit = { cache.kotlinCapabilities(it) },
+    )
+
+    val missesFile = File(temporaryDir, "kotlin-magic-misses.json").apply { bufferWriteJsonList(misses) }
     val newEntriesFile = File(temporaryDir, "kotlin-magic-cache-new.json")
 
+    // NB: submitted even when there are no misses. The worker also writes `errorsReport`, an output file that must
+    // always exist; skipping the worker on an empty `misses` would leave it missing.
     workerExecutor.classLoaderIsolation {
       // kotlin-metadata-jvm is not on the main plugin classpath (issue 1671); add it for the isolated worker only.
       it.classpath.from(kotlinMetadataClasspath)
     }.submit(Action::class.java) {
-      it.artifacts.set(artifacts)
-      it.inlineUsageReport.set(outputInlineMembers)
-      it.typealiasReport.set(outputTypealiases)
+      it.artifacts.set(missesFile)
       it.errorsReport.set(outputErrors)
-      it.cacheSeed.set(seedFile)
       it.newCacheEntries.set(newEntriesFile)
     }
 
-    // Block so we can merge the worker's results back into the shared cache.
+    // Block so we can merge the worker's results back into the shared cache and write the reports.
     workerExecutor.await()
-    newEntriesFile.fromJsonMap<String, KotlinCapabilities>().forEach { (key, capabilities) ->
-      cache.inlineMembers(key, capabilities)
-    }
+
+    val newEntries = newEntriesFile.fromJsonMap<String, KotlinCapabilities>(compressed = true)
+    newEntries.forEach { (key, capabilities) -> cache.inlineMembers(key, capabilities) }
+
+    val (inlineMembers, typealiases) = mergeKotlinMagic(allArtifacts, cacheHits, newEntries)
+    outputInlineMembers.getAndDelete().bufferWriteJsonSet(inlineMembers)
+    outputTypealiases.getAndDelete().bufferWriteJsonSet(typealiases)
   }
 
   public interface Parameters : WorkParameters {
+    /**
+     * [`List<PhysicalArtifact>`][PhysicalArtifact] to analyze: the subset of the task's artifacts that missed the
+     * build-scoped cache.
+     */
     public val artifacts: RegularFileProperty
-    public val inlineUsageReport: RegularFileProperty
-    public val typealiasReport: RegularFileProperty
     public val errorsReport: RegularFileProperty
 
-    /** [`Map<String, KotlinCapabilities>`][KotlinCapabilities] of already-cached results, keyed by artifact path. */
-    public val cacheSeed: RegularFileProperty
-
-    /** [`Map<String, KotlinCapabilities>`][KotlinCapabilities] of cache misses, for the task to merge back. */
+    /** [`Map<String, KotlinCapabilities>`][KotlinCapabilities] computed by this worker, for the task to merge back. */
     public val newCacheEntries: RegularFileProperty
   }
 
@@ -122,23 +126,15 @@ public abstract class FindKotlinMagicTask @Inject constructor(
     private val logger = getLogger<FindKotlinMagicTask>()
 
     override fun execute() {
-      val inlineUsageReportFile = parameters.inlineUsageReport.getAndDelete()
-      val typealiasReportFile = parameters.typealiasReport.getAndDelete()
       val errorsReport = parameters.errorsReport.getAndDelete()
       val newCacheEntries = parameters.newCacheEntries.getAndDelete()
 
       val finder = KotlinMagicFinder(
-        seedCache = parameters.cacheSeed.fromJsonMap(),
         artifacts = parameters.artifacts.fromJsonList<PhysicalArtifact>(),
         errorsReport = errorsReport,
       )
-      val inlineMembers = finder.inlineMembers
-      val typealiases = finder.typealiases
 
-      inlineUsageReportFile.bufferWriteJsonSet(inlineMembers)
-      typealiasReportFile.bufferWriteJsonSet(typealiases)
-
-      newCacheEntries.bufferWriteJsonMap(finder.newEntries)
+      newCacheEntries.bufferWriteJsonMap(finder.capabilities, compress = true)
 
       if (finder.didWriteErrors) {
         logger.warn("There were errors during inline member analysis. See ${errorsReport.toPath().toUri()}")
@@ -150,8 +146,38 @@ public abstract class FindKotlinMagicTask @Inject constructor(
   }
 }
 
+/**
+ * Combines the [cacheHits] with the [newEntries] just computed by the worker, into the reports for [artifacts].
+ *
+ * Runs in the daemon, so a cache hit is reused by reference and is never copied.
+ */
+internal fun mergeKotlinMagic(
+  artifacts: List<PhysicalArtifact>,
+  cacheHits: Map<String, KotlinCapabilities>,
+  newEntries: Map<String, KotlinCapabilities>,
+): Pair<Set<InlineMemberDependency>, Set<TypealiasDependency>> {
+  val inlineMembers = mutableSetOf<InlineMemberDependency>()
+  val typealiases = mutableSetOf<TypealiasDependency>()
+
+  artifacts.forEach { artifact ->
+    val key = artifact.file.absolutePath
+    val capabilities = cacheHits[key] ?: newEntries.getValue(key)
+    if (capabilities.inlineMembers.isNotEmpty()) {
+      inlineMembers += InlineMemberDependency.newInstance(artifact.coordinates, capabilities.inlineMembers)
+    }
+    if (capabilities.typealiases.isNotEmpty()) {
+      typealiases += TypealiasDependency.newInstance(artifact.coordinates, capabilities.typealiases)
+    }
+  }
+
+  return inlineMembers to typealiases
+}
+
+/**
+ * Analyzes the artifacts it is given, which are only ever the ones [FindKotlinMagicTask] could not serve from its
+ * build-scoped cache. Cache hits never reach this class, and so never cross the worker boundary.
+ */
 internal class KotlinMagicFinder(
-  private val seedCache: Map<String, KotlinCapabilities>,
   artifacts: List<PhysicalArtifact>,
   private val errorsReport: File,
 ) {
@@ -159,34 +185,9 @@ internal class KotlinMagicFinder(
   private val logger = getLogger<FindKotlinMagicTask>()
   var didWriteErrors = false
 
-  val inlineMembers: Set<InlineMemberDependency>
-  val typealiases: Set<TypealiasDependency>
-
-  /** [KotlinCapabilities] computed during this run (cache misses), keyed by artifact path, to merge into the cache. */
-  val newEntries: MutableMap<String, KotlinCapabilities> = LinkedHashMap()
-
-  init {
-    val inlineMembersMut = mutableSetOf<InlineMemberDependency>()
-    val typealiasesMut = mutableSetOf<TypealiasDependency>()
-
-    artifacts.asSequence()
-      .filter {
-        it.isJar() || it.containsClassFiles()
-      }.map { artifact ->
-        val key = artifact.file.absolutePath
-        val capabilities = seedCache[key] ?: findKotlinMagic(artifact, artifact.mode).also { newEntries[key] = it }
-        artifact to capabilities
-      }.forEach { (artifact, capabilities) ->
-        if (capabilities.inlineMembers.isNotEmpty()) {
-          inlineMembersMut += InlineMemberDependency.newInstance(artifact.coordinates, capabilities.inlineMembers)
-        }
-        if (capabilities.typealiases.isNotEmpty()) {
-          typealiasesMut += TypealiasDependency.newInstance(artifact.coordinates, capabilities.typealiases)
-        }
-      }
-
-    inlineMembers = inlineMembersMut
-    typealiases = typealiasesMut
+  /** [KotlinCapabilities] keyed by artifact path, for [FindKotlinMagicTask] to merge into its cache. */
+  val capabilities: Map<String, KotlinCapabilities> = artifacts.associate { artifact ->
+    artifact.file.absolutePath to findKotlinMagic(artifact, artifact.mode)
   }
 
   /**

--- a/src/test/kotlin/com/autonomousapps/internal/JarExploderTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/JarExploderTest.kt
@@ -8,7 +8,6 @@ import com.autonomousapps.model.GradleVariantIdentification
 import com.autonomousapps.model.ModuleCoordinates
 import com.autonomousapps.model.internal.PhysicalArtifact
 import com.autonomousapps.model.internal.intermediates.producer.ExpensiveJar
-import com.autonomousapps.model.internal.intermediates.producer.ExplodedJar
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -45,14 +44,13 @@ internal class JarExploderTest {
     val exploder = JarExploder(
       artifacts = listOf(artifact),
       androidLinters = emptySet(),
-      seedCache = emptyMap(),
     )
 
     // Must not throw — the future-versioned class is skipped rather than handed to ASM.
-    val exploded = exploder.explodedJars()
+    val exploded = exploder.expensiveJars()
 
     assertThat(exploded).hasSize(1)
-    val classNames = exploded.first().simplifiedBinaryClasses.map { it.className }
+    val classNames = exploded.values.first().binaryClasses.map { it.className }
     assertThat(classNames).contains("com.example.Foo")
     assertThat(classNames).doesNotContain("com.example.Future")
   }
@@ -60,12 +58,12 @@ internal class JarExploderTest {
   /**
    * Regression test for https://github.com/autonomousapps/dependency-analysis-gradle-plugin/pull/1719.
    *
-   * The exploded-jar cache is keyed by file path, and (once kotlin-metadata was isolated to workers) its value became
-   * [ExplodedJar], which carries the dependency's [ExplodedJar.coordinates]. A single physical file can be resolved
-   * under different coordinates by different consumers. For example, a classifier/capability variant can be pulled by more than one
-   * project. A cache hit must reuse the cached file-content analysis but report the *current* artifact's coordinates,
-   * not whichever consumer populated the (build-scoped) cache first. Otherwise dependencies are mis-attributed and DAGP
-   * emits wrong advice (the `ClassifiersSpec` "transitive classifier" failures).
+   * The exploded-jar cache is keyed by file path, and its value carries the dependency's coordinates. A single physical
+   * file can be resolved under different coordinates by different consumers. For example, a classifier/capability
+   * variant can be pulled by more than one project. A cache hit must reuse the cached file-content analysis but report
+   * the *current* artifact's coordinates, not whichever consumer populated the (build-scoped) cache first. Otherwise
+   * dependencies are mis-attributed and DAGP emits wrong advice (the `ClassifiersSpec` "transitive classifier"
+   * failures).
    */
   @Test fun `a cache hit does not leak coordinates across artifacts that share a file`(@TempDir dir: File) {
     val jar = File(dir, "shared.jar").apply {
@@ -78,25 +76,25 @@ internal class JarExploderTest {
     val firstCoordinates = ModuleCoordinates("joda-time:joda-time", "2.10.7", GradleVariantIdentification.EMPTY)
     val secondCoordinates = ModuleCoordinates("net.danlew:android.joda", "2.10.7.2", GradleVariantIdentification.EMPTY)
 
-    // The first consumer explodes the file and seeds the build-scoped cache, as ExplodeJarTask merges it back.
-    val first = JarExploder(
+    // The first consumer explodes the file; ExplodeJarTask merges these entries into the build-scoped cache.
+    val cached: Map<String, ExpensiveJar> = JarExploder(
       artifacts = listOf(PhysicalArtifact(coordinates = firstCoordinates, file = jar)),
       androidLinters = emptySet(),
-      seedCache = emptyMap(),
-    )
-    val seededCache: Map<String, ExpensiveJar> = first.newEntries
-    // Sanity: the second consumer below must get a cache *hit*, else this test would pass vacuously.
-    assertThat(seededCache).isNotEmpty()
+    ).expensiveJars()
+    // Sanity: the second consumer below must get a cache *hit*. If this map were empty, the assertion below would hold
+    // no matter what the merge did.
+    assertThat(cached).isNotEmpty()
 
-    // The second consumer explodes the same file under different coordinates, seeded from that shared cache.
-    val second = JarExploder(
+    // The second consumer reaches the same file under different coordinates, and is served entirely from that cache.
+    val second = mergeExpensiveJars(
       artifacts = listOf(PhysicalArtifact(coordinates = secondCoordinates, file = jar)),
-      androidLinters = emptySet(),
-      seedCache = seededCache,
-    ).explodedJars().single()
+      cacheHits = cached,
+      newEntries = emptyMap(),
+    ).single()
 
     // It must report its own coordinates, not the first consumer's.
     assertThat(second.coordinates).isEqualTo(secondCoordinates)
+    assertThat(second.explodedJar.coordinates).isEqualTo(secondCoordinates)
   }
 
   /** As in a dependency with classifiers. */
@@ -115,31 +113,70 @@ internal class JarExploderTest {
     // The same coordinates, referencing two different files on disk.
     val coordinates = ModuleCoordinates("group:name", "2.10.7", GradleVariantIdentification.EMPTY)
 
-    // The first consumer explodes the file and seeds the build-scoped cache, as ExplodeJarTask merges it back.
-    val firstExploder = JarExploder(
+    // The first consumer explodes its file and seeds the build-scoped cache, as ExplodeJarTask merges it back.
+    val cached: Map<String, ExpensiveJar> = JarExploder(
       artifacts = listOf(PhysicalArtifact(coordinates = coordinates, file = jar1)),
       androidLinters = emptySet(),
-      seedCache = emptyMap(),
+    ).expensiveJars()
+
+    // Check contents
+    assertThat(cached.values.single().binaryClasses.map { it.className }).containsExactly("com.example.Foo")
+    // Sanity: the cache is non-empty, so a merge that keyed on coordinates rather than path would find this entry.
+    assertThat(cached).isNotEmpty()
+
+    // The second consumer resolves the "same" artifact (identical coordinates) to a different file, so it misses that
+    // cache and its jar is exploded by the worker.
+    val secondArtifact = PhysicalArtifact(coordinates = coordinates, file = jar2)
+    val newEntries = JarExploder(
+      artifacts = listOf(secondArtifact),
+      androidLinters = emptySet(),
+    ).expensiveJars()
+
+    val second = mergeExpensiveJars(
+      artifacts = listOf(secondArtifact),
+      cacheHits = cached,
+      newEntries = newEntries,
+    ).single()
+
+    // Check contents
+    assertThat(second.binaryClasses.map { it.className }).containsExactly("com.example.Bar")
+    assertThat(second.coordinates).isEqualTo(coordinates)
+  }
+
+  /**
+   * `ExplodeJarTask` serves cache hits from the daemon and sends only the misses to its isolated worker, so the reports
+   * it writes are a merge of the two. Every artifact must appear exactly once, whichever side it came from.
+   */
+  @Test fun `merges cache hits with jars exploded by the worker`(@TempDir dir: File) {
+    fun jar(name: String, className: String) = File(dir, name).apply {
+      ZipOutputStream(outputStream()).use { it.writeEntry("$className.class", validClass(className)) }
+    }
+
+    val cachedArtifact = PhysicalArtifact(
+      coordinates = ModuleCoordinates("org.example:cached", "1", GradleVariantIdentification.EMPTY),
+      file = jar("cached.jar", "com/example/Cached"),
+    )
+    val freshArtifact = PhysicalArtifact(
+      coordinates = ModuleCoordinates("org.example:fresh", "1", GradleVariantIdentification.EMPTY),
+      file = jar("fresh.jar", "com/example/Fresh"),
     )
 
-    // Check contents
-    val firstExplodedJar = firstExploder.explodedJars().single()
-    assertThat(firstExplodedJar.simplifiedBinaryClasses.map { it.className }).containsExactly("com.example.Foo")
+    // The first artifact is already cached, so only the second one reaches the worker's exploder.
+    val cacheHits = JarExploder(artifacts = listOf(cachedArtifact), androidLinters = emptySet()).expensiveJars()
+    val newEntries = JarExploder(artifacts = listOf(freshArtifact), androidLinters = emptySet()).expensiveJars()
 
-    val seededCache: Map<String, ExpensiveJar> = firstExploder.newEntries
-    // Sanity: the second consumer below must get a cache *hit*, else this test would pass vacuously.
-    assertThat(seededCache).isNotEmpty()
+    val merged = mergeExpensiveJars(
+      artifacts = listOf(cachedArtifact, freshArtifact),
+      cacheHits = cacheHits,
+      newEntries = newEntries,
+    )
 
-    // The second consumer explodes the "same" artifact (identical coordinates), not seeded from that shared cache.
-    val secondExplodedJar = JarExploder(
-      artifacts = listOf(PhysicalArtifact(coordinates = coordinates, file = jar2)),
-      androidLinters = emptySet(),
-      seedCache = seededCache,
-    ).explodedJars().single()
-
-    // Check contents
-    assertThat(secondExplodedJar.simplifiedBinaryClasses.map { it.className }).containsExactly("com.example.Bar")
-    assertThat(secondExplodedJar.coordinates).isEqualTo(coordinates)
+    assertThat(merged.map { it.coordinates })
+      .containsExactly(cachedArtifact.coordinates, freshArtifact.coordinates)
+    assertThat(merged.flatMap { expensive -> expensive.binaryClasses.map { it.className } })
+      .containsExactly("com.example.Cached", "com.example.Fresh")
+    assertThat(merged.flatMap { it.explodedJar.simplifiedBinaryClasses.map { c -> c.className } })
+      .containsExactly("com.example.Cached", "com.example.Fresh")
   }
 
   private fun ZipOutputStream.writeEntry(name: String, bytes: ByteArray) {

--- a/src/test/kotlin/com/autonomousapps/tasks/FindKotlinMagicTaskTest.kt
+++ b/src/test/kotlin/com/autonomousapps/tasks/FindKotlinMagicTaskTest.kt
@@ -1,0 +1,79 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.tasks
+
+import com.autonomousapps.model.GradleVariantIdentification
+import com.autonomousapps.model.ModuleCoordinates
+import com.autonomousapps.model.internal.InlineMemberCapability
+import com.autonomousapps.model.internal.PhysicalArtifact
+import com.autonomousapps.model.internal.TypealiasCapability
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+
+internal class FindKotlinMagicTaskTest {
+
+  /**
+   * `FindKotlinMagicTask` serves cache hits from the daemon and sends only the misses to its isolated worker, so its
+   * reports are a merge of the two. Each dependency must be attributed to its own artifact's coordinates, whichever
+   * side it came from.
+   */
+  @Test fun `merges cache hits with capabilities computed by the worker`() {
+    val cachedArtifact = artifact("org.example:cached")
+    val freshArtifact = artifact("org.example:fresh")
+
+    val (inlineMembers, typealiases) = mergeKotlinMagic(
+      artifacts = listOf(cachedArtifact, freshArtifact),
+      cacheHits = mapOf(cachedArtifact.key to kotlinMagic("Cached")),
+      newEntries = mapOf(freshArtifact.key to kotlinMagic("Fresh")),
+    )
+
+    assertThat(inlineMembers.map { it.coordinates })
+      .containsExactly(cachedArtifact.coordinates, freshArtifact.coordinates)
+    assertThat(inlineMembers.flatMap { dependency -> dependency.inlineMembers.map { it.className } })
+      .containsExactly("com.example.CachedKt", "com.example.FreshKt")
+    assertThat(typealiases.map { it.coordinates })
+      .containsExactly(cachedArtifact.coordinates, freshArtifact.coordinates)
+  }
+
+  /** An artifact contributing neither inline members nor typealiases belongs in neither report. */
+  @Test fun `artifacts without kotlin magic are left out of both reports`() {
+    val bare = artifact("org.example:bare")
+    val magic = artifact("org.example:magic")
+
+    val (inlineMembers, typealiases) = mergeKotlinMagic(
+      artifacts = listOf(bare, magic),
+      cacheHits = mapOf(bare.key to KotlinCapabilities.EMPTY),
+      newEntries = mapOf(magic.key to kotlinMagic("Magic")),
+    )
+
+    assertThat(inlineMembers.map { it.coordinates }).containsExactly(magic.coordinates)
+    assertThat(typealiases.map { it.coordinates }).containsExactly(magic.coordinates)
+  }
+
+  /** The cache is keyed by artifact path, as in the task. */
+  private val PhysicalArtifact.key: String get() = file.absolutePath
+
+  /** [mergeKotlinMagic] reads only coordinates and the file path, so the jar itself need not exist on disk. */
+  private fun artifact(identifier: String) = PhysicalArtifact(
+    coordinates = ModuleCoordinates(identifier, "1", GradleVariantIdentification.EMPTY),
+    file = File("${identifier.substringAfter(':')}.jar"),
+  )
+
+  private fun kotlinMagic(simpleName: String) = KotlinCapabilities(
+    inlineMembers = setOf(
+      InlineMemberCapability.InlineMember.newInstance(
+        className = "com.example.${simpleName}Kt",
+        packageName = "com.example",
+        inlineMembers = setOf("com.example.thing"),
+      )
+    ),
+    typealiases = setOf(
+      TypealiasCapability.Typealias.newInstance(
+        packageName = "com.example",
+        alternatePackageName = "com.example",
+        typealiases = setOf(TypealiasCapability.Typealias.Alias(simpleName, "kotlin.String")),
+      )
+    ),
+  )
+}


### PR DESCRIPTION
Isolating kotlin-metadata to workers means `InMemoryCache` contents have to cross a classloader boundary. `ExplodeJarTask` and `FindKotlinMagicTask` do that by serializing every cache hit into the worker as a JSON seed, which the worker parses back into a deep copy, so a warm cache costs one full copy of the compile classpath analysis per task. This partitions in the daemon instead: hits stay there by reference, the worker receives only the artifacts it has to analyze, and the task merges the two before writing its reports.

On 40 synthetic `java-library` projects that all declare the same compile classpath, where 68 of the 80 `explodeJar` tasks have no cache misses at all:

```
buildHealth, medians of 4 interleaved runs

                 10-jar classpath   14-jar classpath
                     -Xmx4g            -Xmx2560m
  3.17.0              14.0s              37.5s
  main                24.0s              67.5s
  this PR             15.5s              43.5s
```

3.17.0 is there as the pre-isolation reference. It is the last release that used a `noIsolation` worker and shared the cache by reference.

A JFR recording attributes the difference. `com.squareup.moshi` accounts for 82% of the CPU samples that disappear, 1049 down to 639 against a total drop of 500, while `com.autonomousapps.internal.asm` is unchanged at 80 to 99. So the bytecode analysis is untouched and what goes away is the copying. GC pause time falls from 1054ms to 608ms, about 5% of the wall-clock difference.

The smallest `-Xmx` that completes drops too, from 640m to 576m on the 10-jar fixture and from 2560m to 2048m on the 14-jar one.
