### PR TITLE
fix: track component identifiers as input to tasks that write them to output

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/VersionBumpSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/VersionBumpSpec.groovy
@@ -1,0 +1,33 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.jvm
+
+import com.autonomousapps.jvm.projects.VersionBumpProject
+
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertThat
+
+final class VersionBumpSpec extends AbstractJvmSpec {
+
+  def "advice tracks a version bump with byte-identical artifacts (#gradleVersion)"() {
+    given:
+    def project = new VersionBumpProject()
+    gradleProject = project.gradleProject
+
+    when: 'We build the first time'
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth('1.0'))
+
+    when: 'We bump the dependency to a version with byte-identical artifacts, and build again'
+    project.bumpVersion()
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then: 'the advice reflects the correct version'
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth('1.1'))
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/VersionBumpProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/VersionBumpProject.groovy
@@ -1,0 +1,103 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.gradle.Dependency
+import com.autonomousapps.kit.gradle.Repository
+import com.autonomousapps.model.Advice
+import com.autonomousapps.model.ProjectAdvice
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.jar.JarOutputStream
+import java.util.zip.ZipEntry
+
+import static com.autonomousapps.AdviceHelper.*
+
+final class VersionBumpProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  VersionBumpProject() {
+    writeLocalRepo()
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newGradleProjectBuilder()
+      .withSubproject('consumer') { s ->
+        s.sources = consumerSources
+        s.withBuildScript { bs ->
+          bs.plugins = javaLibrary
+          bs.repositories = Repository.DEFAULT + Repository.ofMaven(localRepo().toUri().toString())
+          bs.dependencies = [new Dependency('implementation', 'com.example:lib:1.0')]
+        }
+      }
+      .write()
+  }
+
+  void bumpVersion() {
+    def buildScript = gradleProject.projectDir('consumer').resolve('build.gradle')
+    buildScript.text = buildScript.text.replace('com.example:lib:1.0', 'com.example:lib:1.1')
+  }
+
+  private Path localRepo() {
+    return rootDir.resolve('repo')
+  }
+
+  private void writeLocalRepo() {
+    def v1 = localRepo().resolve('com/example/lib/1.0')
+    def v2 = localRepo().resolve('com/example/lib/1.1')
+    Files.createDirectories(v1)
+    Files.createDirectories(v2)
+
+    def jar1 = v1.resolve('lib-1.0.jar')
+    new JarOutputStream(Files.newOutputStream(jar1)).withCloseable { jos ->
+      jos.putNextEntry(new ZipEntry('META-INF/services/com.example.Spi'))
+      jos.write('com.example.SpiImpl\n'.getBytes(StandardCharsets.UTF_8))
+      jos.closeEntry()
+    }
+    // 1.1 is byte-identical to 1.0: only the coordinates differ
+    Files.copy(jar1, v2.resolve('lib-1.1.jar'))
+
+    v1.resolve('lib-1.0.pom').text = pom('1.0')
+    v2.resolve('lib-1.1.pom').text = pom('1.1')
+  }
+
+  private static String pom(String version) {
+    return """\
+      <?xml version="1.0" encoding="UTF-8"?>
+      <project xmlns="http://maven.apache.org/POM/4.0.0">
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>com.example</groupId>
+        <artifactId>lib</artifactId>
+        <version>$version</version>
+        <packaging>jar</packaging>
+      </project>""".stripIndent()
+  }
+
+  private final List<Source> consumerSources = [
+    Source.java(
+      '''\
+      package com.example.consumer;
+
+      public class Consumer {}'''.stripIndent()
+    ).build(),
+  ]
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  Set<ProjectAdvice> expectedBuildHealth(String version) {
+    return [
+      projectAdviceForDependencies(':consumer', [
+        Advice.ofChange(moduleCoordinates("com.example:lib:$version"), 'implementation', 'runtimeOnly'),
+      ] as Set<Advice>),
+    ]
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/internal/artifactViews.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/artifactViews.kt
@@ -10,6 +10,7 @@ import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.Category
+import org.gradle.api.provider.Provider
 import org.gradle.internal.component.local.model.OpaqueComponentArtifactIdentifier
 
 /**
@@ -21,6 +22,16 @@ internal val CATEGORY = Attribute.of("org.gradle.category", String::class.java)
 private val attributeKey = Attribute.of("artifactType", String::class.java)
 
 internal fun Configuration.artifactsFor(attrValue: String): ArtifactCollection = artifactViewFor(attrValue).artifacts
+
+/**
+ * Returns the component identifiers of the artifacts in this collection (sorted for consistency).
+ * A task that writes these identifiers into its output must declare them as an [Input][org.gradle.api.tasks.Input].
+ * Otherwise, the task would keep stale identifiers in its output, since a version bump with byte-identical files
+ * wouldn't invalidate the file inputs.
+ */
+internal fun ArtifactCollection.identifiers(): Provider<List<String>> {
+  return resolvedArtifacts.map { artifacts -> artifacts.map { it.id.componentIdentifier.displayName }.sorted() }
+}
 
 /** Captures things like the Gradle version catalog and Gradle API jar. */
 internal fun Configuration.opaqueComponentArtifacts(): ArtifactCollection = incoming.artifactView { view ->

--- a/src/main/kotlin/com/autonomousapps/tasks/DiscoverClasspathDuplicationTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/DiscoverClasspathDuplicationTask.kt
@@ -3,6 +3,7 @@
 package com.autonomousapps.tasks
 
 import com.autonomousapps.TASK_GROUP_DEP
+import com.autonomousapps.internal.identifiers
 import com.autonomousapps.internal.utils.*
 import com.autonomousapps.model.Coordinates
 import com.autonomousapps.model.DuplicateClass
@@ -13,6 +14,7 @@ import org.gradle.api.artifacts.ArtifactCollection
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 import java.util.TreeSet
@@ -35,10 +37,15 @@ public abstract class DiscoverClasspathDuplicationTask : DefaultTask() {
 
   public fun setClasspath(artifacts: ArtifactCollection) {
     this.classpath = artifacts
+    classpathIdentifiers.set(artifacts.identifiers())
   }
 
   @Classpath
   public fun getClasspath(): FileCollection = classpath.artifactFiles
+
+  /** The output contains artifact coordinates, which aren't reflected in [getClasspath]. See [identifiers]. */
+  @get:Input
+  public abstract val classpathIdentifiers: ListProperty<String>
 
   @get:Input
   public abstract val classpathName: Property<String>

--- a/src/main/kotlin/com/autonomousapps/tasks/FindAndroidAssetProviders.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindAndroidAssetProviders.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.tasks
 
+import com.autonomousapps.internal.identifiers
 import com.autonomousapps.internal.utils.bufferWriteJsonSet
 import com.autonomousapps.internal.utils.getAndDelete
 import com.autonomousapps.internal.utils.toCoordinates
@@ -11,6 +12,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.artifacts.ArtifactCollection
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.*
 
 @CacheableTask
@@ -24,11 +26,16 @@ public abstract class FindAndroidAssetProviders : DefaultTask() {
 
   public fun setAssets(assets: ArtifactCollection) {
     this.assetDirs = assets
+    assetIdentifiers.set(assets.identifiers())
   }
 
   @PathSensitive(PathSensitivity.RELATIVE)
   @InputFiles
   public fun getAssetArtifactFiles(): FileCollection = assetDirs.artifactFiles
+
+  /** The output contains artifact coordinates, which aren't reflected in [getAssetArtifactFiles]. See [identifiers]. */
+  @get:Input
+  public abstract val assetIdentifiers: ListProperty<String>
 
   @get:OutputFile
   public abstract val output: RegularFileProperty

--- a/src/main/kotlin/com/autonomousapps/tasks/FindAndroidLinters.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindAndroidLinters.kt
@@ -4,6 +4,7 @@ package com.autonomousapps.tasks
 
 import com.autonomousapps.internal.LINT_ISSUE_REGISTRY_PATH
 import com.autonomousapps.internal.MANIFEST_PATH
+import com.autonomousapps.internal.identifiers
 import com.autonomousapps.internal.utils.bufferWriteJsonSet
 import com.autonomousapps.internal.utils.getAndDelete
 import com.autonomousapps.internal.utils.toCoordinates
@@ -13,8 +14,10 @@ import org.gradle.api.GradleException
 import org.gradle.api.artifacts.ArtifactCollection
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import java.io.BufferedReader
@@ -36,10 +39,15 @@ public abstract class FindAndroidLinters : DefaultTask() {
 
   public fun setLintJars(lintJars: ArtifactCollection) {
     this.lintJars = lintJars
+    lintJarIdentifiers.set(lintJars.identifiers())
   }
 
   @Classpath
   public fun getLintArtifactFiles(): FileCollection = lintJars.artifactFiles
+
+  /** The output contains artifact coordinates, which aren't reflected in [getLintArtifactFiles]. See [identifiers]. */
+  @get:Input
+  public abstract val lintJarIdentifiers: ListProperty<String>
 
   @get:OutputFile
   public abstract val output: RegularFileProperty

--- a/src/main/kotlin/com/autonomousapps/tasks/FindAndroidResTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindAndroidResTask.kt
@@ -4,6 +4,7 @@
 
 package com.autonomousapps.tasks
 
+import com.autonomousapps.internal.identifiers
 import com.autonomousapps.internal.utils.*
 import com.autonomousapps.model.internal.AndroidResCapability
 import com.autonomousapps.model.Coordinates
@@ -13,6 +14,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.artifacts.ArtifactCollection
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.*
 import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
@@ -32,6 +34,7 @@ public abstract class FindAndroidResTask : DefaultTask() {
 
   public fun setAndroidSymbols(resources: ArtifactCollection) {
     this.androidSymbols = resources
+    androidSymbolIdentifiers.set(resources.identifiers())
   }
 
   /** Artifact type "android-symbol-with-package-name". All Android libraries seem to have this. */
@@ -39,10 +42,15 @@ public abstract class FindAndroidResTask : DefaultTask() {
   @InputFiles
   public fun getAndroidSymbols(): FileCollection = androidSymbols.artifactFiles
 
+  /** The output contains artifact coordinates, which aren't reflected in [getAndroidSymbols]. See [identifiers]. */
+  @get:Input
+  public abstract val androidSymbolIdentifiers: ListProperty<String>
+
   private lateinit var androidPublicRes: ArtifactCollection
 
   public fun setAndroidPublicRes(androidPublicRes: ArtifactCollection) {
     this.androidPublicRes = androidPublicRes
+    androidPublicResIdentifiers.set(androidPublicRes.identifiers())
   }
 
   /**
@@ -52,6 +60,10 @@ public abstract class FindAndroidResTask : DefaultTask() {
   @PathSensitive(PathSensitivity.NAME_ONLY)
   @InputFiles
   public fun getAndroidPublicRes(): FileCollection = androidPublicRes.artifactFiles
+
+  /** The output contains artifact coordinates, which aren't reflected in [getAndroidPublicRes]. See [identifiers]. */
+  @get:Input
+  public abstract val androidPublicResIdentifiers: ListProperty<String>
 
   @get:OutputFile
   public abstract val output: RegularFileProperty

--- a/src/main/kotlin/com/autonomousapps/tasks/FindDeclaredProcsTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindDeclaredProcsTask.kt
@@ -3,6 +3,7 @@
 package com.autonomousapps.tasks
 
 import com.autonomousapps.internal.ANNOTATION_PROCESSOR_PATH
+import com.autonomousapps.internal.identifiers
 import com.autonomousapps.internal.utils.bufferWriteJsonList
 import com.autonomousapps.internal.utils.getAndDelete
 import com.autonomousapps.model.internal.intermediates.producer.AnnotationProcessorDependency
@@ -12,6 +13,7 @@ import org.gradle.api.artifacts.ArtifactCollection
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 import java.io.BufferedReader
@@ -60,19 +62,32 @@ public abstract class FindDeclaredProcsTask : DefaultTask() {
 
   public fun setKaptArtifacts(artifacts: ArtifactCollection) {
     kaptArtifacts = artifacts
+    kaptArtifactIdentifiers.set(artifacts.identifiers())
   }
 
   public fun setAnnotationProcessorArtifacts(artifacts: ArtifactCollection) {
     annotationProcessorArtifacts = artifacts
+    annotationProcessorArtifactIdentifiers.set(artifacts.identifiers())
   }
 
   @Optional
   @Classpath
   public fun getKaptArtifactFiles(): FileCollection? = kaptArtifacts?.artifactFiles
 
+  /** The output contains artifact coordinates, which aren't reflected in [getKaptArtifactFiles]. See [identifiers]. */
+  @get:Input
+  public abstract val kaptArtifactIdentifiers: ListProperty<String>
+
   @Optional
   @Classpath
   public fun getAnnotationProcessorArtifactFiles(): FileCollection? = annotationProcessorArtifacts?.artifactFiles
+
+  /**
+   * The output contains artifact coordinates, which aren't reflected in [getAnnotationProcessorArtifactFiles]. See
+   * [identifiers].
+   */
+  @get:Input
+  public abstract val annotationProcessorArtifactIdentifiers: ListProperty<String>
 
   @get:OutputFile
   public abstract val output: RegularFileProperty

--- a/src/main/kotlin/com/autonomousapps/tasks/FindNativeLibsTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindNativeLibsTask.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.tasks
 
+import com.autonomousapps.internal.identifiers
 import com.autonomousapps.internal.utils.bufferWriteJsonSet
 import com.autonomousapps.internal.utils.getAndDelete
 import com.autonomousapps.internal.utils.mapNotNullToOrderedSet
@@ -12,6 +13,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.artifacts.ArtifactCollection
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.*
 
 @CacheableTask
@@ -25,6 +27,7 @@ public abstract class FindNativeLibsTask : DefaultTask() {
 
   public fun setAndroidJni(androidJni: ArtifactCollection) {
     this.androidJni = androidJni
+    androidJniIdentifiers.set(androidJni.identifiers())
   }
 
   @Optional // Only available on Android
@@ -35,10 +38,15 @@ public abstract class FindNativeLibsTask : DefaultTask() {
     return androidJni.artifactFiles
   }
 
+  /** The output contains artifact coordinates, which aren't reflected in [getAndroidJniFiles]. See [identifiers]. */
+  @get:Input
+  public abstract val androidJniIdentifiers: ListProperty<String>
+
   private lateinit var dylibs: ArtifactCollection
 
   public fun setMacNativeLibs(dylibs: ArtifactCollection) {
     this.dylibs = dylibs
+    macNativeLibIdentifiers.set(dylibs.identifiers())
   }
 
   @Optional // Only available on JVM
@@ -48,6 +56,10 @@ public abstract class FindNativeLibsTask : DefaultTask() {
     if (!::dylibs.isInitialized) return null
     return dylibs.artifactFiles
   }
+
+  /** The output contains artifact coordinates, which aren't reflected in [getMacNativeLibs]. See [identifiers]. */
+  @get:Input
+  public abstract val macNativeLibIdentifiers: ListProperty<String>
 
   @get:OutputFile
   public abstract val output: RegularFileProperty

--- a/src/main/kotlin/com/autonomousapps/tasks/FindServiceLoadersTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindServiceLoadersTask.kt
@@ -4,6 +4,7 @@ package com.autonomousapps.tasks
 
 import com.autonomousapps.internal.ANNOTATION_PROCESSOR_PATH
 import com.autonomousapps.internal.SERVICE_LOADER_PATH
+import com.autonomousapps.internal.identifiers
 import com.autonomousapps.internal.utils.*
 import com.autonomousapps.internal.utils.filterNonGradle
 import com.autonomousapps.internal.utils.flatMapToSet
@@ -14,8 +15,10 @@ import org.gradle.api.artifacts.ArtifactCollection
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import java.io.BufferedReader
@@ -38,10 +41,15 @@ public abstract class FindServiceLoadersTask : DefaultTask() {
 
   public fun setCompileClasspath(artifacts: ArtifactCollection) {
     this.compileClasspath = artifacts
+    compileClasspathIdentifiers.set(artifacts.identifiers())
   }
 
   @Classpath
   public fun getCompileClasspath(): FileCollection = compileClasspath.artifactFiles
+
+  /** The output contains artifact coordinates, which aren't reflected in [getCompileClasspath]. See [identifiers]. */
+  @get:Input
+  public abstract val compileClasspathIdentifiers: ListProperty<String>
 
   @get:OutputFile
   public abstract val output: RegularFileProperty

--- a/src/main/kotlin/com/autonomousapps/tasks/ManifestComponentsExtractionTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ManifestComponentsExtractionTask.kt
@@ -5,6 +5,7 @@
 package com.autonomousapps.tasks
 
 import com.autonomousapps.internal.ManifestParser
+import com.autonomousapps.internal.identifiers
 import com.autonomousapps.internal.utils.bufferWriteJsonSet
 import com.autonomousapps.internal.utils.getAndDelete
 import com.autonomousapps.internal.utils.mapNotNullToOrderedSet
@@ -15,6 +16,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.artifacts.ArtifactCollection
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 
@@ -29,11 +31,16 @@ public abstract class ManifestComponentsExtractionTask : DefaultTask() {
 
   public fun setArtifacts(manifestArtifacts: ArtifactCollection) {
     this.manifestArtifacts = manifestArtifacts
+    manifestIdentifiers.set(manifestArtifacts.identifiers())
   }
 
   @PathSensitive(PathSensitivity.NAME_ONLY)
   @InputFiles
   public fun getManifestFiles(): FileCollection = manifestArtifacts.artifactFiles
+
+  /** The output contains artifact coordinates, which aren't reflected in [getManifestFiles]. See [identifiers]. */
+  @get:Input
+  public abstract val manifestIdentifiers: ListProperty<String>
 
   @get:Input
   public abstract val namespace: Property<String>


### PR DESCRIPTION
Fixes #1426 

I added a functional test for only one of the scenarios. Should I add for all of them?

### Contributor Checklist
- [x] I have read the [Contributing guide](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/blob/main/CONTRIBUTING.asciidoc).
- [x] I have read the 
  [Code of Conduct](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/blob/main/CODE_OF_CONDUCT.md).
- [x] No part of this pull request was created with an LLM/AI.
- [x] All contributed code can be distributed under the terms of the
  [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or
  the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) 
  in pull request so that additional changes can be pushed by project maintainers.
- [x] Provide functional tests (under `src/functionalTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `src/test`) to verify logic.
- [x] Ensure that unit tests pass: `./gradlew test`.
- [ ] Ensure that functional tests pass: `./gradlew :functionalTest -DfuncTest.quick`. I keep getting a single failure in different tests, but those tests pass when run individually; still looking into that.
