### PR TITLE
fix: warn about duplicate classes relating to Kotlin inline members.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/AdviceHelper.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/AdviceHelper.groovy
@@ -107,6 +107,17 @@ final class AdviceHelper {
     return new ProjectAdvice(projectPath, advice, pluginAdvice, moduleAdvice, Warning.empty(), shouldFail)
   }
 
+  static ProjectAdvice projectAdvice(
+    String projectPath,
+    Set<Advice> advice,
+    Set<PluginAdvice> pluginAdvice,
+    Set<ModuleAdvice> moduleAdvice,
+    Warning warning,
+    boolean shouldFail
+  ) {
+    return new ProjectAdvice(projectPath, advice, pluginAdvice, moduleAdvice, warning, shouldFail)
+  }
+
   private static GradleVariantIdentification defaultGVI(String capability) {
     new GradleVariantIdentification(capability ? [capability] as Set : [] as Set, [:])
   }

--- a/src/functionalTest/groovy/com/autonomousapps/android/KtxSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/KtxSpec.groovy
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.autonomousapps.android
 
+import com.autonomousapps.android.projects.CoreKtxProject
 import com.autonomousapps.android.projects.KtxProject
+import com.autonomousapps.internal.android.AgpVersion
+import spock.lang.Issue
 
 import static com.autonomousapps.utils.Runner.build
 import static com.google.common.truth.Truth.assertThat
@@ -10,7 +13,7 @@ import static com.google.common.truth.Truth.assertThat
 @SuppressWarnings("GroovyAssignabilityCheck")
 final class KtxSpec extends AbstractAndroidSpec {
 
-  def "ktx dependencies are treated per user configuration (#gradleVersion, AGP #agpVersion, ignoreKtx=#ignoreKtx, useKtx=#useKtx)"() {
+  def "ktx dependencies are treated per user configuration (#gradleVersion AGP #agpVersion, ignoreKtx=#ignoreKtx, useKtx=#useKtx)"() {
     given:
     def project = new KtxProject(agpVersion, ignoreKtx, useKtx)
     gradleProject = project.gradleProject
@@ -24,5 +27,21 @@ final class KtxSpec extends AbstractAndroidSpec {
     // This test is too expensive, so we're only going to test against the latest AGP
     where:
     [gradleVersion, agpVersion, ignoreKtx, useKtx] << gradleAgpMatrixPlus(AGP_LATEST_STABLE, [true, false], [true, false])
+  }
+
+  @Issue("https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1730")
+  def "core-ktx is empty now (#gradleVersion AGP #agpVersion)"() {
+    given:
+    def project = new CoreKtxProject(agpVersion)
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth())
+
+    where: 'core-ktx:1.19.0 requires >= AGP 9.1.0'
+    [gradleVersion, agpVersion] << gradleAgpMatrix(AgpVersion.AGP_MAX)
   }
 }

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/CoreKtxProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/CoreKtxProject.groovy
@@ -1,0 +1,126 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.android.projects
+
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.model.*
+import com.autonomousapps.model.source.AndroidSourceKind
+
+import static com.autonomousapps.AdviceHelper.*
+import static com.autonomousapps.kit.gradle.Dependency.implementation
+
+/**
+ * Android's `-ktx` dependencies have become hollowed-out over time. This issue was originally reported because, when
+ * the newer -ktx dep was no longer directly declared, an older version of it that still provided class files was
+ * resolved instead. That older version duplicated classes provided by the newer non-ktx version of the dependency,
+ * leading to unreported duplicate class problems. This class reproduces that unreported duplicate problem, and its
+ * resolution.
+ */
+final class CoreKtxProject extends AbstractAndroidProject {
+
+  final GradleProject gradleProject
+  private final String agpVersion
+
+  CoreKtxProject(String agpVersion) {
+    super(agpVersion)
+    this.agpVersion = agpVersion
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newAndroidGradleProjectBuilder()
+      .withAndroidLibProject('lib') { lib ->
+        lib.withBuildScript { bs ->
+          bs.plugins(androidLib(true))
+          bs.android = defaultAndroidLibBlock(true)
+          bs.dependencies(
+            implementation('androidx.core:core:1.19.0'),
+            implementation('androidx.fragment:fragment:1.6.2'),
+          )
+        }
+        lib.sources = source()
+      }
+      .write()
+  }
+
+  private List<Source> source() {
+    [
+      Source.kotlin(
+        '''\
+            package com.example.lib
+            
+            import android.net.Uri
+            import androidx.core.net.toUri
+            
+            class CoreKtxUsage {
+              fun parse(url: String): Uri = url.toUri()
+            }'''.stripIndent()
+      ).build()
+    ]
+  }
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  private Set<Advice> libAdvice() {
+    return [
+      Advice.ofAdd(moduleCoordinates('androidx.core:core-ktx:1.2.0'), 'implementation'),
+      // actually unused, but provides core-ktx:1.2.0 transitively, which is the point
+      Advice.ofRemove(moduleCoordinates('androidx.fragment:fragment:1.6.2'), 'implementation'),
+    ]
+  }
+
+  private Warning libWarning() {
+    new Warning(
+      [
+        new DuplicateClass(
+          new AndroidSourceKind(
+            "debug",
+            "MAIN",
+            "debugCompileClasspath",
+            "debugRuntimeClasspath"
+          ),
+          "compile",
+          "androidx/core/net/UriKt",
+          [
+            new ModuleCoordinates('androidx.core:core-ktx', '1.2.0', GradleVariantIdentification.ofCapabilities('androidx.core:core-ktx')),
+            new ModuleCoordinates('androidx.core:core', '1.19.0', GradleVariantIdentification.ofCapabilities('androidx.core:core')),
+          ] as Set
+        ),
+        new DuplicateClass(
+          new AndroidSourceKind(
+            "release",
+            "MAIN",
+            "releaseCompileClasspath",
+            "releaseRuntimeClasspath"
+          ),
+          "compile",
+          "androidx/core/net/UriKt",
+          [
+            new ModuleCoordinates('androidx.core:core-ktx', '1.2.0', GradleVariantIdentification.ofCapabilities('androidx.core:core-ktx')),
+            new ModuleCoordinates('androidx.core:core', '1.19.0', GradleVariantIdentification.ofCapabilities('androidx.core:core')),
+          ] as Set
+        ),
+      ] as Set
+    )
+  }
+
+  private Set<ModuleAdvice> libModuleAdvice() {
+    [new AndroidScore(false, false, true, false, true, false)]
+  }
+
+  final Set<ProjectAdvice> expectedBuildHealth() {
+    return [
+      projectAdvice(
+        ':lib',
+        libAdvice(),
+        Collections.emptySet(),
+        libModuleAdvice(),
+        libWarning(),
+        false
+      ),
+    ]
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/KtxProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/KtxProject.groovy
@@ -35,7 +35,7 @@ final class KtxProject extends AbstractAndroidProject {
   }
 
   private GradleProject build() {
-    return newAndroidGradleProjectBuilder(agpVersion)
+    return newAndroidGradleProjectBuilder()
       .withRootProject { r ->
         r.withBuildScript { bs ->
           bs.withGroovy(

--- a/src/main/kotlin/com/autonomousapps/model/internal/ProjectVariant.kt
+++ b/src/main/kotlin/com/autonomousapps/model/internal/ProjectVariant.kt
@@ -149,6 +149,17 @@ internal data class ProjectVariant(
       .flatMapToOrderedSet { it.imports }
   }
 
+  /**
+   * Uses a similar heuristic to
+   * [InlineMember.candidateImports][com.autonomousapps.model.internal.InlineMemberCapability.InlineMember.candidateImports]
+   */
+  val candidateInlineImports: Set<String> by unsafeLazy {
+    // e.g., `androidx.core.net.toUri` -> `androidx.core.net`
+    kotlinImports
+      .map { it.substringBeforeLast('.') }
+      .filterToOrderedSet { it.isNotEmpty() }
+  }
+
   internal fun dependencies(dependenciesDir: Directory): Set<Dependency> {
     return classpath.asSequence()
       .plus(annotationProcessors)

--- a/src/main/kotlin/com/autonomousapps/tasks/DiscoverClasspathDuplicationTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/DiscoverClasspathDuplicationTask.kt
@@ -92,7 +92,7 @@ public abstract class DiscoverClasspathDuplicationTask : DefaultTask() {
         // only warn about duplicates if it's about a class that's actually used.
         .filterKeys {
           val fqcn = it.replace('/', '.').removeSuffix(".class")
-          fqcn in project.usedClasses || fqcn in project.usedAnnotationClassesBySrc
+          fqcn in project.usedClasses || fqcn in project.usedAnnotationClassesBySrc || fqcn.substringBeforeLast('.') in project.candidateInlineImports
         }
         // filter out "duplicates" where the GAV is identical. This can be an issue with, say, Kotlin, which adds
         // variants of the same dependency with different capabilities. Not user-actionable.

--- a/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/android/AndroidBlock.kt
+++ b/testkit/gradle-testkit-support/src/main/kotlin/com/autonomousapps/kit/gradle/android/AndroidBlock.kt
@@ -106,7 +106,7 @@ public class AndroidBlock @JvmOverloads constructor(
 
   public class Builder {
     public var namespace: String? = null
-    public var compileSdkVersion: Int = 34
+    public var compileSdkVersion: Int = 37
     public var defaultConfig: DefaultConfig = DefaultConfig.DEFAULT_APP
     public var buildTypes: BuildTypes? = null
     public var compileOptions: CompileOptions = CompileOptions.DEFAULT
@@ -149,7 +149,7 @@ public class AndroidBlock @JvmOverloads constructor(
       namespace: String? = null,
     ): AndroidBlock = AndroidBlock(
       namespace = namespace,
-      compileSdkVersion = 34,
+      compileSdkVersion = 37,
       defaultConfig = DefaultConfig.DEFAULT_APP,
       compileOptions = CompileOptions.DEFAULT,
     )
@@ -162,7 +162,7 @@ public class AndroidBlock @JvmOverloads constructor(
       namespace: String? = null,
     ): AndroidBlock = AndroidBlock(
       namespace = namespace,
-      compileSdkVersion = 34,
+      compileSdkVersion = 37,
       defaultConfig = DefaultConfig.DEFAULT_LIB,
       compileOptions = CompileOptions.DEFAULT,
     )
@@ -176,7 +176,7 @@ public class AndroidBlock @JvmOverloads constructor(
       namespace: String? = null,
     ): AndroidBlock = AndroidBlock(
       namespace = namespace,
-      compileSdkVersion = 34,
+      compileSdkVersion = 37,
       targetProjectPath = targetProjectPath,
       defaultConfig = DefaultConfig.DEFAULT_TEST,
       compileOptions = CompileOptions.DEFAULT,

--- a/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestGroovy.kt
+++ b/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestGroovy.kt
@@ -590,7 +590,7 @@ internal class ScribeTestGroovy {
       assertThat(text).isEqualTo(
         """
           android {
-            compileSdkVersion 34
+            compileSdkVersion 37
             defaultConfig {
               applicationId 'com.example'
               minSdkVersion 23

--- a/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestKotlin.kt
+++ b/testkit/gradle-testkit-support/src/test/kotlin/com/autonomousapps/kit/render/ScribeTestKotlin.kt
@@ -592,7 +592,7 @@ internal class ScribeTestKotlin {
       assertThat(text).isEqualTo(
         """
           android {
-            compileSdk = 34
+            compileSdk = 37
             defaultConfig {
               applicationId = "com.example"
               minSdk = 23


### PR DESCRIPTION
Resolves https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1730

This uses an import-based heuristic, similar to the existing reporting of inline member usage.