### PR TITLE
chore: update build-logic's KGP to 2.4.0 (matching main build). Try to fix Renovate rule.

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026. Tony Robalik.
 // SPDX-License-Identifier: Apache-2.0
 plugins {
-  id("org.jetbrains.kotlin.jvm") version "2.3.20" apply false
+  id("org.jetbrains.kotlin.jvm") version "2.4.0" apply false
   alias(libs.plugins.dependencyAnalysis)
 }
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -45,6 +45,7 @@
     {
       "description": "Ignore updates to KGP",
       "matchPackageNames": ["org.jetbrains.kotlin:kotlin-gradle-plugin*"],
+      "matchDepNames": ["org.jetbrains.kotlin.jvm"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
I don't want Renovate touching this dep.