### PR TITLE
fix: preserve classes across artifacts with shared coordinates

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/android/TestFixturesSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/TestFixturesSpec.groovy
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.android
 
+import com.autonomousapps.android.projects.SplitJvmTestFixturesProject
 import com.autonomousapps.android.projects.TestFixturesAddTransitiveProject
+import com.autonomousapps.android.projects.TestFixturesDuplicatedWithMainProject
 import com.autonomousapps.android.projects.TestFixturesUnusedDependencyProject
 import com.autonomousapps.android.projects.TestFixturesWithAbiProject
-import com.autonomousapps.android.projects.TestFixturesDuplicatedWithMainProject
 import com.autonomousapps.internal.android.AgpVersion
 import org.gradle.util.GradleVersion
 
@@ -16,6 +17,21 @@ import static com.google.common.truth.Truth.assertAbout
 final class TestFixturesSpec extends AbstractAndroidSpec {
   
   private static final AgpVersion MINIMAL_AGP_SUPPORTING_TEST_FIXTURES = AgpVersion.version("8.5.0")
+
+  def "supports relocated mixed JVM test fixture outputs (#gradleVersion AGP #agpVersion)"() {
+    given:
+    def project = new SplitJvmTestFixturesProject(agpVersion as String)
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion as GradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    noExceptionThrown()
+
+    where:
+    [gradleVersion, agpVersion] << gradleAgpMatrix(MINIMAL_AGP_SUPPORTING_TEST_FIXTURES)
+  }
 
   def "should not falsely report duplicated dependencies with main source set(#gradleVersion AGP #agpVersion)"() {
     given:

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/SplitJvmTestFixturesProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/SplitJvmTestFixturesProject.groovy
@@ -1,0 +1,107 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.android.projects
+
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.gradle.GradleProperties
+import com.autonomousapps.kit.gradle.kotlin.Kotlin
+
+import static com.autonomousapps.kit.gradle.Dependency.project
+
+final class SplitJvmTestFixturesProject extends AbstractAndroidProject {
+
+  final GradleProject gradleProject
+
+  SplitJvmTestFixturesProject(String agpVersion) {
+    super(agpVersion)
+    gradleProject = newGradleProjectBuilder(GradleProject.DslKind.KOTLIN)
+      .withRootProject { root ->
+        root.gradleProperties += GradleProperties.minimalAndroidProperties()
+        root.withBuildScript { buildScript ->
+          buildScript.plugins += plugins.androidAppNoApply
+          buildScript.withKotlin(
+            '''\
+            dependencyAnalysis {
+              usage {
+                analysis {
+                  checkSuperClasses(true)
+                }
+              }
+            }'''.stripIndent()
+          )
+        }
+      }
+      .withAndroidSubproject('consumer') { consumer ->
+        consumer.sources = consumerSources
+        consumer.manifest = libraryManifest('com.example.consumer')
+        consumer.withBuildScript { buildScript ->
+          buildScript.plugins(androidLib(true))
+          buildScript.android = defaultAndroidLibBlock(true, 'com.example.consumer').tap {
+            defaultConfig = null
+          }
+          buildScript.kotlin = Kotlin.DEFAULT
+          buildScript.dependencies(project('testImplementation', ':producer').onTestFixtures())
+        }
+      }
+      .withSubproject('producer') { producer ->
+        producer.sources = producerSources
+        producer.withBuildScript { buildScript ->
+          buildScript.plugins = kotlin + javaTestFixtures
+          buildScript.withKotlin(
+            '''\
+            sourceSets.named("testFixtures") {
+              java.destinationDirectory.set(layout.buildDirectory.dir("testFixtures-classes/java"))
+            }
+            kotlin.sourceSets.named("testFixtures") {
+              kotlin.destinationDirectory.set(layout.buildDirectory.dir("testFixtures-classes/kotlin"))
+            }
+            '''.stripIndent()
+          )
+        }
+      }
+      .write()
+  }
+
+  private static final List<Source> consumerSources = [
+    Source.kotlin(
+      '''\
+      package com.example.consumer
+
+      import com.example.producer.KotlinFixture
+      import com.example.producer.JavaFixture
+
+      class ConsumerTest {
+        val kotlinFixture = KotlinFixture()
+        val javaFixture = JavaFixture()
+      }
+      '''
+    )
+      .withPath('com.example.consumer', 'ConsumerTest')
+      .withSourceSet('test')
+      .build(),
+  ]
+
+  private static final List<Source> producerSources = [
+    Source.kotlin(
+      '''\
+      package com.example.producer
+
+      class KotlinFixture
+      '''
+    )
+      .withPath('com.example.producer', 'KotlinFixture')
+      .withSourceSet('testFixtures')
+      .build(),
+    Source.java(
+      '''\
+      package com.example.producer;
+
+      public final class JavaFixture {}
+      '''
+    )
+      .withPath('com.example.producer', 'JavaFixture')
+      .withSourceSet('testFixtures')
+      .build(),
+  ]
+}

--- a/src/main/kotlin/com/autonomousapps/internal/JarExploder.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/JarExploder.kt
@@ -38,7 +38,11 @@ internal class JarExploder(
     .toExpensiveJars()
 
   fun binaryClasses(): Map<Coordinates, Set<BinaryClass>> {
-    return expensiveJars.associate { it.coordinates to it.binaryClasses }.toSortedMap().efficient()
+    val binaryClasses = sortedMapOf<Coordinates, MutableSet<BinaryClass>>()
+    expensiveJars.forEach { jar ->
+      binaryClasses.getOrPut(jar.coordinates) { sortedSetOf() }.addAll(jar.binaryClasses)
+    }
+    return binaryClasses.mapValues { (_, classes) -> classes.efficient() }.efficient()
   }
 
   fun explodedJars(): Set<ExplodedJar> {

--- a/src/test/kotlin/com/autonomousapps/internal/JarExploderTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/JarExploderTest.kt
@@ -142,11 +142,39 @@ internal class JarExploderTest {
     assertThat(secondExplodedJar.coordinates).isEqualTo(coordinates)
   }
 
+  @Test fun `binary classes are preserved across artifacts with the same coordinates`(@TempDir dir: File) {
+    val kotlinClasses = dir.classDirectory("kotlin", "com/example/Fake")
+    val generatedJavaClasses = dir.classDirectory("java", "com/example/Fake_Factory")
+    val coordinates = ModuleCoordinates("group:name", "1.0", GradleVariantIdentification.EMPTY)
+
+    val binaryClasses = JarExploder(
+      artifacts = listOf(
+        PhysicalArtifact(coordinates = coordinates, file = kotlinClasses),
+        PhysicalArtifact(coordinates = coordinates, file = generatedJavaClasses),
+      ),
+      androidLinters = emptySet(),
+      seedCache = emptyMap(),
+    ).binaryClasses().getValue(coordinates)
+
+    assertThat(binaryClasses.map { it.className }).containsExactly(
+      "com.example.Fake",
+      "com.example.Fake_Factory",
+    )
+  }
+
   private fun ZipOutputStream.writeEntry(name: String, bytes: ByteArray) {
     putNextEntry(ZipEntry(name))
     write(bytes)
     closeEntry()
   }
+
+  private fun File.classDirectory(directoryName: String, className: String): File =
+    resolve(directoryName).also { directory ->
+      directory.resolve("$className.class").apply {
+        parentFile.mkdirs()
+        writeBytes(validClass(className))
+      }
+    }
 
   /** Generates a minimal, valid `.class` file (parseable by ASM) for the given internal name, e.g. `com/example/Foo`. */
   private fun validClass(internalName: String): ByteArray {


### PR DESCRIPTION
## Problem

Gradle can resolve multiple physical artifacts for the same logical component and capability. One example is a test-fixtures variant whose Kotlin and Java classes are exposed as separate class directories but carry the same dependency coordinates.

`JarExploder.binaryClasses()` converted exploded artifacts to a `Map<Coordinates, Set<BinaryClass>>` with `associate`. When two artifacts had the same coordinates, the second set replaced the first. Dependency synthesis still retained the union of classes from both artifacts, which left the two views of the dependency inconsistent:

1. dependency synthesis recorded classes from both physical artifacts
2. the coordinate-keyed binary class map retained classes from only one artifact
3. superclass analysis requested a recorded class that was missing from the map and threw `NoSuchElementException`

## Triggering build

This can happen whenever one component exposes separate physical artifacts under the same dependency coordinates.

`producer/build.gradle.kts`:

```kotlin
plugins {
  kotlin("jvm")
  `java-test-fixtures`
}
```

The producer contains one fixture in `src/testFixtures/kotlin` and another in `src/testFixtures/java`.

Our build also relocates those outputs:

```kotlin
sourceSets.named("testFixtures") {
  java.destinationDirectory.set(layout.buildDirectory.dir("testFixtures-classes/java"))
}
kotlin.sourceSets.named("testFixtures") {
  kotlin.destinationDirectory.set(layout.buildDirectory.dir("testFixtures-classes/kotlin"))
}
```

We do this to avoid source-set contamination. Without the relocation, DAGP analyzes compiled test-fixture classes as part of the producer's main capability, so dependency advice can depend on whether the fixtures have already been compiled. I have #1810 to remove the need for this workaround.

`consumer/build.gradle.kts`:

```kotlin
plugins {
  id("com.android.library")
  kotlin("android")
}

dependencies {
  testImplementation(testFixtures(project(":producer")))
}
```

Analysis resolves the relocated Kotlin and Java fixture outputs as separate class-directory artifacts with the same component coordinates. The relocation does not cause the aggregation bug, but it makes the duplicate-coordinate case observable.

Checking super classes enables the code path that fails today:

```kotlin
dependencyAnalysis {
  usage {
    analysis {
      checkSuperClasses(true)
    }
  }
}
```

## Change

- merge binary class sets when multiple physical artifacts share dependency coordinates
- cover the aggregation boundary with a unit test
- cover the producer/consumer scenario with a functional test