### PR TITLE
docs: clarify that checkSuperClasses() is only for source code, not for external deps.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -225,7 +225,6 @@ val functionalTest = tasks.named("functionalTest", Test::class) {
     "jvm" -> {
       include("com/autonomousapps/jvm/**")
 
-      // We advertise that we support Java 11
       javaLauncher.set(javaToolchains.launcherFor {
         languageVersion.set(JavaLanguageVersion.of(17))
       })

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/MissingSuperclassSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/MissingSuperclassSpec.groovy
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.jvm
 
+import com.autonomousapps.jvm.projects.KafkaServerProject
 import com.autonomousapps.jvm.projects.MissingSuperclassProject
 import com.autonomousapps.utils.Colors
+import spock.lang.Ignore
+import spock.lang.Issue
 
 import static com.autonomousapps.utils.Runner.build
 import static com.google.common.truth.Truth.assertThat
@@ -74,5 +77,23 @@ final class MissingSuperclassSpec extends AbstractJvmSpec {
 
     where:
     gradleVersion << [GRADLE_LATEST]
+  }
+
+  // Leaving this has kind of extra documentation that this isn't a supported use-case (currently at least)
+  @Ignore
+  @Issue("https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1828")
+  def "advises keeping superclass dependency for kafka-server (#gradleVersion)"() {
+    given:
+    def project = new KafkaServerProject()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, ':buildHealth', '--rerun-tasks')
+
+    then:
+    assertThat(project.actualProjectAdvice()).containsExactlyElementsIn(project.expectedProjectAdvice())
+
+    where:
+    gradleVersion << gradleVersions()
   }
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/KafkaServerProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/KafkaServerProject.groovy
@@ -1,0 +1,74 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.actualProjectAdvice
+import static com.autonomousapps.AdviceHelper.emptyProjectAdviceFor
+import static com.autonomousapps.kit.gradle.Dependency.implementation
+
+final class KafkaServerProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  KafkaServerProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newGradleProjectBuilder()
+      .withRootProject { r ->
+        r.withBuildScript { bs ->
+          bs.withGroovy(
+            """\
+              dependencyAnalysis {
+                usage {
+                  analysis {
+                    checkSuperClasses true
+                  }
+                }
+              }""".stripIndent()
+          )
+        }
+      }
+      .withSubproject('lib') { s ->
+        s.sources = libSources
+        s.withBuildScript { bs ->
+          bs.plugins = javaLibrary
+          bs.dependencies(
+            implementation('org.apache.kafka:kafka_2.13:4.3.1'),
+            // Shouldn't need this. Use it because 'kafka_2.13' has broken metadata
+            implementation('org.apache.kafka:kafka-server:4.3.1'),
+          )
+        }
+      }
+      .write()
+  }
+
+  private static final List<Source> libSources = [
+    Source.java(
+      '''\
+        package com.example.lib;
+
+        import kafka.server.KafkaConfig;
+        import java.util.Properties;
+
+        public class Lib {
+          private KafkaConfig config = new KafkaConfig(new Properties());
+        }
+      '''
+    ).build(),
+  ]
+
+  Set<ProjectAdvice> actualProjectAdvice() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  final Set<ProjectAdvice> expectedProjectAdvice() {
+    return [emptyProjectAdviceFor(':lib')]
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/model/internal/ProjectVariant.kt
+++ b/src/main/kotlin/com/autonomousapps/model/internal/ProjectVariant.kt
@@ -90,7 +90,10 @@ internal data class ProjectVariant(
    * The set of super classes and interfaces not available from [codeSource] (therefore "external" to "this" module).
    */
   val externalSupers: Set<String> by unsafeLazy {
-    val supers = codeSource.mapNotNullToOrderedSet { src -> src.superClass }
+    val supers = codeSource
+      .mapNotNull { src -> src.superClass }
+      .filterNotToOrderedSet { it == "java.lang.Object" }
+
     val interfaces = codeSource.flatMapToOrderedSet { src -> src.interfaces }
     // These super classes and interfaces are not available from "this" module, so must come from dependencies.
     val externalSupers = supers - classNames

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeUsagesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeUsagesTask.kt
@@ -452,6 +452,10 @@ private class GraphVisitor(
     }
   }
 
+  /**
+   * This checks if [coordinates] provides a symbol for a superclass missing from THIS module's source code. It does NOT
+   * check if [coordinates] (or any dependency) has superclasses missing from the compile classpath.
+   */
   private fun isForMissingSuperclass(
     coordinates: Coordinates,
     context: GraphViewVisitor.Context,

--- a/testkit/gradle-testkit-truth/src/main/kotlin/com/autonomousapps/kit/truth/artifact/JarSubject.kt
+++ b/testkit/gradle-testkit-truth/src/main/kotlin/com/autonomousapps/kit/truth/artifact/JarSubject.kt
@@ -36,7 +36,7 @@ public class JarSubject private constructor(
     val actual = assertNonNull(actual) { "jar was null" }
 
     // Open zip, copy entry to temp dir, close zip.
-    val tempResource = FileSystems.newFileSystem(actual, null).use { fs ->
+    val tempResource = FileSystems.newFileSystem(actual, null as ClassLoader?).use { fs ->
       val resource = fs.getPath(path)
       if (resource.notExists()) {
         failWithActual(Fact.simpleFact("No resource found at '$path' in '$actual'"))


### PR DESCRIPTION
Resolves (as works-as-intended) https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1828

As the new KDOC in `ComputeUsagesTask` says:
```
  /**
   * This checks if [coordinates] provides a symbol for a superclass missing from THIS module's source code. It does NOT
   * check if [coordinates] (or any dependency) has superclasses missing from the compile classpath.
   */
```

So, the issue in question is not for a supported use-case.