### PR TITLE
fix: an 'analyzable class file' should have non-zero length.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
@@ -59,9 +59,11 @@ private fun String.isAnalyzableClassFileName(): Boolean {
 }
 
 private fun File.isAnalyzableClassFile(): Boolean {
-  return extension == "class" &&
-    !name.endsWith("module-info.class") &&
-    !isUnsupportedMultiReleaseClass(invariantSeparatorsPath)
+  return extension == "class"
+    && !name.endsWith("module-info.class")
+    && !isUnsupportedMultiReleaseClass(invariantSeparatorsPath)
+    // https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1829
+    && length() > 0
 }
 
 /**


### PR DESCRIPTION
I can imagine a more robust check that also ensures this is a 'valid class file,' but this seems good enough for now. A rare case.

Resolves https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1829