### PR TITLE
fix: don't crash when analyzing KMP project with 'jvm("foo")' target.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/kmp/CustomJvmTargetSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/kmp/CustomJvmTargetSpec.groovy
@@ -1,0 +1,28 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.kmp
+
+import com.autonomousapps.kmp.projects.JvmDesktopProject
+import spock.lang.Issue
+
+import static com.autonomousapps.kit.GradleBuilder.build
+import static com.google.common.truth.Truth.assertThat
+
+final class CustomJvmTargetSpec extends AbstractKmpSpec {
+
+  @Issue("https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1865")
+  def "can analyze a jvm-desktop target (#gradleVersion)"() {
+    given:
+    def project = new JvmDesktopProject()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, ':buildHealth')
+
+    then:
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/kmp/projects/JvmDesktopProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/kmp/projects/JvmDesktopProject.groovy
@@ -1,0 +1,81 @@
+// Copyright (c) 2026. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+package com.autonomousapps.kmp.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.gradle.kotlin.KotlinJvmTarget
+import com.autonomousapps.model.Advice
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.actualProjectAdvice
+import static com.autonomousapps.AdviceHelper.projectAdviceForDependencies
+import static com.autonomousapps.kit.gradle.Dependency.implementation
+
+final class JvmDesktopProject extends AbstractProject {
+
+  private static final String KOTLIN_VERSION = '2.4.10'
+
+  final GradleProject gradleProject
+
+  JvmDesktopProject() {
+    super(KOTLIN_VERSION)
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    return newGradleProjectBuilder(GradleProject.DslKind.KOTLIN)
+      .withRootProject { r ->
+        r.withBuildScript { bs ->
+          bs.plugins(plugins.dependencyAnalysis, plugins.kotlinMultiplatformNoApply)
+        }
+      }
+      .withSubproject('consumer') { s ->
+        s.sources = consumerSources()
+        s.withBuildScript { bs ->
+          bs.plugins(kmpLibrary)
+          bs.kotlinKmp { k ->
+            k.jvmTarget = new KotlinJvmTarget("desktop")
+            k.sourceSets { sourceSets ->
+              sourceSets.named("desktopMain", true) { desktopMain ->
+                desktopMain.dependencies(
+                  implementation("com.ibm.icu:icu4j:77.1"),
+                )
+              }
+            }
+          }
+        }
+      }
+      .write()
+  }
+
+  private static List<Source> consumerSources() {
+    return [
+      Source
+        .kotlin(
+          '''
+            package desktop.main
+            
+            import com.ibm.icu.text.ListFormatter
+            
+            fun formatItems(items: List<String>): String = ListFormatter.getInstance().format(items)
+          '''
+        )
+        .withPath('desktop.main', 'example')
+        .withSourceSet('desktopMain')
+        .build(),
+    ]
+  }
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  private final Set<Advice> consumerAdvice = []
+
+  final Set<ProjectAdvice> expectedBuildHealth = [
+    projectAdviceForDependencies(':consumer', consumerAdvice)
+  ]
+}
+

--- a/src/main/kotlin/com/autonomousapps/model/source/SourceKind.kt
+++ b/src/main/kotlin/com/autonomousapps/model/source/SourceKind.kt
@@ -318,20 +318,46 @@ public data class KmpSourceKind(
         compileClasspathName = when (sourceSetName) {
           // jvmMain => jvmCompileClasspath (jvmMain is special)
           JVM_MAIN_NAME -> "jvmCompileClasspath"
+
           // androidMain => androidCompileClasspath (androidMain is special)
           ANDROID_MAIN_NAME -> "androidCompileClasspath"
-          // jvmTest => jvmTestCompileClasspath
-          else -> "${sourceSetName}CompileClasspath"
+
+          else -> {
+            if (isProbablyJvmMain(sourceSetName)) {
+              // desktopMaim => desktopCompileClasspath
+              "${sourceSetName.substringBefore("Main")}CompileClasspath"
+            } else {
+              // jvmTest => jvmTestCompileClasspath
+              "${sourceSetName}CompileClasspath"
+            }
+          }
         },
         runtimeClasspathName = when (sourceSetName) {
           // jvmMain => jvmRuntimeClasspath (jvmMain is special)
           JVM_MAIN_NAME -> "jvmRuntimeClasspath"
+
           // androidMain => androidRuntimeClasspath (androidMain is special)
           ANDROID_MAIN_NAME -> "androidRuntimeClasspath"
-          // jvmTest => jvmTestRuntimeClasspath
-          else -> "${sourceSetName}RuntimeClasspath"
+
+          else -> {
+            if (isProbablyJvmMain(sourceSetName)) {
+              // desktopMaim => desktopRuntimeClasspath
+              "${sourceSetName.substringBefore("Main")}RuntimeClasspath"
+            } else {
+              // jvmTest => jvmTestRuntimeClasspath
+              "${sourceSetName}RuntimeClasspath"
+            }
+          }
         },
       )
+    }
+
+    /**
+     * Returns true if [sourceSetName] is probably from `jvm("sourceSetName")`. Explicitly ignores the `commonMain`
+     * source set because that's special.
+     */
+    private fun isProbablyJvmMain(sourceSetName: String): Boolean {
+      return sourceSetName != COMMON_MAIN_NAME && sourceSetName.endsWith("Main")
     }
   }
 }

--- a/src/test/kotlin/com/autonomousapps/model/internal/declaration/ConfigurationNamesTest.kt
+++ b/src/test/kotlin/com/autonomousapps/model/internal/declaration/ConfigurationNamesTest.kt
@@ -321,6 +321,8 @@ internal class ConfigurationNamesTest {
       "jvmMain",
       "jvmTest",
       "jvmIntegrationTest",
+      "desktopMain",
+      "desktopTest",
       "androidMain",
       "androidDeviceTest",
       "androidHostTest",
@@ -363,6 +365,11 @@ internal class ConfigurationNamesTest {
         "jvmMainAnnotationProcessor, jvmMain",
         "jvmIntegrationTestAnnotationProcessor, jvmIntegrationTest",
         "jvmTestAnnotationProcessor, jvmTest",
+
+        "desktopMainApi, desktopMain",
+        "desktopMainCompileOnly, desktopMain",
+        "desktopMainImplementation, desktopMain",
+        "desktopMainRuntimeOnly, desktopMain",
 
         "kapt, jvmMain",
         "kaptIntegrationTest, jvmIntegrationTest",
@@ -426,6 +433,11 @@ internal class ConfigurationNamesTest {
         "jvmIntegrationTestCompileOnly, true",
         "jvmIntegrationTestImplementation, true",
         "jvmIntegrationTestRuntimeOnly, true",
+
+        "desktopMainApi, true",
+        "desktopMainCompileOnly, true",
+        "desktopMainImplementation, true",
+        "desktopMainRuntimeOnly, true",
 
         // annotation processors
         "annotationProcessor, true",


### PR DESCRIPTION
Resolves https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1865.