### PR TITLE
fix: scope mixed JVM class outputs to their source set

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/android/TestFixturesSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/TestFixturesSpec.groovy
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.android
 
+import com.autonomousapps.android.projects.MixedJvmTestFixturesProject
 import com.autonomousapps.android.projects.TestFixturesAddTransitiveProject
 import com.autonomousapps.android.projects.TestFixturesUnusedDependencyProject
 import com.autonomousapps.android.projects.TestFixturesWithAbiProject
@@ -17,6 +18,22 @@ final class TestFixturesSpec extends AbstractAndroidSpec {
   
   private static final AgpVersion MINIMAL_AGP_SUPPORTING_TEST_FIXTURES = AgpVersion.version("8.5.0")
 
+  def "detects Kotlin test fixtures from a mixed JVM producer (#gradleVersion AGP #agpVersion)"() {
+    given:
+    def project = new MixedJvmTestFixturesProject(agpVersion as String)
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion as GradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertAbout(buildHealth())
+      .that(project.actualBuildHealth())
+      .isEquivalentIgnoringModuleAdviceAndWarnings(project.expectedBuildHealth())
+
+    where:
+    [gradleVersion, agpVersion] << gradleAgpMatrix(MINIMAL_AGP_SUPPORTING_TEST_FIXTURES)
+  }
   def "should not falsely report duplicated dependencies with main source set(#gradleVersion AGP #agpVersion)"() {
     given:
     def project = new TestFixturesDuplicatedWithMainProject(agpVersion as String)

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/MixedJvmTestFixturesProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/MixedJvmTestFixturesProject.groovy
@@ -1,0 +1,125 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.android.projects
+
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.kit.gradle.kotlin.Kotlin
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.*
+import static com.autonomousapps.kit.gradle.Dependency.project
+
+final class MixedJvmTestFixturesProject extends AbstractAndroidProject {
+
+  final GradleProject gradleProject
+
+  MixedJvmTestFixturesProject(String agpVersion) {
+    super(agpVersion)
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newAndroidGradleProjectBuilder()
+      .withAndroidSubproject('consumer') { s ->
+        s.sources = consumerSources
+        s.manifest = libraryManifest('com.example.consumer')
+        s.withBuildScript { bs ->
+          bs.plugins(androidLib(true))
+          bs.android = defaultAndroidLibBlock(true, 'com.example.consumer')
+          bs.kotlin = Kotlin.DEFAULT
+          bs.dependencies(
+            project('implementation', ':producer'),
+            project('testImplementation', ':producer').onTestFixtures(),
+          )
+        }
+      }
+      .withSubproject('producer') { s ->
+        s.sources = producerSources
+        s.withBuildScript { bs ->
+          bs.plugins = kotlin + plugins.javaTestFixtures
+        }
+      }
+      .write()
+  }
+
+  private final List<Source> consumerSources = [
+    Source.kotlin(
+      """\
+      package com.example.consumer
+
+      import com.example.producer.Producer
+
+      class Consumer {
+        fun consume() = Producer().produce()
+      }
+      """
+    )
+      .withPath('com.example.consumer', 'Consumer')
+      .build(),
+    Source.kotlin(
+      """\
+      package com.example.consumer
+
+      import com.example.producer.FakeProducer
+
+      class ConsumerTest {
+        fun consume() = FakeProducer().produce()
+      }
+      """
+    )
+      .withPath('com.example.consumer', 'ConsumerTest')
+      .withSourceSet('test')
+      .build(),
+  ]
+
+  private final List<Source> producerSources = [
+    Source.kotlin(
+      """\
+      package com.example.producer
+
+      class Producer {
+        fun produce() = Unit
+      }
+      """
+    )
+      .withPath('com.example.producer', 'Producer')
+      .build(),
+    Source.kotlin(
+      """\
+      package com.example.producer
+
+      class FakeProducer {
+        fun produce() = Unit
+      }
+      """
+    )
+      .withPath('com.example.producer', 'FakeProducer')
+      .withSourceSet('testFixtures')
+      .build(),
+    new Source(
+      SourceType.JAVA,
+      'UnusedFixture',
+      'com/example/producer',
+      """\
+      package com.example.producer;
+
+      public final class UnusedFixture {
+      }
+      """.stripIndent(),
+      'testFixtures'
+    ),
+  ]
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  static Set<ProjectAdvice> expectedBuildHealth() {
+    return [
+      emptyProjectAdviceFor(':consumer'),
+      emptyProjectAdviceFor(':producer'),
+    ]
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/tasks/ArtifactsReportTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ArtifactsReportTask.kt
@@ -21,6 +21,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.*
+import java.io.File
 
 /**
  * Produces a report of all the artifacts required to build the given project; i.e., the artifacts on the compile
@@ -125,20 +126,17 @@ public abstract class ArtifactsReportTask : DefaultTask() {
   private fun toPhysicalArtifacts(artifacts: ArtifactCollection): Set<PhysicalArtifact> {
     return artifacts.asSequence()
       .filterNonGradle()
-      .mapNotNull {
-        try {
-          // https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/948#issuecomment-1711177139
-          val file = if (it.file.path.endsWith("kotlin/main") || it.file.path.endsWith("java/main")) {
-            it.file.parentFile!!.parentFile!!
-          } else {
-            it.file
+      .flatMap { artifact ->
+        // https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/948#issuecomment-1711177139
+        artifact.file.sourceSetClassDirectories().asSequence().mapNotNull { file ->
+          try {
+            PhysicalArtifact.of(
+              artifact = artifact,
+              file = file
+            )
+          } catch (_: GradleException) {
+            null
           }
-          PhysicalArtifact.of(
-            artifact = it,
-            file = file
-          )
-        } catch (_: GradleException) {
-          null
         }
       }
       .toSortedSet()
@@ -148,5 +146,19 @@ public abstract class ArtifactsReportTask : DefaultTask() {
     return excludedIdentifiers.get().asSequence()
       .map { ExcludedIdentifier(it.intern()) }
       .toSortedSet()
+  }
+}
+
+private val JVM_CLASS_OUTPUT_LANGUAGES = setOf("java", "kotlin")
+
+internal fun File.sourceSetClassDirectories(): Set<File> {
+  val languageDirectory = parentFile ?: return setOf(this)
+  val classesDirectory = languageDirectory.parentFile ?: return setOf(this)
+  if (classesDirectory.name != "classes" || languageDirectory.name !in JVM_CLASS_OUTPUT_LANGUAGES) {
+    return setOf(this)
+  }
+
+  return JVM_CLASS_OUTPUT_LANGUAGES.mapTo(sortedSetOf()) { language ->
+    classesDirectory.resolve("$language/$name")
   }
 }

--- a/src/test/kotlin/com/autonomousapps/tasks/ArtifactsReportTaskTest.kt
+++ b/src/test/kotlin/com/autonomousapps/tasks/ArtifactsReportTaskTest.kt
@@ -1,0 +1,28 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.tasks
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+internal class ArtifactsReportTaskTest {
+
+  @Test fun `mixed JVM outputs remain scoped to the resolved source set`(@TempDir dir: File) {
+    val classesDirectory = dir.resolve("build/classes")
+    val javaMain = classesDirectory.resolve("java/main")
+    val kotlinMain = classesDirectory.resolve("kotlin/main")
+    val javaTestFixtures = classesDirectory.resolve("java/testFixtures")
+    val kotlinTestFixtures = classesDirectory.resolve("kotlin/testFixtures")
+
+    assertThat(kotlinMain.sourceSetClassDirectories()).containsExactly(javaMain, kotlinMain)
+    assertThat(javaTestFixtures.sourceSetClassDirectories()).containsExactly(javaTestFixtures, kotlinTestFixtures)
+  }
+
+  @Test fun `nonstandard class directory remains unchanged`(@TempDir dir: File) {
+    val classDirectory = dir.resolve("custom/classes")
+
+    assertThat(classDirectory.sourceSetClassDirectories()).containsExactly(classDirectory)
+  }
+}


### PR DESCRIPTION
## Problem

Gradle can resolve one class directory for a mixed Java and Kotlin project dependency. For example, it may return `build/classes/kotlin/main` even when the same source set also has classes in `build/classes/java/main`.

The plugin currently finds the other language output by widening that path to `build/classes`, which crosses source-set boundaries. Once test fixtures have been compiled, the directory also contains `kotlin/testFixtures` and `java/testFixtures`. Analyzing `implementation(project(":producer"))` therefore sees classes from the `testFixtures` source set too. A reference to a fixture class can then be attributed to the main project dependency instead of `testImplementation(testFixtures(project(":producer")))`.

## Triggering build

The producer is a JVM project with Kotlin and Java test fixtures.

`producer/build.gradle.kts`:

```kotlin
plugins {
  kotlin("jvm")
  `java-test-fixtures`
}
```

An Android consumer depends on the producer in production and on its test fixtures in tests. The Android consumer is significant because it resolves the JVM producer as class-directory artifacts. A JVM consumer resolves the producer and its test fixtures as JARs, so it does not reach the class-directory expansion changed here.

`consumer/build.gradle.kts`:

```kotlin
plugins {
  id("com.android.library")
  kotlin("android")
}

dependencies {
  implementation(project(":producer"))
  testImplementation(testFixtures(project(":producer")))
}
```

The consumer's production source references a main class through `implementation(project(":producer"))`. Its test source references a fixture class through `testImplementation(testFixtures(project(":producer")))`. Today, analyzing the first dependency widens the scan to all four outputs:

```text
build/classes/kotlin/main
build/classes/java/main
build/classes/kotlin/testFixtures
build/classes/java/testFixtures
```

Our build worked around this by moving its fixture outputs outside `build/classes`:

```kotlin
sourceSets.named("testFixtures") {
  java.destinationDirectory.set(layout.buildDirectory.dir("testFixtures-classes/java"))
}
kotlin.sourceSets.named("testFixtures") {
  kotlin.destinationDirectory.set(layout.buildDirectory.dir("testFixtures-classes/kotlin"))
}
```

That kept fixture classes out of the analysis for `implementation(project(":producer"))`, but caused the relocated Java and Kotlin directories to resolve as separate artifacts with the same coordinates, exposing the aggregation bug fixed by #1809.

This PR removes the need for that relocation but should land afterward because the Java and Kotlin sibling directories returned here share coordinates and must both survive aggregation.

## Change

When a resolved artifact matches `build/classes/<language>/<sourceSet>`, analyze only the Java and Kotlin siblings for that source set:

```text
build/classes/kotlin/main
build/classes/java/main
```

or:

```text
build/classes/kotlin/testFixtures
build/classes/java/testFixtures
```